### PR TITLE
Fix indentation in auto-assign workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -11,9 +11,9 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue@v1
-      with:
+      - name: 'Auto-assign issue'
+        uses: pozil/auto-assign-issue@v1
+        with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: yumiaura
           numOfAssignee: 1


### PR DESCRIPTION
I noticed that the new file `auto-assign.yml` has been added here, but it seems that there is a problem with its indentation, I adjusted it in this PR.