### PR TITLE
CI + config hardening + autostart & system-tray cat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Qt's offscreen platform plugin needs a few system libs even headless.
+      - name: Install Qt runtime libs
+        run: sudo apt-get update && sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3
+
+      - name: Install package + dev tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff pytest
+          pip install .
+
+      - name: Ruff
+        run: ruff check .
+
+      - name: Tests
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: python -m pytest -q

--- a/mycat/__init__.py
+++ b/mycat/__init__.py
@@ -1,4 +1,4 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("mycat")

--- a/mycat/autostart.py
+++ b/mycat/autostart.py
@@ -1,0 +1,108 @@
+"""Cross-platform "start mycat on login" toggle.
+
+Linux uses an XDG autostart .desktop file; Windows uses the HKCU Run key.
+Everything degrades to a no-op / unsupported elsewhere.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+APP_ID = "mycat"
+WIN_RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
+
+
+def launch_command() -> str:
+    """Command that starts mycat — the installed console script, else python -m."""
+    exe = shutil.which("mycat")
+    if exe:
+        return exe
+    return f'"{sys.executable}" -m mycat'
+
+
+# -- Linux (XDG autostart) --------------------------------------------------
+
+def linux_desktop_path() -> Path:
+    return Path.home() / ".config" / "autostart" / f"{APP_ID}.desktop"
+
+
+def linux_is_enabled() -> bool:
+    return linux_desktop_path().exists()
+
+
+def linux_set(enabled: bool) -> None:
+    path = linux_desktop_path()
+    if enabled:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "[Desktop Entry]\n"
+            "Type=Application\n"
+            f"Name={APP_ID}\n"
+            f"Exec={launch_command()}\n"
+            "Terminal=false\n"
+            "X-GNOME-Autostart-enabled=true\n"
+        )
+    elif path.exists():
+        path.unlink()
+
+
+# -- Windows (HKCU Run key) -------------------------------------------------
+
+def windows_is_enabled() -> bool:
+    import winreg
+
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, WIN_RUN_KEY) as key:
+            winreg.QueryValueEx(key, APP_ID)
+            return True
+    except OSError:
+        return False
+
+
+def windows_set(enabled: bool) -> None:
+    import winreg
+
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, WIN_RUN_KEY, 0, winreg.KEY_SET_VALUE) as key:
+        if enabled:
+            winreg.SetValueEx(key, APP_ID, 0, winreg.REG_SZ, launch_command())
+        else:
+            try:
+                winreg.DeleteValue(key, APP_ID)
+            except OSError:
+                pass
+
+
+# -- public API -------------------------------------------------------------
+
+def is_supported() -> bool:
+    return sys.platform.startswith("linux") or sys.platform.startswith("win")
+
+
+def is_enabled() -> bool:
+    try:
+        if sys.platform.startswith("win"):
+            return windows_is_enabled()
+        if sys.platform.startswith("linux"):
+            return linux_is_enabled()
+    except Exception as exc:  # noqa: BLE001 - never let autostart crash the app
+        logger.warning("autostart is_enabled failed: %s", exc)
+    return False
+
+
+def set_enabled(enabled: bool) -> None:
+    try:
+        if sys.platform.startswith("win"):
+            windows_set(enabled)
+        elif sys.platform.startswith("linux"):
+            linux_set(enabled)
+        logger.info("Autostart %s", "enabled" if enabled else "disabled")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("autostart set_enabled failed: %s", exc)
+
+
+__all__ = ["is_supported", "is_enabled", "set_enabled", "launch_command"]

--- a/mycat/llm.py
+++ b/mycat/llm.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 import os
 from dataclasses import dataclass
-from typing import Optional, Protocol
+from typing import Protocol
 
 from PySide6 import QtWidgets
 
@@ -49,9 +49,9 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def initialize(args) -> Optional[LLMContext]:
+def initialize(args) -> LLMContext | None:
     """Configure the selected backend (OpenAI or Ollama)."""
-    backend_name: Optional[str] = None
+    backend_name: str | None = None
     if getattr(args, "openai", False):
         backend_name = "openai"
     elif getattr(args, "ollama", False):

--- a/mycat/llm_ollama.py
+++ b/mycat/llm_ollama.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import urllib.error
 import urllib.request
-from typing import Any, Dict
+from typing import Any
 
 
 class OllamaBackend:
@@ -17,7 +17,7 @@ class OllamaBackend:
         self.timeout = timeout
 
     def reply(self, user_text: str, system_prompt: str) -> str:
-        payload: Dict[str, Any] = {
+        payload: dict[str, Any] = {
             "model": self.model,
             "messages": [
                 {"role": "system", "content": system_prompt},

--- a/mycat/llm_openai.py
+++ b/mycat/llm_openai.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 
 class OpenAIBackend:
     """Thin wrapper over the OpenAI Chat Completions API."""
 
-    def __init__(self, *, api_key: str, model: str, timeout: Optional[float] = 60.0) -> None:
+    def __init__(self, *, api_key: str, model: str, timeout: float | None = 60.0) -> None:
         try:
             from openai import OpenAI
         except ImportError as exc:
@@ -35,10 +33,7 @@ class OpenAIBackend:
             return message.strip()
 
         if isinstance(message, list):
-            parts: List[str] = []
-            for chunk in message:
-                if isinstance(chunk, dict):
-                    parts.append(chunk.get("text", "").strip())
+            parts = [chunk.get("text", "").strip() for chunk in message if isinstance(chunk, dict)]
             return " ".join(parts).strip()
 
         return str(message or "").strip()

--- a/mycat/llm_prompt.py
+++ b/mycat/llm_prompt.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+from . import secret_store
+
 logger = logging.getLogger(__name__)
 
 APP_NAME = "mycat"
@@ -92,7 +94,8 @@ def load_env_file() -> None:
 def load_llm_settings() -> LLMSettings:
     """Merge values from environment variables and config.ini into a single settings object."""
     settings = LLMSettings(
-        openai_api_key=os.getenv("OPENAI_API_KEY"),
+        # Prefer the OS keyring; fall back to the env var (and a config section below).
+        openai_api_key=secret_store.get_secret("openai_api_key") or os.getenv("OPENAI_API_KEY"),
         openai_model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
         ollama_url=os.getenv("OLLAMA_URL", "http://127.0.0.1:11434"),
         ollama_model=os.getenv("OLLAMA_MODEL", "llama3.1"),
@@ -142,6 +145,7 @@ def save_ollama_settings(url: str, model: str) -> None:
     parser.set("ollama", "model", model)
     with open(CFG_FILE, "w") as handle:
         parser.write(handle)
+    secret_store.secure_file(CFG_FILE)
     logger.info("Saved Ollama settings: url=%s model=%s", url, model)
 
 
@@ -159,6 +163,7 @@ def save_llm_enabled(enabled: bool) -> None:
     parser.set("llm", "enabled", "true" if enabled else "false")
     with open(CFG_FILE, "w") as handle:
         parser.write(handle)
+    secret_store.secure_file(CFG_FILE)
     logger.info("Saved LLM enabled=%s", enabled)
 
 

--- a/mycat/llm_prompt.py
+++ b/mycat/llm_prompt.py
@@ -10,7 +10,6 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 from . import secret_store
 
@@ -31,7 +30,7 @@ Recent conversation (latest {{history_count}} messages):
 Stay warm, playful, and loving when you reply."""
 
 _ENV_LOADED = False
-_PROMPT_TEMPLATE_CACHE: Optional[str] = None
+_PROMPT_TEMPLATE_CACHE: str | None = None
 
 HISTORY_HEADER_RE = re.compile(r"^\[(?P<timestamp>.+?)\]\s+(?P<label>REQUEST|RESPONSE):$")
 
@@ -40,7 +39,7 @@ HISTORY_HEADER_RE = re.compile(r"^\[(?P<timestamp>.+?)\]\s+(?P<label>REQUEST|RES
 class LLMSettings:
     """Configuration bundle for all supported LLM backends."""
 
-    openai_api_key: Optional[str]
+    openai_api_key: str | None
     openai_model: str
     ollama_url: str
     ollama_model: str
@@ -75,7 +74,7 @@ def load_env_file() -> None:
         except OSError as exc:
             logger.debug("Unable to read env file %s: %s", path, exc)
 
-    candidates: List[Path] = []
+    candidates: list[Path] = []
     override_path = os.environ.get("MYCAT_ENV_FILE")
     if override_path:
         candidates.append(Path(override_path).expanduser())
@@ -230,12 +229,12 @@ def rotate_history_if_needed(path: Path, max_bytes: int = HISTORY_MAX_BYTES) -> 
         logger.warning("Unable to rotate history file %s: %s", path, exc)
 
 
-def parse_history_file(path: Path) -> List[Tuple[str, str, str]]:
+def parse_history_file(path: Path) -> list[tuple[str, str, str]]:
     """Parse history file into structured messages."""
-    entries: List[Tuple[str, str, str]] = []
-    role: Optional[str] = None
-    timestamp: Optional[str] = None
-    buffer: List[str] = []
+    entries: list[tuple[str, str, str]] = []
+    role: str | None = None
+    timestamp: str | None = None
+    buffer: list[str] = []
 
     def flush() -> None:
         nonlocal role, timestamp, buffer
@@ -277,7 +276,7 @@ def append_history_entry(path: Path, role: str, text: str, timestamp: str) -> No
         logger.debug("Unable to write history entry: %s", exc)
 
 
-def get_history_tail(history_path: Path, limit: int) -> List[str]:
+def get_history_tail(history_path: Path, limit: int) -> list[str]:
     """Return the last `limit` messages serialised back to history-file lines.
 
     Operates on message boundaries (not text lines), so multi-line replies
@@ -289,7 +288,7 @@ def get_history_tail(history_path: Path, limit: int) -> List[str]:
     if not entries:
         return []
     tail = entries[-limit:]
-    out: List[str] = []
+    out: list[str] = []
     for role, text, ts in tail:
         label = "REQUEST" if role == "user" else "RESPONSE"
         out.append(f"[{ts}] {label}:")
@@ -300,7 +299,7 @@ def get_history_tail(history_path: Path, limit: int) -> List[str]:
 _PLACEHOLDER_RE = re.compile(r"\{\{\s*(date|history|history_count)\s*\}\}")
 
 
-def render_prompt(history_lines: List[str], history_limit: int) -> str:
+def render_prompt(history_lines: list[str], history_limit: int) -> str:
     """Produce the final system prompt text using the stored template.
 
     Supports both `{{key}}` and `{{ key }}` placeholder forms so the file may

--- a/mycat/llm_ui.py
+++ b/mycat/llm_ui.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import html
 import logging
 import time
 from datetime import datetime
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def attach_chat(window: QtWidgets.QWidget, context: "LLMContext", enabled: bool = True) -> None:
+def attach_chat(window: QtWidgets.QWidget, context: LLMContext, enabled: bool = True) -> None:
     controller = _LLMController(window, context, enabled=enabled)
     setattr(window, "_llm_controller", controller)
     setattr(window, "_toggle_llm_chat", controller.toggle_chat)
@@ -30,12 +29,12 @@ def attach_chat(window: QtWidgets.QWidget, context: "LLMContext", enabled: bool 
 class _LLMController(QtCore.QObject):
     """Owns the chat dialog lifecycle and keeps it anchored to the cat window."""
 
-    def __init__(self, window: QtWidgets.QWidget, context: "LLMContext", enabled: bool = True) -> None:
+    def __init__(self, window: QtWidgets.QWidget, context: LLMContext, enabled: bool = True) -> None:
         super().__init__(window)
         self.window = window
         self.context = context
         self.enabled = enabled
-        self.chat_dialog: Optional[ChatDialog] = None
+        self.chat_dialog: ChatDialog | None = None
         self.history_file = llm_prompt.ensure_history_file()
 
         window.installEventFilter(self)
@@ -134,11 +133,11 @@ class ChatDialog(QtWidgets.QDialog):
         self.message_count = 0
         self._waiting_for_response = False
         self._thread_pool = QtCore.QThreadPool.globalInstance()
-        self._pending_worker: Optional[_LLMWorker] = None
-        self._pending_request_started: Optional[float] = None
-        self._pending_request_text: Optional[str] = None
+        self._pending_worker: _LLMWorker | None = None
+        self._pending_request_started: float | None = None
+        self._pending_request_text: str | None = None
         self._suspend_anchor = False
-        self._messages: List[tuple[str, str, str]] = []
+        self._messages: list[tuple[str, str, str]] = []
 
         self.setWindowFlags(
             QtCore.Qt.WindowType.Window
@@ -231,7 +230,7 @@ class ChatDialog(QtWidgets.QDialog):
 
         main_layout.addLayout(input_layout)
         self.input_field.returnPressed.connect(self._send_message)
-        self._typing_indicator: Optional[TypingIndicator] = None
+        self._typing_indicator: TypingIndicator | None = None
 
     def _load_history(self) -> None:
         entries = llm_prompt.parse_history_file(self.history_file)
@@ -319,7 +318,7 @@ class ChatDialog(QtWidgets.QDialog):
         self,
         role: str,
         text: str,
-        timestamp: Optional[str] = None,
+        timestamp: str | None = None,
         persist: bool = True,
     ) -> None:
         timestamp = timestamp or datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Pixel Cat with GIF animation from ZIP archives, PySide6 transparent overlay
 - Shows first frame of GIF from ZIP for 5 seconds, then plays GIF once, then back to first frame
@@ -22,7 +21,6 @@ import tempfile
 import warnings
 import zipfile
 from pathlib import Path
-from typing import Optional
 
 # Allow running both as `python -m mycat` and `python mycat/main.py`
 if __package__:
@@ -182,16 +180,16 @@ def scale_pixmap_if_needed(pixmap: QtGui.QPixmap, max_width: int, max_height: in
     return pixmap
 
 
-def load_packaged_images(image_path: Optional[str] = None, default_image: Optional[str] = None) -> tuple[QtGui.QPixmap, QtGui.QMovie, str]:
+def load_packaged_images(
+    image_path: str | None = None, default_image: str | None = None
+) -> tuple[QtGui.QPixmap, QtGui.QMovie, str]:
     """
     Load GIF from ZIP archive and extract to temp files.
     If image_path is provided, use it (should point to ZIP file).
     Returns: (first_frame_pixmap, gif_movie, base_name)
     """
     global STATIC_PNG_PATH, ANIMATION_GIF_PATH
-    
-    script_dir = Path(__file__).resolve().parent
-    
+
     if image_path:
         # User provided ZIP path
         zip_path = Path(image_path)
@@ -251,8 +249,12 @@ def load_packaged_images(image_path: Optional[str] = None, default_image: Option
     original_size = first_frame.size()
     first_frame = scale_pixmap_if_needed(first_frame, IMAGE_WIDTH_MAX, IMAGE_HEIGHT_MAX)
     if original_size != first_frame.size():
-        logger.info(f"Resized {Path(zip_path).name}: {original_size.width()}x{original_size.height()} -> {first_frame.width()}x{first_frame.height()}")
-    
+        logger.info(
+            f"Resized {Path(zip_path).name}: "
+            f"{original_size.width()}x{original_size.height()} -> "
+            f"{first_frame.width()}x{first_frame.height()}"
+        )
+
     # Save first frame as PNG
     first_frame.save(str(STATIC_PNG_PATH), "PNG")
     
@@ -321,10 +323,10 @@ def save_config(config: dict) -> None:
         logger.error(f"Config save error: {e}")
 
 
-def load_image_from_ini() -> Optional[str]:
+def load_image_from_ini() -> str | None:
     """Load default image setting from INI file."""
     if not CFG_FILE.exists():
-        logger.info(f"INI config not found, using default: cat")
+        logger.info("INI config not found, using default: cat")
         return None
     
     try:
@@ -336,7 +338,7 @@ def load_image_from_ini() -> Optional[str]:
             logger.info(f"Loaded image from INI: {image_name}")
             return image_name
         else:
-            logger.info(f"INI config exists but no default_image setting found, using default: cat")
+            logger.info("INI config exists but no default_image setting found, using default: cat")
             return None
     except Exception as e:
         logger.error(f"Error reading INI file: {e}, using default: cat")
@@ -472,7 +474,10 @@ class PixelCatWindow(QtWidgets.QWidget):
         frame_count = self.gif_movie.frameCount()
         gif_size = self.gif_movie.scaledSize()
         logger.debug(f"GIF info: {frame_count} frames, duration: {self.gif_duration:.2f}s")
-        logger.info(f"Playing {self.file_name}.zip {original_size.width()}x{original_size.height()} > {gif_size.width()}x{gif_size.height()} (first_frame, {self.wait_time:.1f}s static)")
+        logger.info(
+            f"Playing {self.file_name}.zip {original_size.width()}x{original_size.height()} > "
+            f"{gif_size.width()}x{gif_size.height()} (first_frame, {self.wait_time:.1f}s static)"
+        )
 
         # Dragging state
         self.dragging = False
@@ -588,7 +593,11 @@ class PixelCatWindow(QtWidgets.QWidget):
             original_size = first_frame.size()
             first_frame = scale_pixmap_if_needed(first_frame, IMAGE_WIDTH_MAX, IMAGE_HEIGHT_MAX)
             if original_size != first_frame.size():
-                logger.info(f"Resized {image_name}.zip: {original_size.width()}x{original_size.height()} -> {first_frame.width()}x{first_frame.height()}")
+                logger.info(
+                    f"Resized {image_name}.zip: "
+                    f"{original_size.width()}x{original_size.height()} -> "
+                    f"{first_frame.width()}x{first_frame.height()}"
+                )
             
             # Save as PNG
             first_frame.save(str(STATIC_PNG_PATH), "PNG")
@@ -951,7 +960,7 @@ def parse_args() -> argparse.Namespace:
     llm.add_arguments(parser)
     return parser.parse_args()
 
-def x11_compositor_active() -> Optional[bool]:
+def x11_compositor_active() -> bool | None:
     """Return True/False when an X11 compositing manager is running, None if undetermined.
 
     Every EWMH-compliant compositor (picom, xfwm4, mutter, kwin, ...) owns the
@@ -991,7 +1000,7 @@ def x11_compositor_active() -> Optional[bool]:
         x11.XCloseDisplay(display)
 
 
-def x11_screen_size() -> Optional[tuple]:
+def x11_screen_size() -> tuple | None:
     """Root window size straight from the X server, for when Qt reports a 0x0 screen.
 
     Some X setups (nested or remote servers without RANDR) leave QScreen geometry
@@ -1051,7 +1060,7 @@ def usable_screen_rect() -> "QtCore.QRect":
     return QtCore.QRect(0, 0, 0, 0)
 
 
-def randr_monitor_count() -> Optional[int]:
+def randr_monitor_count() -> int | None:
     """Number of active RANDR monitors via `xrandr --listmonitors`, or None if unknown."""
     xrandr = shutil.which("xrandr")
     if not xrandr:
@@ -1230,7 +1239,10 @@ def main() -> None:
     # Load images
     try:
         png_pixmap, gif_movie, file_name = load_packaged_images(args.image, default_image)
-        logger.info(f"Playing {file_name}.zip (first frame) {png_pixmap.width()}x{png_pixmap.height()} for {args.wait:.1f}s")
+        logger.info(
+            f"Playing {file_name}.zip (first frame) "
+            f"{png_pixmap.width()}x{png_pixmap.height()} for {args.wait:.1f}s"
+        )
     except Exception as e:
         logger.error(f"Error loading images: {e}")
         sys.exit(2)

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 # Allow running both as `python -m mycat` and `python mycat/main.py`
 if __package__:
-    from . import llm, reminder, skin_catalog
+    from . import llm, reminder, secret_store, skin_catalog
 else:
     import importlib
     repo_root = Path(__file__).resolve().parent.parent
@@ -35,6 +35,7 @@ else:
     llm = importlib.import_module("mycat.llm")
     skin_catalog = importlib.import_module("mycat.skin_catalog")
     reminder = importlib.import_module("mycat.reminder")
+    secret_store = importlib.import_module("mycat.secret_store")
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
@@ -314,6 +315,7 @@ def save_config(config: dict) -> None:
         # Write to file
         with open(CFG_FILE, 'w') as f:
             file_config.write(f)
+        secret_store.secure_file(CFG_FILE)
     except Exception as e:
         logger.error(f"Config save error: {e}")
 
@@ -367,6 +369,7 @@ def save_image_to_ini(image_name: str) -> None:
         # Write to file
         with open(CFG_FILE, 'w') as f:
             config.write(f)
+        secret_store.secure_file(CFG_FILE)
 
         logger.info(f"Saved image setting to INI: {image_name}")
     except Exception as e:

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 # Allow running both as `python -m mycat` and `python mycat/main.py`
 if __package__:
-    from . import llm, reminder, secret_store, skin_catalog
+    from . import autostart, llm, reminder, secret_store, skin_catalog
 else:
     import importlib
     repo_root = Path(__file__).resolve().parent.parent
@@ -36,6 +36,7 @@ else:
     skin_catalog = importlib.import_module("mycat.skin_catalog")
     reminder = importlib.import_module("mycat.reminder")
     secret_store = importlib.import_module("mycat.secret_store")
+    autostart = importlib.import_module("mycat.autostart")
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
@@ -701,6 +702,12 @@ class PixelCatWindow(QtWidgets.QWidget):
                 action.triggered.connect(lambda checked, name=img_name: self._load_image(name))
             menu.addSeparator()
 
+        if autostart.is_supported():
+            login_action = menu.addAction("Start on login")
+            login_action.setCheckable(True)
+            login_action.setChecked(autostart.is_enabled())
+            login_action.toggled.connect(autostart.set_enabled)
+
         quit_action = menu.addAction("Quit")
         quit_action.triggered.connect(QtWidgets.QApplication.quit)
         menu.exec(self.mapToGlobal(pos))
@@ -1115,6 +1122,44 @@ def make_app_icon() -> QtGui.QIcon:
     return QtGui.QIcon(pixmap)
 
 
+def setup_tray(app, window, icon_pixmap):
+    """A persistent cat icon in the system tray with a quick-action menu.
+
+    Returns the tray icon (kept alive by the caller), or None when no system
+    tray is available.
+    """
+    if not QtWidgets.QSystemTrayIcon.isSystemTrayAvailable():
+        return None
+    icon = QtGui.QIcon(icon_pixmap) if icon_pixmap and not icon_pixmap.isNull() else make_app_icon()
+    tray = QtWidgets.QSystemTrayIcon(icon, app)
+    tray.setToolTip("mycat 🐱")
+
+    menu = QtWidgets.QMenu(window)
+    toggle_chat = getattr(window, "_toggle_llm_chat", None)
+    if callable(toggle_chat):
+        menu.addAction("Chat", toggle_chat)
+    menu.addAction("Reminder…", window._open_reminder)
+    menu.addAction("LLM…", window.open_llm_settings)
+    if autostart.is_supported():
+        menu.addSeparator()
+        login_action = menu.addAction("Start on login")
+        login_action.setCheckable(True)
+        login_action.setChecked(autostart.is_enabled())
+        login_action.toggled.connect(autostart.set_enabled)
+    menu.addSeparator()
+    menu.addAction("Quit", QtWidgets.QApplication.quit)
+    tray.setContextMenu(menu)
+
+    def on_activated(reason):
+        if reason == QtWidgets.QSystemTrayIcon.ActivationReason.DoubleClick:
+            window.show()
+            window.raise_()
+
+    tray.activated.connect(on_activated)
+    tray.show()
+    return tray
+
+
 def main() -> None:
     """Main entry point."""
     args = parse_args()
@@ -1203,6 +1248,8 @@ def main() -> None:
         QtCore.QTimer.singleShot(0, app.quit)
     else:
         window.show()
+        # Persistent cat tray icon (kept on the window so it isn't GC'd).
+        window.tray_icon = setup_tray(app, window, png_pixmap)
 
     try:
         sys.exit(app.exec())

--- a/mycat/reminder.py
+++ b/mycat/reminder.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 from PySide6 import QtCore
 
+from . import secret_store
+
 logger = logging.getLogger(__name__)
 
 # Same config file the rest of the app uses (see main.py). Derived locally to
@@ -123,6 +125,7 @@ def save_reminder(reminder: Reminder) -> None:
         section["in_minutes"] = str(reminder.in_minutes)
         with open(CFG_FILE, "w") as fh:
             config.write(fh)
+        secret_store.secure_file(CFG_FILE)
     except Exception as exc:  # noqa: BLE001
         logger.error("Failed to save reminder to config: %s", exc)
 
@@ -137,6 +140,7 @@ def clear_reminder() -> None:
         if config.remove_section("reminder"):
             with open(CFG_FILE, "w") as fh:
                 config.write(fh)
+            secret_store.secure_file(CFG_FILE)
     except Exception as exc:  # noqa: BLE001
         logger.error("Failed to clear reminder in config: %s", exc)
 

--- a/mycat/secret_store.py
+++ b/mycat/secret_store.py
@@ -1,0 +1,74 @@
+"""Security helpers: owner-only config files and OS-keyring-backed secrets.
+
+Keyring is optional — when it (or a backend) is missing every call degrades
+gracefully so the app keeps working with plaintext config + chmod 600.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+KEYRING_SERVICE = "mycat"
+
+
+def secure_file(path) -> None:
+    """Restrict a file to the owner (chmod 600). No-op where unsupported (Windows)."""
+    try:
+        os.chmod(path, 0o600)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def keyring_available() -> bool:
+    try:
+        import keyring
+
+        backend = keyring.get_keyring()
+        # The "fail" backend is registered when nothing usable is installed.
+        return backend is not None and "fail" not in type(backend).__name__.lower()
+    except Exception:  # noqa: BLE001 - any import/backend error means "unavailable"
+        return False
+
+
+def get_secret(name: str) -> str:
+    """Read a secret from the OS keyring, or "" when unavailable/absent."""
+    try:
+        import keyring
+
+        return keyring.get_password(KEYRING_SERVICE, name) or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def set_secret(name: str, value: str) -> bool:
+    """Store a secret in the OS keyring. Returns True on success."""
+    try:
+        import keyring
+
+        keyring.set_password(KEYRING_SERVICE, name, value)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("keyring set failed for %s: %s", name, exc)
+        return False
+
+
+def delete_secret(name: str) -> None:
+    try:
+        import keyring
+
+        keyring.delete_password(KEYRING_SERVICE, name)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+__all__ = [
+    "KEYRING_SERVICE",
+    "secure_file",
+    "keyring_available",
+    "get_secret",
+    "set_secret",
+    "delete_secret",
+]

--- a/mycat/shop_api.py
+++ b/mycat/shop_api.py
@@ -16,9 +16,9 @@ import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ class SkinEntry:
     license: str = ""
 
     @classmethod
-    def from_dict(cls, data: dict) -> "SkinEntry":
+    def from_dict(cls, data: dict) -> SkinEntry:
         return cls(
             id=str(data["id"]),
             name=str(data.get("name", data["id"])),
@@ -74,7 +74,7 @@ class Catalog:
     skins: list[SkinEntry]
 
     @classmethod
-    def from_dict(cls, data: dict) -> "Catalog":
+    def from_dict(cls, data: dict) -> Catalog:
         return cls(
             schema_version=int(data.get("schema_version", 1)),
             generated_at=str(data.get("generated_at", "")),
@@ -86,7 +86,7 @@ class ShopError(RuntimeError):
     """Raised for any shop-API failure that should surface to the user."""
 
 
-def resolve_base_url(config_path: Optional[Path] = None) -> str:
+def resolve_base_url(config_path: Path | None = None) -> str:
     """Resolve the shop base URL via env > config.ini > default."""
     env_url = (os.environ.get("MYCAT_SHOP_URL") or "").strip()
     if env_url:
@@ -119,7 +119,7 @@ class ShopClient:
         *,
         catalog_timeout: float = DEFAULT_CATALOG_TIMEOUT,
         download_timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
-        cache_dir: Optional[Path] = None,
+        cache_dir: Path | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.catalog_timeout = catalog_timeout
@@ -140,7 +140,7 @@ class ShopClient:
         cache_file = self.cache_dir / "catalog.json"
         etag_file = self.cache_dir / "catalog.etag"
 
-        cached_etag: Optional[str] = None
+        cached_etag: str | None = None
         if etag_file.exists() and cache_file.exists() and not force_refresh:
             try:
                 cached_etag = etag_file.read_text(encoding="utf-8").strip() or None
@@ -189,7 +189,7 @@ class ShopClient:
 
         return self._load_cached_catalog(cache_file)
 
-    def _maybe_load_cached_catalog(self, cache_file: Path) -> Optional[Catalog]:
+    def _maybe_load_cached_catalog(self, cache_file: Path) -> Catalog | None:
         if not cache_file.exists():
             return None
         try:
@@ -205,7 +205,7 @@ class ShopClient:
 
     # ---- preview -----------------------------------------------------------
 
-    def fetch_preview(self, skin: SkinEntry) -> Optional[Path]:
+    def fetch_preview(self, skin: SkinEntry) -> Path | None:
         """Download a skin's preview into the cache, return local path or None on failure."""
         if not skin.preview_url:
             return None
@@ -242,8 +242,8 @@ class ShopClient:
         skin: SkinEntry,
         dest_dir: Path,
         *,
-        progress_cb: Optional[Callable[[int, int], None]] = None,
-        auth_token: Optional[str] = None,
+        progress_cb: Callable[[int, int], None] | None = None,
+        auth_token: str | None = None,
     ) -> Path:
         """Download `skin` into `dest_dir/<id>.zip`, verifying SHA-256.
 

--- a/mycat/shop_ui.py
+++ b/mycat/shop_ui.py
@@ -9,14 +9,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import skin_catalog
 from .shop_api import (
     Catalog,
-    DEFAULT_BASE_URL,
     ShopClient,
     ShopError,
     SkinEntry,
@@ -63,7 +61,7 @@ class _DownloadWorker(QtCore.QRunnable):
         signals: _Signals,
         skin: SkinEntry,
         dest_dir: Path,
-        auth_token: Optional[str] = None,
+        auth_token: str | None = None,
     ) -> None:
         super().__init__()
         self._client = client
@@ -240,10 +238,10 @@ class ShopDialog(QtWidgets.QDialog):
 
     def __init__(
         self,
-        parent: Optional[QtWidgets.QWidget] = None,
+        parent: QtWidgets.QWidget | None = None,
         *,
-        base_url: Optional[str] = None,
-        config_path: Optional[Path] = None,
+        base_url: str | None = None,
+        config_path: Path | None = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Mycat Shop")
@@ -262,7 +260,7 @@ class ShopDialog(QtWidgets.QDialog):
         self._signals = _Signals()
         self._pool = QtCore.QThreadPool.globalInstance()
         self._cards: dict[str, _SkinCard] = {}
-        self._catalog: Optional[Catalog] = None
+        self._catalog: Catalog | None = None
         self._user_skins_dir = skin_catalog.ensure_user_skins_dir()
 
         self._build_ui()

--- a/mycat/skin_catalog.py
+++ b/mycat/skin_catalog.py
@@ -18,7 +18,6 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,7 @@ def scan_all() -> list[str]:
     return sorted(seen)
 
 
-def find_skin_zip(skin_id: str) -> Optional[Path]:
+def find_skin_zip(skin_id: str) -> Path | None:
     """Resolve `skin_id` to an existing ZIP path. User dir takes precedence."""
     for directory in (user_skins_dir(), bundled_skins_dir()):
         candidate = directory / f"{skin_id}.zip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ dev = [
     "pytest>=8.0",
 ]
 
+# Optional: store API keys in the OS keyring instead of plaintext config.
+[project.optional-dependencies]
+secure = ["keyring>=24"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,0 +1,27 @@
+"""Tests for the cross-platform autostart toggle (Linux path)."""
+
+import sys
+
+import pytest
+
+from mycat import autostart
+
+
+def test_launch_command_is_nonempty():
+    assert autostart.launch_command()
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux XDG autostart")
+def test_linux_enable_disable_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    desktop = tmp_path / ".config" / "autostart" / "mycat.desktop"
+
+    assert autostart.is_enabled() is False
+    autostart.set_enabled(True)
+    assert autostart.is_enabled() is True
+    assert desktop.exists()
+    assert "Exec=" in desktop.read_text()
+
+    autostart.set_enabled(False)
+    assert autostart.is_enabled() is False
+    assert not desktop.exists()

--- a/tests/test_secret_store.py
+++ b/tests/test_secret_store.py
@@ -1,0 +1,42 @@
+"""Tests for the security helpers (chmod 600 + keyring fallback)."""
+
+import os
+import stat
+import sys
+
+import pytest
+
+from mycat import secret_store
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX file modes")
+def test_secure_file_sets_owner_only(tmp_path):
+    path = tmp_path / "config.ini"
+    path.write_text("secret = 1\n")
+    os.chmod(path, 0o644)
+    secret_store.secure_file(path)
+    mode = stat.S_IMODE(path.stat().st_mode)
+    assert mode == 0o600
+
+
+def test_secure_file_missing_path_is_noop(tmp_path):
+    # Must not raise even when the file does not exist.
+    secret_store.secure_file(tmp_path / "nope.ini")
+
+
+def test_secret_helpers_degrade_without_keyring(monkeypatch):
+    # Simulate keyring being unavailable: every call should be a safe no-op.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def block_keyring(name, *args, **kwargs):
+        if name == "keyring":
+            raise ImportError("no keyring")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_keyring)
+    assert secret_store.keyring_available() is False
+    assert secret_store.get_secret("openai_api_key") == ""
+    assert secret_store.set_secret("openai_api_key", "x") is False
+    secret_store.delete_secret("openai_api_key")  # no raise


### PR DESCRIPTION
Implements 3 of the 4 prioritised "right now" items (shop excluded as requested). Item 2 (in-memory skin loading) is deliberately left for its own focused PR — see the note at the bottom.

## ✅ Included

### 1. CI with tests + ruff
- `.github/workflows/ci.yml` — on push/PR, runs `ruff check .` and the pytest suite (headless Qt via the offscreen platform) on Python 3.10 and 3.12.
- Made the repo **ruff-clean**: applied autofixes (import sorting, modern typing, comprehensions) and wrapped the remaining long log lines.

### 3. Config hardening: chmod 600 + keyring
- New `mycat/secret_store.py`: `secure_file()` restricts `config.ini` to the owner (0600); `get/set/delete_secret()` back the OS keyring with a graceful no-op fallback when keyring (or a backend) is missing.
- Every config writer (`llm_prompt`, `reminder`, `main`) now chmod 600 the file.
- The OpenAI key is read from the keyring first, then the env var.
- `keyring` is an optional dependency: `pip install mycat[secure]`.

### 4. Autostart + system-tray cat
- New `mycat/autostart.py`: cross-platform "start on login" (Linux XDG `.desktop`, Windows `HKCU\…\Run`), no-op elsewhere.
- A persistent **cat icon in the system tray** with a quick menu (Chat, Reminder…, LLM…, Start on login, Quit); double-click raises the cat.
- "Start on login" is also in the right-click context menu.

## ⏭️ Deferred — item 2 (eliminate /tmp/mycat → in-memory skins)
This refactors the **core image pipeline** (`load_packaged_images`, the per-frame `QMovie`/`QPixmap` recreation, skin switching) away from `tempfile.gettempdir()/mycat/{static.png,animation.gif}` to an in-memory `QMovie` fed by a `QBuffer`. It's the right fix (closes the predictable-shared-temp security issue + a bug class) but touches global state and every animation path, so it deserves its own change with thorough live testing rather than being rushed. Plan: `QMovie` from a parented `QBuffer(gif_bytes)`, derive the first frame via `jumpToFrame(0).currentPixmap()`, store the gif bytes on the window for restarts, drop the temp files entirely.

## Test plan
- [ ] CI is green (ruff + pytest, 3.10/3.12).
- [ ] Config files are written with mode 600.
- [ ] Tray icon appears; menu actions work; "Start on login" toggles the autostart entry.
- [ ] `python -m pytest` passes locally (29 tests).