### PR TITLE
Rename "Start on login" menu item to "Autostart"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ## Unreleased
 
 ### Changed
+- Renamed the "Start on login" item to "Autostart" in the context and tray menus (branch `chore/autostart-label`).
 - Skins are now decoded straight from the packaged ZIP bytes into an in-memory `QBuffer`-backed `QMovie`; nothing is written to `/tmp/mycat` anymore (branch `feat/in-memory-skins`). The animation restart and skin-switch paths recreate the movie from the held GIF bytes, so no temp files are touched at any point.
 
 ### Removed

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -679,7 +679,7 @@ class PixelCatWindow(QtWidgets.QWidget):
             menu.addSeparator()
 
         if autostart.is_supported():
-            login_action = menu.addAction("Start on login")
+            login_action = menu.addAction("Autostart")
             login_action.setCheckable(True)
             login_action.setChecked(autostart.is_enabled())
             login_action.toggled.connect(autostart.set_enabled)
@@ -1113,7 +1113,7 @@ def setup_tray(app, window, icon_pixmap):
     menu.addAction("LLM…", window.open_llm_settings)
     if autostart.is_supported():
         menu.addSeparator()
-        login_action = menu.addAction("Start on login")
+        login_action = menu.addAction("Autostart")
         login_action.setCheckable(True)
         login_action.setChecked(autostart.is_enabled())
         login_action.toggled.connect(autostart.set_enabled)


### PR DESCRIPTION
## Summary

Renames the autostart toggle from "Start on login" to "Autostart" in both places it appears: the cat's right-click context menu and the system-tray menu. The label now matches the module name (`mycat/autostart.py`).

## Test plan

- [x] `ruff check .` — clean
- [x] `pytest -q` — 29 passed (offscreen)
- [x] Offscreen boot smoke — no errors
- [x] `grep "Start on login"` — no remaining occurrences