### PR TITLE
Fix dragging the reminder flyby plane on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project are documented in this file.
 ### Removed
 - `/tmp/mycat` temp-file extraction and the `TEMP_DIR` / `STATIC_PNG_PATH` / `ANIMATION_GIF_PATH` globals plus `get_temp_dir()` (branch `feat/in-memory-skins`).
 
+### Fixed
+- The reminder flyby plane could not be dragged during flight on X11: the window manager shifted the frameless overlay down by the panel height and hijacked a body click-drag as a "move window" gesture, so pressing the plane only changed the cursor while the plane stayed put. The overlay now bypasses the window manager on X11 (`X11BypassWindowManagerHint`), and its grab region is grown a few pixels so the moving plane/cat is an easy target on no-compositor sessions (branch `fix/flyby-grab-region`).
+
 ## 0.1.6
 
 ### Added

--- a/mycat/reminder_ui.py
+++ b/mycat/reminder_ui.py
@@ -87,6 +87,27 @@ def _resolve_plane_color(name: str) -> QtGui.QColor:
     return PLANE_COLORS["pink"]
 
 
+# How far to grow the plane/cat hit-region when the window is clipped to its
+# silhouette (no-compositor X11). The bare silhouette of a moving plane is a
+# painfully thin target — only the exact opaque pixels absorb clicks, so the
+# user keeps missing. Growing it by a few pixels turns it into an easy target
+# at the cost of a thin dark outline (the only thing that can show without a
+# compositor). Has no effect in the normal bounding-box path.
+GRAB_GROW_PX = 5
+
+
+def grow_region(region: QtGui.QRegion, radius: int) -> QtGui.QRegion:
+    """Dilate ``region`` by ``radius`` px (8-neighbour translate + union)."""
+    if radius <= 0 or region.isEmpty():
+        return region
+    grown = QtGui.QRegion(region)
+    for dx in (-radius, 0, radius):
+        for dy in (-radius, 0, radius):
+            if dx or dy:
+                grown = grown.united(region.translated(dx, dy))
+    return grown
+
+
 def _tinted_pixmap(base: QtGui.QPixmap, tint: QtGui.QColor) -> QtGui.QPixmap:
     """Multiply-blend ``base`` by ``tint``, then restore the alpha mask.
 
@@ -153,6 +174,14 @@ class FlybyWindow(QtWidgets.QWidget):
         platform_name = (app.platformName() or "").lower() if app is not None else ""
         if platform_name != "offscreen":
             flags |= QtCore.Qt.WindowType.WindowStaysOnTopHint
+        # On X11, let the window manager NOT manage this overlay. Without this,
+        # many WMs (a) shift the frameless window down by the panel height and
+        # (b) hijack a body click-drag as "move the whole window" — so pressing
+        # the plane only changes the cursor and the plane never follows the drag
+        # (the WM ate the motion). Bypassing the WM makes the X server deliver
+        # the drag straight to us, and keeps the overlay glued to (0, 0).
+        if platform_name == "xcb":
+            flags |= QtCore.Qt.WindowType.X11BypassWindowManagerHint
         super().__init__(parent, flags)
 
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_TranslucentBackground, True)
@@ -416,9 +445,12 @@ class FlybyWindow(QtWidgets.QWidget):
             pixmap, bx, by = blit
             bitmap = pixmap.mask()
             if bitmap.isNull():
-                region += QtGui.QRegion(int(bx), int(by), pixmap.width(), pixmap.height())
+                blit_region = QtGui.QRegion(int(bx), int(by), pixmap.width(), pixmap.height())
             else:
-                region += QtGui.QRegion(bitmap).translated(int(bx), int(by))
+                blit_region = QtGui.QRegion(bitmap).translated(int(bx), int(by))
+            # Grow the plane/cat so they are easy to grab mid-flight; the flag,
+            # pole and rope stay crisp (the flag is already a solid target).
+            region += grow_region(blit_region, GRAB_GROW_PX)
 
         # A window mask that is entirely off-screen stops the window from
         # receiving paint events, which would freeze the mask there forever and


### PR DESCRIPTION
## Summary

The reminder flyby (cat-on-a-plane banner) couldn't be dragged during flight on X11. Reported symptom: *"the cursor changes to the move shape but the plane stays in place."*

**Root cause:** the flyby is a frameless, full-screen-width overlay that paints a click-through mask each frame. On X11 the window manager was *managing* this overlay — it shifted it down by the panel height (geometry jumped from `y=0` to `y=26`) and treated a body click-drag as a **"move the whole window"** gesture. So pressing the plane flipped the cursor to the move shape, but the WM swallowed the motion and the plane never followed.

The drag code itself was never broken (verified: a directly-delivered press→move→release updates the offset correctly).

## Changes

- **`X11BypassWindowManagerHint` on xcb** — the X server now delivers the drag straight to the overlay, and it stays glued to `(0, 0)` (no more panel-height shift). This is the actual fix for the reported symptom.
- **Grown grab region** (`grow_region` / `GRAB_GROW_PX=5`) — on no-compositor sessions the overlay is clipped to its tight silhouette, so a moving plane is a painfully thin click target. The plane/cat hit region is now dilated a few px; the flag, pole and rope stay crisp. No effect when a compositor is present (that path already uses a generous bounding box).

## Verification

- [x] `ruff check .` — clean
- [x] `pytest -q` — 41 passed (offscreen)
- [x] On a live `:0` X11 session: overlay geometry is now `(0, 0)` (was `(0, 26)`); renders correctly with no black box; drag offset updates on a delivered drag.

> Note: real synthetic mouse input (XTEST) is non-functional in the test session, so an end-to-end physical-click drag could not be automated — please confirm dragging works on your desktop.