### PR TITLE
Make reminder settings dialog non-modal (testable flyby)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - **Multiple chat vendors.** The LLM settings dialog (right-click → LLM…) now lets you pick a vendor — Ollama (default, local), OpenAI, Grok (xAI), Groq, DeepSeek, OpenRouter — or define a **custom** OpenAI-compatible endpoint (name + base URL + key + model). One adapter covers every OpenAI-compatible provider. API keys are hybrid: typed into the dialog (saved to config) or read from the vendor's environment variable.
 
 ### Changed
+- The reminder settings dialog is now **non-modal**, so the flyby launched by its **Test** button can be grabbed and dragged while the dialog stays open (a modal dialog grabbed all input, leaving the test plane unclickable). Reopening while already open just raises the existing dialog (branch `fix/reminder-dialog-nonmodal`).
 - The OpenAI/cloud backend is now a dependency-free `urllib` client (no `openai` package required) that supports any `base_url`.
 - Renamed the "Start on login" item to "Autostart" in the context and tray menus (branch `chore/autostart-label`).
 - Skins are now decoded straight from the packaged ZIP bytes into an in-memory `QBuffer`-backed `QMovie`; nothing is written to `/tmp/mycat` anymore (branch `feat/in-memory-skins`). The animation restart and skin-switch paths recreate the movie from the held GIF bytes, so no temp files are touched at any point.

--- a/mycat/reminder.py
+++ b/mycat/reminder.py
@@ -167,6 +167,7 @@ class ReminderController(QtCore.QObject):
         self._window = window
         self._reminder = load_reminder()
         self._flyby = None  # keep a ref so the window isn't garbage-collected mid-flight
+        self.settings_dialog = None  # non-modal dialog ref (kept alive while open)
 
         self._normalize_on_start()
 
@@ -197,7 +198,17 @@ class ReminderController(QtCore.QObject):
         self.show_flyby(reminder)
 
     def open_dialog(self) -> None:
-        """Lazily build and show the settings dialog."""
+        """Build and show the settings dialog NON-modally.
+
+        Non-modal on purpose: a modal ``exec()`` grabs all input, so the Test
+        flyby launched from the dialog could not be clicked or dragged while the
+        dialog stayed open. With ``show()`` the user can fire Test, then grab and
+        park the plane, and keep tweaking settings — all at once.
+        """
+        if self.settings_dialog is not None and self.settings_dialog.isVisible():
+            self.settings_dialog.raise_()
+            self.settings_dialog.activateWindow()
+            return
         try:
             if __package__:
                 from .reminder_ui import ReminderDialog
@@ -210,7 +221,12 @@ class ReminderController(QtCore.QObject):
             return
 
         dialog = ReminderDialog(self, self._reminder, parent=self._window)
-        dialog.exec()
+        dialog.setModal(False)
+        dialog.finished.connect(lambda result: setattr(self, "settings_dialog", None))
+        self.settings_dialog = dialog
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
 
     def show_flyby(self, reminder: Reminder) -> None:
         """Create and launch a flyby for ``reminder`` (no-op on headless platforms)."""


### PR DESCRIPTION
## Summary

The reminder settings dialog was shown with `exec()` — a **modal** event loop that grabs all input. So the flyby plane launched by the dialog's **Test** button couldn't be clicked or dragged while the dialog stayed open. (This was the cause of "the Test plane won't move": the dialog was holding the input grab.)

Now the dialog is shown **non-modally**:
- `show()` instead of `exec()`, with the dialog kept on the controller so it isn't garbage-collected.
- The reference is cleared when the dialog closes (`finished`).
- Calling `open_dialog()` again just raises the existing dialog instead of opening a second one.

Save / Clear / Cancel behavior is unchanged — those call the controller directly, not via the modal return value.

## Verification

- [x] `ruff check .` — clean
- [x] `pytest -q` — 41 passed (offscreen)
- [x] Live `:0`: with the dialog open and non-modal, `topLevelAt`/`widgetAt` at the flying plane resolve to the `FlybyWindow`, and a delivered drag moves the plane (`_user_offset` updates) — i.e. the Test plane is grabbable while the dialog stays open.