### PR TITLE
Persistence hardening: tray-resident, first-run autostart prompt, single instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project are documented in this file.
 ## Unreleased
 
 ### Added
+- **First-run prompt to start on login.** On the first launch (where autostart is supported and not already on), mycat asks once whether to start every login — the autostart toggle was otherwise buried in the right-click menu. The answer is remembered in `[settings] autostart_prompted` so it is never asked twice (branch `feat/persistence-hardening`).
+- **Single-instance guard.** A second launch no longer spawns a second cat — it detects the running instance via a `QLockFile` and exits (a lock left by a crashed instance is reclaimed automatically) (branch `feat/persistence-hardening`).
 - **Multiple chat vendors.** The LLM settings dialog (right-click → LLM…) now lets you pick a vendor — Ollama (default, local), OpenAI, Grok (xAI), Groq, DeepSeek, OpenRouter — or define a **custom** OpenAI-compatible endpoint (name + base URL + key + model). One adapter covers every OpenAI-compatible provider. API keys are hybrid: typed into the dialog (saved to config) or read from the vendor's environment variable.
 
 ### Changed
+- mycat now **lives in the system tray**: closing or hiding its windows no longer quits the app — only the explicit Quit action does (when a tray is available, so the user is never left with an invisible process). Keeps the cat persistent across the session (branch `feat/persistence-hardening`).
 - The reminder settings dialog is now **non-modal**, so the flyby launched by its **Test** button can be grabbed and dragged while the dialog stays open (a modal dialog grabbed all input, leaving the test plane unclickable). Reopening while already open just raises the existing dialog (branch `fix/reminder-dialog-nonmodal`).
 - The OpenAI/cloud backend is now a dependency-free `urllib` client (no `openai` package required) that supports any `base_url`.
 - Renamed the "Start on login" item to "Autostart" in the context and tray menus (branch `chore/autostart-label`).

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -368,6 +368,72 @@ def save_image_to_ini(image_name: str) -> None:
         logger.error(f"Error saving to INI file: {e}")
 
 
+def autostart_was_prompted() -> bool:
+    """Whether the first-run "start on login?" prompt has already been shown.
+
+    Stored as ``[settings] autostart_prompted`` so the user is asked at most once.
+    """
+    if not CFG_FILE.exists():
+        return False
+    try:
+        config = configparser.ConfigParser()
+        config.read(CFG_FILE)
+        return config.getboolean("settings", "autostart_prompted", fallback=False)
+    except Exception as exc:
+        logger.debug("Could not read autostart_prompted flag: %s", exc)
+        return False
+
+
+def mark_autostart_prompted() -> None:
+    """Record that the first-run autostart prompt has been shown."""
+    try:
+        CFG_DIR.mkdir(parents=True, exist_ok=True)
+        config = configparser.ConfigParser()
+        if CFG_FILE.exists():
+            config.read(CFG_FILE)
+        if "settings" not in config:
+            config.add_section("settings")
+        config["settings"]["autostart_prompted"] = "true"
+        with open(CFG_FILE, "w") as f:
+            config.write(f)
+        secret_store.secure_file(CFG_FILE)
+    except Exception as exc:
+        logger.error("Could not save autostart_prompted flag: %s", exc)
+
+
+def should_offer_autostart() -> bool:
+    """First run, on a platform that supports autostart, not enabled, not asked."""
+    return (
+        autostart.is_supported()
+        and not autostart.is_enabled()
+        and not autostart_was_prompted()
+    )
+
+
+def offer_autostart_on_first_run(window: QtWidgets.QWidget) -> None:
+    """Ask once, on first run, whether to keep mycat on screen every login.
+
+    The whole point of autostart is to make the cat persistent — but the toggle
+    is buried in the right-click menu, so most users never find it. A single
+    gentle first-run prompt is the biggest lever for "always running".
+    """
+    if not should_offer_autostart():
+        return
+    # Record first so a crash mid-prompt never re-asks on every launch.
+    mark_autostart_prompted()
+    answer = QtWidgets.QMessageBox.question(
+        window,
+        "mycat",
+        "Keep mycat on screen every time you log in?\n\n"
+        "You can change this any time from the right-click menu → Autostart.",
+        QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
+        QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+    if answer == QtWidgets.QMessageBox.StandardButton.Yes:
+        autostart.set_enabled(True)
+        logger.info("Autostart enabled via first-run prompt")
+
+
 class PixelCatWindow(QtWidgets.QWidget):
     """Main cat window widget with PNG/GIF animation and dragging."""
     
@@ -1181,6 +1247,18 @@ def main() -> None:
         logger.error(f"Failed to initialize Qt application: {e}")
         sys.exit(1)
     
+    # Single instance: a second launch must not spawn a second cat. Hold the
+    # lock for the whole process lifetime (it is released when the process
+    # exits). A lock left by a crashed instance is reclaimed automatically
+    # because QLockFile records the owner PID and detects a dead owner.
+    if platform_name != "offscreen":
+        CFG_DIR.mkdir(parents=True, exist_ok=True)
+        instance_lock = QtCore.QLockFile(str(CFG_DIR / "mycat.lock"))
+        instance_lock.setStaleLockTime(0)
+        if not instance_lock.tryLock(100):
+            logger.info("Another mycat instance is already running — exiting.")
+            sys.exit(0)
+
     # Setup signal handlers for graceful shutdown
     def signal_handler(signum, frame):
         """Handle Ctrl+C gracefully."""
@@ -1233,6 +1311,12 @@ def main() -> None:
         window.show()
         # Persistent cat tray icon (kept on the window so it isn't GC'd).
         window.tray_icon = setup_tray(app, window, png_pixmap)
+        # Live in the tray: hiding/closing windows no longer quits the app —
+        # only the explicit Quit action does. With no tray to quit from, keep
+        # the old behaviour so the user is never stuck with an invisible process.
+        app.setQuitOnLastWindowClosed(window.tray_icon is None)
+        # First-run nudge to start on login (after the cat is up).
+        QtCore.QTimer.singleShot(600, lambda: offer_autostart_on_first_run(window))
 
     try:
         sys.exit(app.exec())

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,48 @@
+"""Tests for first-run autostart-prompt bookkeeping (livability phase A)."""
+
+from mycat import main
+
+
+def use_temp_config(monkeypatch, tmp_path):
+    monkeypatch.setattr(main, "CFG_DIR", tmp_path)
+    monkeypatch.setattr(main, "CFG_FILE", tmp_path / "config.ini")
+
+
+def test_prompted_flag_roundtrips(monkeypatch, tmp_path):
+    use_temp_config(monkeypatch, tmp_path)
+    assert main.autostart_was_prompted() is False
+    main.mark_autostart_prompted()
+    assert main.autostart_was_prompted() is True
+
+
+def test_mark_prompted_preserves_other_settings(monkeypatch, tmp_path):
+    use_temp_config(monkeypatch, tmp_path)
+    main.save_image_to_ini("girl1")
+    main.mark_autostart_prompted()
+    assert main.load_image_from_ini() == "girl1"
+    assert main.autostart_was_prompted() is True
+
+
+def test_should_offer_only_on_fresh_supported_disabled(monkeypatch, tmp_path):
+    use_temp_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(main.autostart, "is_supported", lambda: True)
+    monkeypatch.setattr(main.autostart, "is_enabled", lambda: False)
+    assert main.should_offer_autostart() is True
+
+    # Already prompted -> never again.
+    main.mark_autostart_prompted()
+    assert main.should_offer_autostart() is False
+
+
+def test_should_not_offer_when_already_enabled(monkeypatch, tmp_path):
+    use_temp_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(main.autostart, "is_supported", lambda: True)
+    monkeypatch.setattr(main.autostart, "is_enabled", lambda: True)
+    assert main.should_offer_autostart() is False
+
+
+def test_should_not_offer_when_unsupported(monkeypatch, tmp_path):
+    use_temp_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(main.autostart, "is_supported", lambda: False)
+    monkeypatch.setattr(main.autostart, "is_enabled", lambda: False)
+    assert main.should_offer_autostart() is False


### PR DESCRIPTION
## Summary

Phase **A (livability)** from the roadmap — keep the cat present every session so the app "stays open":

- **Live in the tray** — `setQuitOnLastWindowClosed(False)` when a system tray is available, so closing/hiding windows no longer quits mycat; only the explicit **Quit** action does. Falls back to the previous behaviour when there's no tray, so the user is never left with an invisible process.
- **First-run autostart prompt** — on the first launch (autostart supported & not already on & not asked before), mycat asks once whether to start on login. The toggle was otherwise buried in the right-click menu, so most users never enabled it. The answer is remembered in `[settings] autostart_prompted`, so it's never asked twice.
- **Single-instance guard** — a second launch detects the running instance via a `QLockFile` and exits instead of spawning a second cat. A lock left by a crashed instance is reclaimed automatically (QLockFile checks the owner PID).

## Test plan

- [x] `ruff check .` — clean
- [x] `pytest -q` — 46 passed (5 new, in `tests/test_persistence.py`: prompt flag round-trip, settings preserved, and the `should_offer_autostart` decision matrix)
- [x] Live `:0`: starting a second instance logs *"Another mycat instance is already running — exiting."* and exits 0 while the first keeps running
- [x] Offscreen boot unaffected (single-instance lock + first-run prompt are skipped on the offscreen platform)

## Notes
- "Raise the existing cat on second launch" (IPC) is deferred — for now a duplicate launch just exits.