### PR TITLE
feat: import custom cat skins

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ mycat                 # or, without installing:  python3 mycat/main.py
 ## ✨ Features
 
 - **Animated overlay** 🐱 — a frameless, always-on-top, draggable cat. Right-click for the menu (switch skin, quit).
+- **Custom pets** 🐾 — import your own cat or dog GIF from the right-click menu, or launch one from the CLI.
 - **Reminder** 🛩️ — set a message and a time (one-shot or daily) and the cat flies a little banner plane across the top of your screen. Right-click → *Reminder…* to set the message, direction, plane and color.
 - **Chat (Ollama)** 💬 — talk to the cat through a **local [Ollama](https://ollama.com) model**, no account or API key needed (see below).
 
@@ -90,6 +91,14 @@ mycat --image ~/my-custom-cat.zip
 ```
 
 A skin **ZIP** must contain exactly one `.gif`: its first frame is the static pose, then the GIF plays once and returns to that frame. Images larger than 300×500 are scaled down automatically.
+
+**`--pet-image <path>`** 🐾 — install and launch your own pet from a local `.gif` or skin `.zip`:
+
+```bash
+mycat --pet-image ~/Pictures/luna.gif --pet-name luna
+```
+
+Imported pets are saved into the user skins folder, so they appear in the right-click **Images** menu on later launches. You can also import one without the terminal: right-click the pet → **Import pet…** → choose a GIF or ZIP → name it.
 
 **`--pos <x> <y>`** 📍 — start at a specific screen position (otherwise the cat appears bottom-right and remembers where you last dragged it):
 
@@ -123,6 +132,8 @@ zip images/cat.zip images/cat.gif
 ```
 
 Drop the resulting ZIP next to the others and pick it from the right-click **skins** menu.
+
+For a real pet, export a transparent GIF of your cat or dog and import it with **Import pet…**. A short idle animation works best: first frame as the resting pose, then a blink, tail wag or tiny bounce.
 
 ## 🐳 Docker
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mycat                 # or, without installing:  python3 mycat/main.py
 ## ✨ Features
 
 - **Animated overlay** 🐱 — a frameless, always-on-top, draggable cat. Right-click for the menu (switch skin, quit).
-- **Custom pets** 🐾 — import your own cat or dog GIF from the right-click menu, or launch one from the CLI.
+- **Custom cats** 🐾 — import your own cat GIF from the right-click menu, or launch one from the CLI.
 - **Reminder** 🛩️ — set a message and a time (one-shot or daily) and the cat flies a little banner plane across the top of your screen. Right-click → *Reminder…* to set the message, direction, plane and color.
 - **Chat (Ollama)** 💬 — talk to the cat through a **local [Ollama](https://ollama.com) model**, no account or API key needed (see below).
 
@@ -92,13 +92,13 @@ mycat --image ~/my-custom-cat.zip
 
 A skin **ZIP** must contain exactly one `.gif`: its first frame is the static pose, then the GIF plays once and returns to that frame. Images larger than 300×500 are scaled down automatically.
 
-**`--pet-image <path>`** 🐾 — install and launch your own pet from a local `.gif` or skin `.zip`:
+**`--cat-image <path>`** 🐾 — install and launch your own cat from a local `.gif` or skin `.zip`:
 
 ```bash
-mycat --pet-image ~/Pictures/luna.gif --pet-name luna
+mycat --cat-image ~/Pictures/luna.gif --cat-name luna
 ```
 
-Imported pets are saved into the user skins folder, so they appear in the right-click **Images** menu on later launches. You can also import one without the terminal: right-click the pet → **Import pet…** → choose a GIF or ZIP → name it.
+Imported cats are saved into the user skins folder, so they appear in the right-click **Images** menu on later launches. You can also import one without the terminal: right-click the cat → **Import cat…** → choose a GIF or ZIP → name it.
 
 **`--pos <x> <y>`** 📍 — start at a specific screen position (otherwise the cat appears bottom-right and remembers where you last dragged it):
 
@@ -133,7 +133,7 @@ zip images/cat.zip images/cat.gif
 
 Drop the resulting ZIP next to the others and pick it from the right-click **skins** menu.
 
-For a real pet, export a transparent GIF of your cat or dog and import it with **Import pet…**. A short idle animation works best: first frame as the resting pose, then a blink, tail wag or tiny bounce.
+For a real cat, export a transparent GIF and import it with **Import cat…**. A short idle animation works best: first frame as the resting pose, then a blink, tail flick or tiny bounce.
 
 ## 🐳 Docker
 

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -368,10 +368,10 @@ def save_image_to_ini(image_name: str) -> None:
         logger.error(f"Error saving to INI file: {e}")
 
 
-def install_pet_image(source_path: str, pet_name: str | None = None) -> str:
-    """Install a local pet GIF/ZIP and return the new skin id."""
-    skin_id = skin_catalog.install_custom_pet(source_path, pet_name)
-    logger.info("Installed custom pet '%s' from %s", skin_id, source_path)
+def install_cat_image(source_path: str, cat_name: str | None = None) -> str:
+    """Install a local cat GIF/ZIP and return the new skin id."""
+    skin_id = skin_catalog.install_custom_cat(source_path, cat_name)
+    logger.info("Installed custom cat '%s' from %s", skin_id, source_path)
     return skin_id
 
 
@@ -682,8 +682,8 @@ class PixelCatWindow(QtWidgets.QWidget):
         reminder_action.triggered.connect(self._open_reminder)
         menu.addSeparator()
 
-        import_pet_action = menu.addAction("Import pet…")
-        import_pet_action.triggered.connect(self._import_pet_image)
+        import_cat_action = menu.addAction("Import cat…")
+        import_cat_action.triggered.connect(self._import_cat_image)
 
         # Rebuild the list every time so freshly-installed skins appear without restart.
         self.available_images = skin_catalog.scan_all()
@@ -762,32 +762,32 @@ class PixelCatWindow(QtWidgets.QWidget):
         if controller is not None:
             controller.open_dialog()
 
-    def _import_pet_image(self) -> None:
-        """Let users install their own cat/dog GIF or skin ZIP from the menu."""
+    def _import_cat_image(self) -> None:
+        """Let users install their own cat GIF or skin ZIP from the menu."""
         file_path, _selected_filter = QtWidgets.QFileDialog.getOpenFileName(
             self,
-            "Choose pet animation",
+            "Choose cat animation",
             str(Path.home()),
-            "Pet animations (*.gif *.zip)",
+            "Cat animations (*.gif *.zip)",
         )
         if not file_path:
             return
 
         default_name = Path(file_path).stem
-        pet_name, ok = QtWidgets.QInputDialog.getText(
+        cat_name, ok = QtWidgets.QInputDialog.getText(
             self,
-            "Name this pet",
-            "Pet name:",
+            "Name this cat",
+            "Cat name:",
             text=default_name,
         )
         if not ok:
             return
 
         try:
-            skin_id = install_pet_image(file_path, pet_name or default_name)
+            skin_id = install_cat_image(file_path, cat_name or default_name)
         except Exception as exc:
-            logger.error("Could not import pet image: %s", exc)
-            QtWidgets.QMessageBox.warning(self, "Import pet", str(exc))
+            logger.error("Could not import cat image: %s", exc)
+            QtWidgets.QMessageBox.warning(self, "Import cat", str(exc))
             return
 
         self.available_images = skin_catalog.scan_all()
@@ -965,16 +965,16 @@ def parse_args() -> argparse.Namespace:
         help="Start position (overrides remembered position)",
     )
     parser.add_argument(
-        "--pet-image",
+        "--cat-image",
         type=str,
         default=None,
-        help="Install and launch a custom pet from a local .gif or .zip skin archive.",
+        help="Install and launch a custom cat from a local .gif or .zip skin archive.",
     )
     parser.add_argument(
-        "--pet-name",
+        "--cat-name",
         type=str,
         default=None,
-        help="Name to save the --pet-image skin under (for example: luna, max, momo).",
+        help="Name to save the --cat-image skin under (for example: luna, momo, miso).",
     )
     parser.add_argument(
         "--debug",
@@ -983,10 +983,10 @@ def parse_args() -> argparse.Namespace:
     )
     llm.add_arguments(parser)
     args = parser.parse_args()
-    if args.image and args.pet_image:
-        parser.error("--image and --pet-image cannot be used together")
-    if args.pet_name and not args.pet_image:
-        parser.error("--pet-name requires --pet-image")
+    if args.image and args.cat_image:
+        parser.error("--image and --cat-image cannot be used together")
+    if args.cat_name and not args.cat_image:
+        parser.error("--cat-name requires --cat-image")
     return args
 
 def x11_compositor_active() -> bool | None:
@@ -1257,19 +1257,19 @@ def main() -> None:
     available_images = scan_images_directory()
     logger.info(f"Found {len(available_images)} ZIP archive(s): {', '.join(available_images)}")
     
-    # Import a custom pet before scanning so it appears in menus and config.
-    launched_pet = None
-    if args.pet_image:
+    # Import a custom cat before scanning so it appears in menus and config.
+    launched_cat = None
+    if args.cat_image:
         try:
-            launched_pet = install_pet_image(args.pet_image, args.pet_name)
+            launched_cat = install_cat_image(args.cat_image, args.cat_name)
         except Exception as e:
-            logger.error(f"Error importing custom pet: {e}")
+            logger.error(f"Error importing custom cat: {e}")
             sys.exit(2)
 
     # Load default image from INI if no image path provided
     default_image = None
-    if launched_pet:
-        default_image = launched_pet
+    if launched_cat:
+        default_image = launched_cat
         available_images = scan_images_directory()
     elif not args.image:
         default_image = load_image_from_ini()

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -368,6 +368,13 @@ def save_image_to_ini(image_name: str) -> None:
         logger.error(f"Error saving to INI file: {e}")
 
 
+def install_pet_image(source_path: str, pet_name: str | None = None) -> str:
+    """Install a local pet GIF/ZIP and return the new skin id."""
+    skin_id = skin_catalog.install_custom_pet(source_path, pet_name)
+    logger.info("Installed custom pet '%s' from %s", skin_id, source_path)
+    return skin_id
+
+
 class PixelCatWindow(QtWidgets.QWidget):
     """Main cat window widget with PNG/GIF animation and dragging."""
     
@@ -675,6 +682,9 @@ class PixelCatWindow(QtWidgets.QWidget):
         reminder_action.triggered.connect(self._open_reminder)
         menu.addSeparator()
 
+        import_pet_action = menu.addAction("Import pet…")
+        import_pet_action.triggered.connect(self._import_pet_image)
+
         # Rebuild the list every time so freshly-installed skins appear without restart.
         self.available_images = skin_catalog.scan_all()
         if len(self.available_images) > 0:
@@ -751,6 +761,37 @@ class PixelCatWindow(QtWidgets.QWidget):
         controller = getattr(self, "reminder_controller", None)
         if controller is not None:
             controller.open_dialog()
+
+    def _import_pet_image(self) -> None:
+        """Let users install their own cat/dog GIF or skin ZIP from the menu."""
+        file_path, _selected_filter = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Choose pet animation",
+            str(Path.home()),
+            "Pet animations (*.gif *.zip)",
+        )
+        if not file_path:
+            return
+
+        default_name = Path(file_path).stem
+        pet_name, ok = QtWidgets.QInputDialog.getText(
+            self,
+            "Name this pet",
+            "Pet name:",
+            text=default_name,
+        )
+        if not ok:
+            return
+
+        try:
+            skin_id = install_pet_image(file_path, pet_name or default_name)
+        except Exception as exc:
+            logger.error("Could not import pet image: %s", exc)
+            QtWidgets.QMessageBox.warning(self, "Import pet", str(exc))
+            return
+
+        self.available_images = skin_catalog.scan_all()
+        self._load_image(skin_id)
 
     def _on_skin_installed(self, _skin_id: str) -> None:
         self.available_images = skin_catalog.scan_all()
@@ -924,12 +965,29 @@ def parse_args() -> argparse.Namespace:
         help="Start position (overrides remembered position)",
     )
     parser.add_argument(
+        "--pet-image",
+        type=str,
+        default=None,
+        help="Install and launch a custom pet from a local .gif or .zip skin archive.",
+    )
+    parser.add_argument(
+        "--pet-name",
+        type=str,
+        default=None,
+        help="Name to save the --pet-image skin under (for example: luna, max, momo).",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Enable verbose DEBUG logging (per-frame animation cycle, GIF timing, etc.)",
     )
     llm.add_arguments(parser)
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.image and args.pet_image:
+        parser.error("--image and --pet-image cannot be used together")
+    if args.pet_name and not args.pet_image:
+        parser.error("--pet-name requires --pet-image")
+    return args
 
 def x11_compositor_active() -> bool | None:
     """Return True/False when an X11 compositing manager is running, None if undetermined.
@@ -1199,9 +1257,21 @@ def main() -> None:
     available_images = scan_images_directory()
     logger.info(f"Found {len(available_images)} ZIP archive(s): {', '.join(available_images)}")
     
+    # Import a custom pet before scanning so it appears in menus and config.
+    launched_pet = None
+    if args.pet_image:
+        try:
+            launched_pet = install_pet_image(args.pet_image, args.pet_name)
+        except Exception as e:
+            logger.error(f"Error importing custom pet: {e}")
+            sys.exit(2)
+
     # Load default image from INI if no image path provided
     default_image = None
-    if not args.image:
+    if launched_pet:
+        default_image = launched_pet
+        available_images = scan_images_directory()
+    elif not args.image:
         default_image = load_image_from_ini()
         if default_image and default_image not in available_images:
             logger.warning(f"Image '{default_image}' from INI not found in available images, using default: cat")

--- a/mycat/skin_catalog.py
+++ b/mycat/skin_catalog.py
@@ -12,10 +12,13 @@ defaults with newer downloads from the shop).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
+import re
 import sys
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -23,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 INSTALLED_JSON_NAME = "installed.json"
 INSTALLED_SCHEMA_VERSION = 1
+SKIN_ID_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
 
 
 def bundled_skins_dir() -> Path:
@@ -31,6 +35,9 @@ def bundled_skins_dir() -> Path:
 
 def user_skins_dir() -> Path:
     """Platform-specific writable directory for downloaded/user-added skins."""
+    override = os.environ.get("MYCAT_SKINS_DIR")
+    if override:
+        return Path(override).expanduser()
     if sys.platform == "win32":
         base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
         return Path(base) / "mycat" / "skins"
@@ -48,6 +55,75 @@ def ensure_user_skins_dir() -> Path:
     except OSError as exc:
         logger.warning("Could not create user skins dir %s: %s", path, exc)
     return path
+
+
+def normalize_skin_id(value: str) -> str:
+    """Return a filesystem-safe skin id for user-imported pets."""
+    normalized = SKIN_ID_PATTERN.sub("-", value.strip()).strip(".-_").lower()
+    return normalized or "pet"
+
+
+def unique_skin_id(base_id: str) -> str:
+    """Return a skin id that does not overwrite an existing user skin."""
+    base_id = normalize_skin_id(base_id)
+    candidate = base_id
+    suffix = 2
+    user_dir = ensure_user_skins_dir()
+    while (user_dir / f"{candidate}.zip").exists():
+        candidate = f"{base_id}-{suffix}"
+        suffix += 1
+    return candidate
+
+
+def gif_names_in_zip(zip_path: Path) -> list[str]:
+    """Return GIF members from a skin ZIP, ignoring directory entries."""
+    with zipfile.ZipFile(zip_path, "r") as zip_file:
+        return [
+            name
+            for name in zip_file.namelist()
+            if not name.endswith("/") and name.lower().endswith(".gif")
+        ]
+
+
+def validate_skin_zip(zip_path: Path) -> None:
+    """Validate that a ZIP can be used as a skin archive."""
+    try:
+        gif_files = gif_names_in_zip(zip_path)
+    except zipfile.BadZipFile as exc:
+        raise ValueError(f"Invalid ZIP file: {zip_path}") from exc
+    if len(gif_files) != 1:
+        raise ValueError(f"Skin ZIP must contain exactly one GIF, found {len(gif_files)}")
+
+
+def install_custom_pet(source_path: str | Path, pet_name: str | None = None) -> str:
+    """Install a local GIF or skin ZIP as a user pet and return its skin id."""
+    source = Path(source_path).expanduser()
+    if not source.exists():
+        raise FileNotFoundError(f"Pet image not found: {source}")
+    if not source.is_file():
+        raise ValueError(f"Pet image must be a file: {source}")
+
+    base_name = pet_name or source.stem
+    skin_id = unique_skin_id(base_name)
+    destination = ensure_user_skins_dir() / f"{skin_id}.zip"
+
+    if source.suffix.lower() == ".zip":
+        validate_skin_zip(source)
+        destination.write_bytes(source.read_bytes())
+    elif source.suffix.lower() == ".gif":
+        with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.write(source, arcname=f"{skin_id}.gif")
+    else:
+        raise ValueError("Pet image must be a .gif animation or a .zip skin archive")
+
+    record_installed(
+        skin_id,
+        version="local",
+        source=str(source),
+        sha256=hashlib.sha256(destination.read_bytes()).hexdigest(),
+        size_bytes=destination.stat().st_size,
+    )
+    return skin_id
 
 
 def scan_all() -> list[str]:
@@ -140,6 +216,11 @@ __all__ = [
     "bundled_skins_dir",
     "user_skins_dir",
     "ensure_user_skins_dir",
+    "normalize_skin_id",
+    "unique_skin_id",
+    "gif_names_in_zip",
+    "validate_skin_zip",
+    "install_custom_pet",
     "scan_all",
     "find_skin_zip",
     "installed_metadata_path",

--- a/mycat/skin_catalog.py
+++ b/mycat/skin_catalog.py
@@ -58,9 +58,9 @@ def ensure_user_skins_dir() -> Path:
 
 
 def normalize_skin_id(value: str) -> str:
-    """Return a filesystem-safe skin id for user-imported pets."""
+    """Return a filesystem-safe skin id for user-imported cats."""
     normalized = SKIN_ID_PATTERN.sub("-", value.strip()).strip(".-_").lower()
-    return normalized or "pet"
+    return normalized or "cat"
 
 
 def unique_skin_id(base_id: str) -> str:
@@ -95,15 +95,15 @@ def validate_skin_zip(zip_path: Path) -> None:
         raise ValueError(f"Skin ZIP must contain exactly one GIF, found {len(gif_files)}")
 
 
-def install_custom_pet(source_path: str | Path, pet_name: str | None = None) -> str:
-    """Install a local GIF or skin ZIP as a user pet and return its skin id."""
+def install_custom_cat(source_path: str | Path, cat_name: str | None = None) -> str:
+    """Install a local GIF or skin ZIP as a user cat and return its skin id."""
     source = Path(source_path).expanduser()
     if not source.exists():
-        raise FileNotFoundError(f"Pet image not found: {source}")
+        raise FileNotFoundError(f"Cat image not found: {source}")
     if not source.is_file():
-        raise ValueError(f"Pet image must be a file: {source}")
+        raise ValueError(f"Cat image must be a file: {source}")
 
-    base_name = pet_name or source.stem
+    base_name = cat_name or source.stem
     skin_id = unique_skin_id(base_name)
     destination = ensure_user_skins_dir() / f"{skin_id}.zip"
 
@@ -114,7 +114,7 @@ def install_custom_pet(source_path: str | Path, pet_name: str | None = None) -> 
         with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
             zip_file.write(source, arcname=f"{skin_id}.gif")
     else:
-        raise ValueError("Pet image must be a .gif animation or a .zip skin archive")
+        raise ValueError("Cat image must be a .gif animation or a .zip skin archive")
 
     record_installed(
         skin_id,
@@ -220,7 +220,7 @@ __all__ = [
     "unique_skin_id",
     "gif_names_in_zip",
     "validate_skin_zip",
-    "install_custom_pet",
+    "install_custom_cat",
     "scan_all",
     "find_skin_zip",
     "installed_metadata_path",

--- a/tests/test_skin_catalog.py
+++ b/tests/test_skin_catalog.py
@@ -13,12 +13,12 @@ def write_gif(path: Path) -> None:
     image.save(path, format="GIF")
 
 
-def test_install_custom_pet_wraps_gif(monkeypatch, tmp_path):
+def test_install_custom_cat_wraps_gif(monkeypatch, tmp_path):
     monkeypatch.setenv("MYCAT_SKINS_DIR", str(tmp_path / "skins"))
     source = tmp_path / "Momo Cat!.gif"
     write_gif(source)
 
-    skin_id = skin_catalog.install_custom_pet(source, "Momo Cat!")
+    skin_id = skin_catalog.install_custom_cat(source, "Momo Cat!")
 
     assert skin_id == "momo-cat"
     installed = skin_catalog.user_skins_dir() / "momo-cat.zip"
@@ -31,39 +31,39 @@ def test_install_custom_pet_wraps_gif(monkeypatch, tmp_path):
     assert metadata["skins"][0]["sha256"]
 
 
-def test_install_custom_pet_copies_valid_zip(monkeypatch, tmp_path):
+def test_install_custom_cat_copies_valid_zip(monkeypatch, tmp_path):
     monkeypatch.setenv("MYCAT_SKINS_DIR", str(tmp_path / "skins"))
-    gif_path = tmp_path / "dog.gif"
-    zip_path = tmp_path / "dog.zip"
+    gif_path = tmp_path / "miso.gif"
+    zip_path = tmp_path / "miso.zip"
     write_gif(gif_path)
     with zipfile.ZipFile(zip_path, "w") as zip_file:
-        zip_file.write(gif_path, arcname="dog.gif")
+        zip_file.write(gif_path, arcname="miso.gif")
 
-    skin_id = skin_catalog.install_custom_pet(zip_path, "Max")
+    skin_id = skin_catalog.install_custom_cat(zip_path, "Miso")
 
-    assert skin_id == "max"
-    assert skin_catalog.find_skin_zip("max") == skin_catalog.user_skins_dir() / "max.zip"
+    assert skin_id == "miso"
+    assert skin_catalog.find_skin_zip("miso") == skin_catalog.user_skins_dir() / "miso.zip"
 
 
-def test_install_custom_pet_rejects_zip_without_single_gif(monkeypatch, tmp_path):
+def test_install_custom_cat_rejects_zip_without_single_gif(monkeypatch, tmp_path):
     monkeypatch.setenv("MYCAT_SKINS_DIR", str(tmp_path / "skins"))
     zip_path = tmp_path / "empty.zip"
     with zipfile.ZipFile(zip_path, "w") as zip_file:
         zip_file.writestr("readme.txt", "not a skin")
 
     with pytest.raises(ValueError, match="exactly one GIF"):
-        skin_catalog.install_custom_pet(zip_path, "empty")
+        skin_catalog.install_custom_cat(zip_path, "empty")
 
 
-def test_install_custom_pet_keeps_existing_user_skin(monkeypatch, tmp_path):
+def test_install_custom_cat_keeps_existing_user_skin(monkeypatch, tmp_path):
     monkeypatch.setenv("MYCAT_SKINS_DIR", str(tmp_path / "skins"))
     first = tmp_path / "first.gif"
     second = tmp_path / "second.gif"
     write_gif(first)
     write_gif(second)
 
-    first_id = skin_catalog.install_custom_pet(first, "Luna")
-    second_id = skin_catalog.install_custom_pet(second, "Luna")
+    first_id = skin_catalog.install_custom_cat(first, "Luna")
+    second_id = skin_catalog.install_custom_cat(second, "Luna")
 
     assert first_id == "luna"
     assert second_id == "luna-2"

--- a/tests/test_skin_catalog.py
+++ b/tests/test_skin_catalog.py
@@ -1,0 +1,69 @@
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from mycat import skin_catalog
+
+
+def write_gif(path: Path) -> None:
+    image = Image.new("RGBA", (2, 2), (255, 180, 120, 255))
+    image.save(path, format="GIF")
+
+
+def test_install_custom_pet_wraps_gif(monkeypatch, tmp_path):
+    monkeypatch.setenv("MYCAT_SKINS_DIR", str(tmp_path / "skins"))
+    source = tmp_path / "Momo Cat!.gif"
+    write_gif(source)
+
+    skin_id = skin_catalog.install_custom_pet(source, "Momo Cat!")
+
+    assert skin_id == "momo-cat"
+    installed = skin_catalog.user_skins_dir() / "momo-cat.zip"
+    assert installed.exists()
+    assert skin_catalog.gif_names_in_zip(installed) == ["momo-cat.gif"]
+
+    metadata = json.loads((skin_catalog.user_skins_dir() / "installed.json").read_text())
+    assert metadata["skins"][0]["id"] == "momo-cat"
+    assert metadata["skins"][0]["version"] == "local"
+    assert metadata["skins"][0]["sha256"]
+
+
+def test_install_custom_pet_copies_valid_zip(monkeypatch, tmp_path):
+    monkeypatch.setenv("MYCAT_SKINS_DIR", str(tmp_path / "skins"))
+    gif_path = tmp_path / "dog.gif"
+    zip_path = tmp_path / "dog.zip"
+    write_gif(gif_path)
+    with zipfile.ZipFile(zip_path, "w") as zip_file:
+        zip_file.write(gif_path, arcname="dog.gif")
+
+    skin_id = skin_catalog.install_custom_pet(zip_path, "Max")
+
+    assert skin_id == "max"
+    assert skin_catalog.find_skin_zip("max") == skin_catalog.user_skins_dir() / "max.zip"
+
+
+def test_install_custom_pet_rejects_zip_without_single_gif(monkeypatch, tmp_path):
+    monkeypatch.setenv("MYCAT_SKINS_DIR", str(tmp_path / "skins"))
+    zip_path = tmp_path / "empty.zip"
+    with zipfile.ZipFile(zip_path, "w") as zip_file:
+        zip_file.writestr("readme.txt", "not a skin")
+
+    with pytest.raises(ValueError, match="exactly one GIF"):
+        skin_catalog.install_custom_pet(zip_path, "empty")
+
+
+def test_install_custom_pet_keeps_existing_user_skin(monkeypatch, tmp_path):
+    monkeypatch.setenv("MYCAT_SKINS_DIR", str(tmp_path / "skins"))
+    first = tmp_path / "first.gif"
+    second = tmp_path / "second.gif"
+    write_gif(first)
+    write_gif(second)
+
+    first_id = skin_catalog.install_custom_pet(first, "Luna")
+    second_id = skin_catalog.install_custom_pet(second, "Luna")
+
+    assert first_id == "luna"
+    assert second_id == "luna-2"


### PR DESCRIPTION
## Summary
- add a safe custom cat installer for local GIF files and skin ZIP archives
- add `--cat-image` / `--cat-name` so users can launch their own cat from the CLI
- add a right-click "Import cat..." flow that installs the cat and switches to it immediately
- document the workflow and cover the installer with focused tests

## Tests
- `ruff check .`
- `QT_QPA_PLATFORM=offscreen python -m pytest -q`
- `HOME=$(mktemp -d)/home MYCAT_SKINS_DIR=$(mktemp -d)/skins QT_QPA_PLATFORM=offscreen python -m mycat.main --cat-image /tmp/mycat-cat-smoke.gif --cat-name luna --wait 0.01`

Tiny maintainer note:
```text
 /\_/\
( o.o )  custom cats
 > ^ <
```