### PR TITLE
Add live-cat demo prototype (roadmap vertical B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ## Unreleased
 
 ### Added
+- **Live-cat demo (dev prototype).** `demo/live_cat_demo.py` — a standalone prototype of roadmap vertical B ("the cat feels alive"): the existing sprite is animated purely with code (breathing, blink, play hops, sleep, stress jitter) and system load is shown as the cat's *mood* rather than a number. Not wired into the shipped app; run with `python demo/live_cat_demo.py` (branch `demo/live-cat-prototype`).
 - **Multiple chat vendors.** The LLM settings dialog (right-click → LLM…) now lets you pick a vendor — Ollama (default, local), OpenAI, Grok (xAI), Groq, DeepSeek, OpenRouter — or define a **custom** OpenAI-compatible endpoint (name + base URL + key + model). One adapter covers every OpenAI-compatible provider. API keys are hybrid: typed into the dialog (saved to config) or read from the vendor's environment variable.
 
 ### Changed

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,35 +1,44 @@
 # Live-cat demo (local prototype)
 
-A throwaway prototype of roadmap vertical **B — "the cat feels alive"**. It is
-**not** wired into the app and is meant to be run directly so we can *see* the
-idea before committing to a design.
+Prototype of roadmap vertical **B — "the cat feels alive"**, phase 1. It makes
+the cat lively by **animating the existing sprite with code** — no new art, and
+**no numbers on screen**: system load is shown as the cat's *mood*, not a percent.
+
+Run it directly (not wired into the app, not pushed):
 
 ```bash
 python demo/live_cat_demo.py
+python demo/live_cat_demo.py --mood stress   # force one mood, for screenshots
 ```
 
-It reuses the real mycat window and layers liveliness on top:
+## Moods (all procedural transforms of one sprite)
 
-- **Ambient motion** — the cat moves on its own at a varied cadence instead of
-  sitting still after the first play.
-- **CPU-reactive energy** — a busier machine makes a busier cat; the cadence
-  scales with whole-system CPU read natively from `/proc/stat` (no deps).
-- **Reacts to you** — click or grab the cat and it perks up immediately.
-- **Naps** — after ~30 s with no interaction (and low CPU) it settles into a
-  slow, rare cadence; activity or load wakes it back up.
+| Mood | Look | Trigger |
+|---|---|---|
+| `sleep` | slow breathing, dimmed, rising `z z Z` | idle a while + calm box |
+| `yawn` | a vertical stretch | wake/sleep transition |
+| `idle` | gentle breathing | default |
+| `play` | bouncy hops + squash | **click the cat** |
+| `aggro` | short random shake | random (personality) |
+| `stress` | constant jitter, puffed-up, red tint | the box is busy (high CPU) |
 
-A small pill above the cat narrates the current mood and CPU, and the same
-transitions are logged to the console (`[live-cat] mood -> …`).
+Load is read internally from `/proc/stat` (smoothed) and mapped onto a calm↔busy
+axis — it is **never shown as a number**. Mood changes are logged to the console.
 
-### Try it
-- Leave it alone for ~30 s → it goes `napping`.
-- Run a CPU load (e.g. `yes > /dev/null` on a couple of cores) → it turns
-  `lively` and moves more often.
-- Click/grab the cat → instant `excited` reaction.
+## How it renders
+Each frame is drawn onto a fixed-size padded canvas with a **foot-anchored**
+transform (squash/stretch grows from the feet) and fed to the real
+`PixelCatWindow` via `current_pixmap`, so transparency, dragging and the
+no-compositor shape-mask all keep working. The padding gives headroom so
+stretch/jitter never gets clipped.
 
-### Notes / not done
-- No new art: liveliness is expressed by *how often* the existing GIF plays, not
-  by new poses. Mood-specific sprites (sleep, eating-while-charging) are future
-  work.
-- Battery/charging ("the cat eats while charging") isn't shown — this dev box has
-  no battery. That part of vertical B needs an eating sprite anyway.
+## Honest limits (→ phase 2, ComfyUI pipeline)
+Transforms can only move the *one* pose. Genuinely different poses need real
+sprites and are deferred to the generation pipeline:
+- a curled-up **sleep** pose (here: same pose, dimmed + Zzz),
+- real **fur-on-end** for stress (here: puff-scale + red tint),
+- **presenting its back to be petted** (not faked at all yet),
+- ear-flattening for `aggro`.
+
+Battery / "eats while charging" isn't shown — this dev box has no battery and it
+needs an eating sprite anyway.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,35 @@
+# Live-cat demo (local prototype)
+
+A throwaway prototype of roadmap vertical **B — "the cat feels alive"**. It is
+**not** wired into the app and is meant to be run directly so we can *see* the
+idea before committing to a design.
+
+```bash
+python demo/live_cat_demo.py
+```
+
+It reuses the real mycat window and layers liveliness on top:
+
+- **Ambient motion** — the cat moves on its own at a varied cadence instead of
+  sitting still after the first play.
+- **CPU-reactive energy** — a busier machine makes a busier cat; the cadence
+  scales with whole-system CPU read natively from `/proc/stat` (no deps).
+- **Reacts to you** — click or grab the cat and it perks up immediately.
+- **Naps** — after ~30 s with no interaction (and low CPU) it settles into a
+  slow, rare cadence; activity or load wakes it back up.
+
+A small pill above the cat narrates the current mood and CPU, and the same
+transitions are logged to the console (`[live-cat] mood -> …`).
+
+### Try it
+- Leave it alone for ~30 s → it goes `napping`.
+- Run a CPU load (e.g. `yes > /dev/null` on a couple of cores) → it turns
+  `lively` and moves more often.
+- Click/grab the cat → instant `excited` reaction.
+
+### Notes / not done
+- No new art: liveliness is expressed by *how often* the existing GIF plays, not
+  by new poses. Mood-specific sprites (sleep, eating-while-charging) are future
+  work.
+- Battery/charging ("the cat eats while charging") isn't shown — this dev box has
+  no battery. That part of vertical B needs an eating sprite anyway.

--- a/demo/live_cat_demo.py
+++ b/demo/live_cat_demo.py
@@ -1,169 +1,251 @@
 #!/usr/bin/env python3
-"""LOCAL demo — the cat made to feel ALIVE (roadmap vertical B, prototype).
+"""LOCAL demo — procedural moods (roadmap vertical B, phase 1).
 
-It reuses the real mycat window and layers ambient liveliness on top, without
-touching the app:
+Makes the cat feel ALIVE by *animating the existing sprite with code* — no new
+art and no numbers on screen. System load is expressed as the cat's mood, not as
+a percentage.
 
-- idle ambient motion: the cat moves on its own at a varied cadence,
-- CPU-reactive energy: a busy machine makes a busier cat (native /proc/stat),
-- reacts to being clicked/grabbed — it perks up immediately,
-- naps after a stretch with no interaction, wakes on activity or load.
+Moods (all procedural transforms of the one sprite):
+  sleep   slow breathing, dimmed, rising "z z Z"
+  yawn    a stretch, used as the wake/sleep transition
+  idle    gentle breathing
+  play    bouncy hops + squash — triggered by clicking the cat
+  aggro   a short random shake (personality)
+  stress  constant jitter + puffed-up scale + red tint — when the box is busy
 
-A small pill above the cat narrates its current mood + CPU. This is a throwaway
-prototype to *see* the idea; it is not wired into the app and not pushed.
-
-Run it directly:
+Throwaway prototype, run it directly (not wired into the app, not pushed):
     python demo/live_cat_demo.py
+    python demo/live_cat_demo.py --mood stress   # force one mood (for testing)
+
+Phase-2 (separate): real per-mood sprites (sleep curl, fur-on-end, presenting
+its back to be petted) generated via the ComfyUI pipeline — those need actual
+new poses that transforms can't fake.
 """
 
+import argparse
+import math
 import random
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from PySide6 import QtCore, QtWidgets  # noqa: E402
+from PySide6 import QtCore, QtGui, QtWidgets  # noqa: E402
 
 import mycat.main as cat  # noqa: E402
 
-MOOD_FACE = {"excited": "🙀", "lively": "😺", "calm": "🐱", "napping": "😴"}
+PAD = 0.45            # transparent margin (fraction of sprite) for transform headroom
+NAP_AFTER = 18.0      # seconds idle + calm before dozing off
+PLAY_SECS = 1.6
+AGGRO_SECS = 0.8
+YAWN_SECS = 1.1
+RED_TINT = QtGui.QColor(210, 40, 30, 70)
 
 
 def read_cpu_idle_total():
-    """Return (idle, total) jiffies from /proc/stat, or None off Linux."""
+    """(idle, total) jiffies from /proc/stat, or None off Linux. Internal signal."""
     try:
         with open("/proc/stat") as handle:
             fields = handle.readline().split()[1:]
     except OSError:
         return None
     nums = [float(value) for value in fields]
-    idle = nums[3] + (nums[4] if len(nums) > 4 else 0.0)  # idle + iowait
+    idle = nums[3] + (nums[4] if len(nums) > 4 else 0.0)
     return idle, sum(nums)
 
 
-class MoodHud(QtWidgets.QLabel):
-    """A small solid pill that floats above the cat and shows its mood.
+def render_frame(base, size, *, dx=0.0, dy=0.0, sx=1.0, sy=1.0, dim=0.0, tint=None, zzz=None):
+    """Draw the sprite onto a fixed-size canvas with a foot-anchored transform.
 
-    Solid background on purpose: a translucent pill would render as a black box
-    on X11 without a compositor, so the demo stays crisp everywhere.
+    Every frame is the same canvas size, so the window never re-centres and the
+    no-compositor shape-mask (rebuilt from the pixmap each paint) stays aligned.
     """
+    width, height = size
+    out = QtGui.QPixmap(width, height)
+    out.fill(QtCore.Qt.GlobalColor.transparent)
+    painter = QtGui.QPainter(out)
+    painter.setRenderHint(QtGui.QPainter.RenderHint.SmoothPixmapTransform, False)
 
-    def __init__(self):
-        super().__init__(
-            None,
-            QtCore.Qt.WindowType.FramelessWindowHint
-            | QtCore.Qt.WindowType.Tool
-            | QtCore.Qt.WindowType.WindowStaysOnTopHint,
+    # Anchor at the sprite's bottom-centre so squash/stretch grows from the feet.
+    painter.translate(width / 2 + dx, (height + base.height()) / 2 + dy)
+    painter.scale(sx, sy)
+    painter.drawPixmap(int(-base.width() / 2), int(-base.height()), base)
+    painter.resetTransform()
+
+    if dim > 0:
+        painter.setCompositionMode(QtGui.QPainter.CompositionMode.CompositionMode_SourceAtop)
+        painter.fillRect(out.rect(), QtGui.QColor(0, 0, 0, int(dim * 255)))
+    if tint is not None:
+        painter.setCompositionMode(QtGui.QPainter.CompositionMode.CompositionMode_SourceAtop)
+        painter.fillRect(out.rect(), tint)
+
+    painter.setCompositionMode(QtGui.QPainter.CompositionMode.CompositionMode_SourceOver)
+    if zzz is not None:
+        draw_zzz(painter, width, height, base, zzz)
+    painter.end()
+    return out
+
+
+def draw_zzz(painter, width, height, base, phase):
+    """Three rising, fading 'z' glyphs above the head."""
+    top = (height - base.height()) / 2
+    head_x = width / 2 + base.width() * 0.18
+    painter.setPen(QtGui.QColor(120, 150, 220))
+    for index in range(3):
+        local = (phase + index / 3.0) % 1.0
+        font = QtGui.QFont()
+        font.setBold(True)
+        font.setPixelSize(int(9 + index * 4))
+        painter.setFont(font)
+        color = QtGui.QColor(120, 150, 220, int(255 * (1.0 - local)))
+        painter.setPen(color)
+        painter.drawText(
+            int(head_x + index * 7 + local * 6),
+            int(top - 2 - local * 22),
+            "z" if index < 2 else "Z",
         )
-        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
-        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
-        self.setStyleSheet(
-            "QLabel { background: #2b2b2b; color: #ffd34d;"
-            " padding: 4px 10px; font-size: 12px; font-weight: bold; }"
-        )
-        self.setText("…")
-
-    def show_above(self, target: QtWidgets.QWidget) -> None:
-        self.adjustSize()
-        geo = target.geometry()
-        self.move(int(geo.center().x() - self.width() / 2), max(0, geo.y() - self.height() - 6))
-        self.show()
-        self.raise_()
 
 
-class LiveCat(QtCore.QObject):
-    """Drives the cat's liveliness on a single 1 Hz tick."""
+class MoodCat(QtCore.QObject):
+    """Procedural mood machine driving window.current_pixmap."""
 
-    NAP_AFTER = 30.0  # seconds with no interaction (and low CPU) -> nap
-
-    def __init__(self, window: QtWidgets.QWidget, hud: MoodHud):
+    def __init__(self, window, base, canvas_size, forced=None):
         super().__init__(window)
         self.window = window
-        self.hud = hud
+        self.base = base
+        self.size = canvas_size
+        self.forced = forced
+
         self.clock = QtCore.QElapsedTimer()
         self.clock.start()
         self.prev_cpu = read_cpu_idle_total()
-        self.cpu = 0.0
-        self.mood = ""
+        self.busy = 0.0
+        self.mood = "idle"
+        self.mood_since = 0.0
         self.last_interaction = self.now()
-        self.next_replay_at = self.now() + 4.0
 
         window.installEventFilter(self)
-        self.tick_timer = QtCore.QTimer(self)
-        self.tick_timer.timeout.connect(self.tick)
-        self.tick_timer.start(1000)
 
-    def now(self) -> float:
+        self.brain = QtCore.QTimer(self)
+        self.brain.timeout.connect(self.think)
+        self.brain.start(1000)
+
+        self.render_timer = QtCore.QTimer(self)
+        self.render_timer.timeout.connect(self.render)
+        self.render_timer.start(40)  # ~25 fps
+
+    def now(self):
         return self.clock.elapsed() / 1000.0
 
-    def sample_cpu(self) -> None:
-        current = read_cpu_idle_total()
-        if current and self.prev_cpu:
-            delta_idle = current[0] - self.prev_cpu[0]
-            delta_total = current[1] - self.prev_cpu[1]
-            if delta_total > 0:
-                self.cpu = max(0.0, min(100.0, (1.0 - delta_idle / delta_total) * 100.0))
-        self.prev_cpu = current
-
-    def replay(self) -> None:
-        """Make the cat do its thing once. No-op while a play is in progress."""
-        if getattr(self.window, "state", "png") == "png":
-            self.window._start_animation()
-
-    def interval_for(self, napping: bool) -> float:
-        if napping:
-            return random.uniform(35.0, 50.0)
-        # 0% CPU -> ~22s between spontaneous moves; 100% CPU -> ~2.5s.
-        base = 22.0 - (self.cpu / 100.0) * 19.5
-        return random.uniform(base * 0.7, base * 1.3)
-
-    def set_mood(self, mood: str) -> None:
+    def set_mood(self, mood):
         if mood != self.mood:
             self.mood = mood
-            print(f"[live-cat] mood -> {mood} (CPU {self.cpu:.0f}%)", flush=True)
+            self.mood_since = self.now()
+            print(f"[live-cat] {mood}", flush=True)
 
-    def eventFilter(self, obj, event) -> bool:
+    def sample_busy(self):
+        current = read_cpu_idle_total()
+        cpu = self.busy
+        if current and self.prev_cpu:
+            d_idle = current[0] - self.prev_cpu[0]
+            d_total = current[1] - self.prev_cpu[1]
+            if d_total > 0:
+                cpu = max(0.0, min(100.0, (1.0 - d_idle / d_total) * 100.0))
+        self.prev_cpu = current
+        # Smooth so a one-second spike doesn't whiplash the cat.
+        self.busy = self.busy * 0.6 + cpu * 0.4
+
+    def eventFilter(self, obj, event):
         if obj is self.window and event.type() == QtCore.QEvent.Type.MouseButtonPress:
             self.last_interaction = self.now()
-            self.set_mood("excited")
-            self.replay()
-            self.next_replay_at = self.now() + 1.5
+            self.set_mood("play")
         return False
 
-    def tick(self) -> None:
-        self.sample_cpu()
+    def think(self):
+        if self.forced:
+            return
+        self.sample_busy()
+        age = self.now() - self.mood_since
         idle_for = self.now() - self.last_interaction
-        napping = idle_for > self.NAP_AFTER and self.cpu < 15.0
 
-        if idle_for < 2.0:
-            self.set_mood("excited")
-        elif napping:
-            self.set_mood("napping")
+        # One-shots run to completion.
+        if self.mood == "play" and age < PLAY_SECS:
+            return
+        if self.mood == "aggro" and age < AGGRO_SECS:
+            return
+        if self.mood == "yawn" and age < YAWN_SECS:
+            return
+
+        if self.busy >= 30.0:
+            self.set_mood("stress")
+        elif self.mood == "yawn":
+            self.set_mood("sleep")
+        elif idle_for > NAP_AFTER and self.busy < 12.0:
+            self.set_mood("sleep" if self.mood == "sleep" else "yawn")
+        elif random.random() < 0.04:
+            self.set_mood("aggro")
         else:
-            # ~25% whole-system CPU ≈ one busy core on a typical desktop.
-            self.set_mood("lively" if self.cpu >= 25.0 else "calm")
+            self.set_mood("idle")
 
-        if self.now() >= self.next_replay_at:
-            self.replay()
-            self.next_replay_at = self.now() + self.interval_for(napping)
+    def params(self):
+        time = self.now()
+        age = time - self.mood_since
+        mood = self.mood
+        if mood == "sleep":
+            breathe = math.sin(time * 1.4)
+            return {"sy": 1.0 + 0.05 * breathe, "sx": 1.0 - 0.02 * breathe,
+                    "dim": 0.28, "zzz": (time * 0.35) % 1.0}
+        if mood == "yawn":
+            ease = math.sin(min(1.0, age / YAWN_SECS) * math.pi)
+            return {"sy": 1.0 + 0.20 * ease, "sx": 1.0 - 0.08 * ease, "dy": -4 * ease}
+        if mood == "play":
+            hop = abs(math.sin(time * 9.0))
+            return {"dy": -22 * hop, "sy": 1.0 + 0.10 * hop, "sx": 1.0 - 0.06 * hop}
+        if mood == "aggro":
+            return {"dx": random.uniform(-6, 6), "sy": 1.06, "dy": -2}
+        if mood == "stress":
+            jitter = random.uniform(-3, 3)
+            puff = 0.08 + 0.02 * math.sin(time * 20)
+            return {"dx": jitter, "dy": random.uniform(-2, 2),
+                    "sx": 1.0 + puff, "sy": 1.0 + puff, "tint": RED_TINT}
+        breathe = math.sin(time * 2.1)  # idle
+        return {"sy": 1.0 + 0.025 * breathe, "sx": 1.0 - 0.012 * breathe}
 
-        self.hud.setText(f"{MOOD_FACE[self.mood]} {self.mood}  ·  CPU {self.cpu:.0f}%")
-        self.hud.show_above(self.window)
+    def render(self):
+        frame = render_frame(self.base, self.size, **self.params())
+        self.window.current_pixmap = frame
+        self.window.update()
 
 
-def main() -> None:
-    app = QtWidgets.QApplication(sys.argv)
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mood", choices=["sleep", "yawn", "idle", "play", "aggro", "stress"])
+    args = parser.parse_args()
+
+    app = QtWidgets.QApplication([])
     available = cat.scan_images_directory()
-    png, movie, name, data = cat.load_packaged_images(None, cat.load_image_from_ini() or "cat")
-    window = cat.PixelCatWindow(png, movie, 1.0, name, available, data)
+    base, movie, name, data = cat.load_packaged_images(None, cat.load_image_from_ini() or "cat")
+
+    # Padded canvas so squash/stretch/jitter have headroom and never get clipped.
+    pad_w = int(base.width() * PAD)
+    pad_h = int(base.height() * PAD)
+    canvas_size = (base.width() + 2 * pad_w, base.height() + 2 * pad_h)
+    canvas = QtGui.QPixmap(*canvas_size)
+    canvas.fill(QtCore.Qt.GlobalColor.transparent)
+    holder = QtGui.QPainter(canvas)
+    holder.drawPixmap(pad_w, pad_h, base)
+    holder.end()
+
+    window = cat.PixelCatWindow(canvas, movie, 9999.0, name, available, data)
+    # We drive the pixmap ourselves — neutralise the window's own GIF auto-play.
+    window._start_animation = lambda: None
     window.show()
-    hud = MoodHud()
-    LiveCat(window, hud)
-    print(
-        "[live-cat] running — click/grab the cat to excite it; run a CPU load "
-        "to see it perk up; leave it alone to watch it nap. Ctrl+C to quit.",
-        flush=True,
-    )
+
+    MoodCat(window, base, canvas_size, forced=args.mood)
+    if args.mood:
+        print(f"[live-cat] forced mood: {args.mood}", flush=True)
+    print("[live-cat] running — click the cat to play; leave it to doze; load the "
+          "CPU to stress it. Right-click → Quit.", flush=True)
     sys.exit(app.exec())
 
 

--- a/demo/live_cat_demo.py
+++ b/demo/live_cat_demo.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""LOCAL demo — the cat made to feel ALIVE (roadmap vertical B, prototype).
+
+It reuses the real mycat window and layers ambient liveliness on top, without
+touching the app:
+
+- idle ambient motion: the cat moves on its own at a varied cadence,
+- CPU-reactive energy: a busy machine makes a busier cat (native /proc/stat),
+- reacts to being clicked/grabbed — it perks up immediately,
+- naps after a stretch with no interaction, wakes on activity or load.
+
+A small pill above the cat narrates its current mood + CPU. This is a throwaway
+prototype to *see* the idea; it is not wired into the app and not pushed.
+
+Run it directly:
+    python demo/live_cat_demo.py
+"""
+
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PySide6 import QtCore, QtWidgets  # noqa: E402
+
+import mycat.main as cat  # noqa: E402
+
+MOOD_FACE = {"excited": "🙀", "lively": "😺", "calm": "🐱", "napping": "😴"}
+
+
+def read_cpu_idle_total():
+    """Return (idle, total) jiffies from /proc/stat, or None off Linux."""
+    try:
+        with open("/proc/stat") as handle:
+            fields = handle.readline().split()[1:]
+    except OSError:
+        return None
+    nums = [float(value) for value in fields]
+    idle = nums[3] + (nums[4] if len(nums) > 4 else 0.0)  # idle + iowait
+    return idle, sum(nums)
+
+
+class MoodHud(QtWidgets.QLabel):
+    """A small solid pill that floats above the cat and shows its mood.
+
+    Solid background on purpose: a translucent pill would render as a black box
+    on X11 without a compositor, so the demo stays crisp everywhere.
+    """
+
+    def __init__(self):
+        super().__init__(
+            None,
+            QtCore.Qt.WindowType.FramelessWindowHint
+            | QtCore.Qt.WindowType.Tool
+            | QtCore.Qt.WindowType.WindowStaysOnTopHint,
+        )
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
+        self.setStyleSheet(
+            "QLabel { background: #2b2b2b; color: #ffd34d;"
+            " padding: 4px 10px; font-size: 12px; font-weight: bold; }"
+        )
+        self.setText("…")
+
+    def show_above(self, target: QtWidgets.QWidget) -> None:
+        self.adjustSize()
+        geo = target.geometry()
+        self.move(int(geo.center().x() - self.width() / 2), max(0, geo.y() - self.height() - 6))
+        self.show()
+        self.raise_()
+
+
+class LiveCat(QtCore.QObject):
+    """Drives the cat's liveliness on a single 1 Hz tick."""
+
+    NAP_AFTER = 30.0  # seconds with no interaction (and low CPU) -> nap
+
+    def __init__(self, window: QtWidgets.QWidget, hud: MoodHud):
+        super().__init__(window)
+        self.window = window
+        self.hud = hud
+        self.clock = QtCore.QElapsedTimer()
+        self.clock.start()
+        self.prev_cpu = read_cpu_idle_total()
+        self.cpu = 0.0
+        self.mood = ""
+        self.last_interaction = self.now()
+        self.next_replay_at = self.now() + 4.0
+
+        window.installEventFilter(self)
+        self.tick_timer = QtCore.QTimer(self)
+        self.tick_timer.timeout.connect(self.tick)
+        self.tick_timer.start(1000)
+
+    def now(self) -> float:
+        return self.clock.elapsed() / 1000.0
+
+    def sample_cpu(self) -> None:
+        current = read_cpu_idle_total()
+        if current and self.prev_cpu:
+            delta_idle = current[0] - self.prev_cpu[0]
+            delta_total = current[1] - self.prev_cpu[1]
+            if delta_total > 0:
+                self.cpu = max(0.0, min(100.0, (1.0 - delta_idle / delta_total) * 100.0))
+        self.prev_cpu = current
+
+    def replay(self) -> None:
+        """Make the cat do its thing once. No-op while a play is in progress."""
+        if getattr(self.window, "state", "png") == "png":
+            self.window._start_animation()
+
+    def interval_for(self, napping: bool) -> float:
+        if napping:
+            return random.uniform(35.0, 50.0)
+        # 0% CPU -> ~22s between spontaneous moves; 100% CPU -> ~2.5s.
+        base = 22.0 - (self.cpu / 100.0) * 19.5
+        return random.uniform(base * 0.7, base * 1.3)
+
+    def set_mood(self, mood: str) -> None:
+        if mood != self.mood:
+            self.mood = mood
+            print(f"[live-cat] mood -> {mood} (CPU {self.cpu:.0f}%)", flush=True)
+
+    def eventFilter(self, obj, event) -> bool:
+        if obj is self.window and event.type() == QtCore.QEvent.Type.MouseButtonPress:
+            self.last_interaction = self.now()
+            self.set_mood("excited")
+            self.replay()
+            self.next_replay_at = self.now() + 1.5
+        return False
+
+    def tick(self) -> None:
+        self.sample_cpu()
+        idle_for = self.now() - self.last_interaction
+        napping = idle_for > self.NAP_AFTER and self.cpu < 15.0
+
+        if idle_for < 2.0:
+            self.set_mood("excited")
+        elif napping:
+            self.set_mood("napping")
+        else:
+            # ~25% whole-system CPU ≈ one busy core on a typical desktop.
+            self.set_mood("lively" if self.cpu >= 25.0 else "calm")
+
+        if self.now() >= self.next_replay_at:
+            self.replay()
+            self.next_replay_at = self.now() + self.interval_for(napping)
+
+        self.hud.setText(f"{MOOD_FACE[self.mood]} {self.mood}  ·  CPU {self.cpu:.0f}%")
+        self.hud.show_above(self.window)
+
+
+def main() -> None:
+    app = QtWidgets.QApplication(sys.argv)
+    available = cat.scan_images_directory()
+    png, movie, name, data = cat.load_packaged_images(None, cat.load_image_from_ini() or "cat")
+    window = cat.PixelCatWindow(png, movie, 1.0, name, available, data)
+    window.show()
+    hud = MoodHud()
+    LiveCat(window, hud)
+    print(
+        "[live-cat] running — click/grab the cat to excite it; run a CPU load "
+        "to see it perk up; leave it alone to watch it nap. Ctrl+C to quit.",
+        flush=True,
+    )
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a standalone **live-cat demo** — a local prototype of roadmap vertical **B ("the cat feels alive")**, phase 1. It makes the cat lively by **animating the existing sprite with code** (no new art) and shows system load as the cat's **mood**, never as a number on screen.

Everything lives under `demo/` and is **not wired into the shipped app** — it imports `PixelCatWindow` and drives it via `current_pixmap`, so transparency, dragging and the no-compositor shape-mask keep working.

### What it does
- **Procedural moods** — all transforms of the one sprite: `sleep` (slow breathing, dimmed, `z z Z`), `yawn`, `idle` (gentle breathing), `play` (bouncy hops + squash on click), `aggro` (random shake), `stress` (jitter, puffed-up, red tint).
- **Load → mood, not a percent** — load is read from `/proc/stat` (smoothed), mapped onto a calm↔busy axis, and surfaced only as mood. Mood changes are logged to the console.
- **Foot-anchored transforms** on a padded canvas so squash/stretch/jitter never clips.

### Honest limits (→ phase 2, generation pipeline)
Transforms can only move the *one* pose. Genuinely different poses (curled-up sleep, real fur-on-end, presenting its back, ear-flattening) need real sprites and are deferred. See `demo/README.md`.

## Test plan
- [x] `ruff check demo/live_cat_demo.py` — clean
- [x] `python demo/live_cat_demo.py` — runs; moods cycle and click triggers `play`
- [x] `python demo/live_cat_demo.py --mood stress` — forces a single mood (for screenshots)
- [ ] Reviewer: confirm it runs on a non-Linux box (the `/proc/stat` reader is Linux-only; mood falls back gracefully elsewhere)

## Notes
- Branched cleanly from `main` — deliberately excludes the persistence-hardening commit that the original local branch was stacked on (that ships separately in #49).