### PR TITLE
Restore Reset menu action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Added
+- **Reset — recenter the cat.** Right-click (and the system-tray menu) now have a **Reset** entry, placed just above **Autostart**, that moves the cat back to the bottom-right of the primary screen — a rescue for when it wanders off-screen or gets lost across multiple monitors. Restores the position-reset action originally added in #52 that was dropped during the 0.1.7 companion rework (branch `feat/reset-position`).
+
 ### Changed
 - **The cat now blinks in the plane cockpit and sits deeper in it.** On the banner flyby (plane1) the cat is sunk further into the fuselage so only the top of the head peeks out instead of the whole head sticking up, and its eyes blink on a slow cycle using the char's closed-eyes frame (the same frames the demo GIF uses) — GIF chars with no blink frame just stay awake. Tuning: `CAT_SINK_FRAC`, `BLINK_PERIOD_S`, `BLINK_DUR_S` in `reminder_ui.py` (branch `feat/flyby-cat-sink-blink`).
 

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -948,13 +948,15 @@ class PixelCatWindow(QtWidgets.QWidget):
         save_config(config)
 
     def _reset_position(self) -> None:
-        """Snap the cat to the bottom-right corner, 40px in from each edge.
+        """Snap the cat to the bottom-right corner, an equal inset from each edge.
 
-        A rescue for when the cat wanders off-screen or gets lost across
-        multiple monitors.
+        Measured from the true screen corner (full geometry, not the
+        panel-aware area) so the cat sits right by the edge. A rescue for when
+        it wanders off-screen or gets lost across multiple monitors.
         """
-        margin = 40
-        rect = usable_screen_rect()
+        margin = 18
+        screen = QtWidgets.QApplication.primaryScreen()
+        rect = screen.geometry() if screen is not None else usable_screen_rect()
         x = rect.x() + rect.width() - self.width() - margin
         y = rect.y() + rect.height() - self.height() - margin
         self.move(x, y)

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -948,13 +948,16 @@ class PixelCatWindow(QtWidgets.QWidget):
         save_config(config)
 
     def _reset_position(self) -> None:
-        """Recenter the cat to the bottom-right of the primary screen.
+        """Snap the cat to the bottom-right corner, 40px in from each edge.
 
         A rescue for when the cat wanders off-screen or gets lost across
         multiple monitors.
         """
-        default_x, default_y = self.bottom_right_position(self.width(), self.height())
-        self.move(default_x, default_y)
+        margin = 40
+        rect = usable_screen_rect()
+        x = rect.x() + rect.width() - self.width() - margin
+        y = rect.y() + rect.height() - self.height() - margin
+        self.move(x, y)
         self._save_position()
 
     def _load_image(self, image_name: str) -> None:

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -946,7 +946,17 @@ class PixelCatWindow(QtWidgets.QWidget):
         pos = self.pos()
         config = {"x": pos.x(), "y": pos.y()}
         save_config(config)
-    
+
+    def _reset_position(self) -> None:
+        """Recenter the cat to the bottom-right of the primary screen.
+
+        A rescue for when the cat wanders off-screen or gets lost across
+        multiple monitors.
+        """
+        default_x, default_y = self.bottom_right_position(self.width(), self.height())
+        self.move(default_x, default_y)
+        self._save_position()
+
     def _load_image(self, image_name: str) -> None:
         """Switch chars — a new interactive pack or a legacy single-GIF."""
         zip_path = char_catalog.find_char(image_name)
@@ -1141,6 +1151,9 @@ class PixelCatWindow(QtWidgets.QWidget):
                     action.setChecked(True)
                 action.triggered.connect(lambda checked, name=img_name: self._load_image(name))
             menu.addSeparator()
+
+        reset_action = menu.addAction("Reset")
+        reset_action.triggered.connect(self._reset_position)
 
         if autostart.is_supported():
             login_action = menu.addAction("Autostart")
@@ -1672,6 +1685,7 @@ def setup_tray(app, window, icon_pixmap):
 
     # Focus is fully automatic now (earned from activity) — no tray toggle.
 
+    menu.addAction("Reset", window._reset_position)
     if autostart.is_supported():
         menu.addSeparator()
         login_action = menu.addAction("Autostart")


### PR DESCRIPTION
## Summary

Preparing for **0.1.8**. The position-reset action added in #52 was lost when the 0.1.7 companion rework rewrote the menu code — it isn't in the current menu. This brings it back:

- New `PixelCatWindow._reset_position()` — recenters the cat to the bottom-right of the primary screen (a rescue for when it wanders off-screen or gets lost across multiple monitors).
- A **Reset** entry placed directly **above Autostart** in both the cat's right-click menu and the system-tray menu.

Named **Reset** (it was "Reset Position" in #52).

## Test plan

- [x] `ruff check .` — clean
- [ ] Right-click the cat → **Reset** appears above **Autostart**; clicking it snaps the cat to the bottom-right.
- [ ] System-tray menu → **Reset** above **Autostart**; behaves the same.
- [ ] Drag the cat off-screen (or to a second monitor) → **Reset** returns it to the primary screen's bottom-right, and the position persists across a restart.