### PR TITLE
Fix frozen exe crash (ModuleNotFoundError: mycat.llm) + missing chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Fixed
+- **The prebuilt Windows/macOS executables now actually launch.** The frozen build crashed at startup with `ModuleNotFoundError: No module named 'mycat.llm'`: the exe entry runs as `__main__`, so `main.py` pulls its submodules in dynamically (`importlib.import_module("mycat.llm")`), which PyInstaller's static analysis never bundled. The spec now bundles the whole `mycat` package via `collect_submodules('mycat')` (with the source tree added to `sys.path` so it works whether or not the package is pip-installed). It also fixes bundled chars: the folder was renamed `images/` → `chars/`, but the spec still shipped `mycat/images/`, so the exe launched with no cats — it now bundles `mycat/chars/` (both names supported for older tags). Verified with a real PyInstaller build (branch `fix/frozen-exe-imports`).
+
 ### Changed
 - **The cat now blinks in the plane cockpit and sits deeper in it.** On the banner flyby (plane1) the cat is sunk further into the fuselage so only the top of the head peeks out instead of the whole head sticking up, and its eyes blink on a slow cycle using the char's closed-eyes frame (the same frames the demo GIF uses) — GIF chars with no blink frame just stay awake. Tuning: `CAT_SINK_FRAC`, `BLINK_PERIOD_S`, `BLINK_DUR_S` in `reminder_ui.py` (branch `feat/flyby-cat-sink-blink`).
 

--- a/mycat.spec
+++ b/mycat.spec
@@ -14,14 +14,24 @@
 import sys
 from pathlib import Path
 
+from PyInstaller.utils.hooks import collect_submodules
+
+# Make the in-tree `mycat` package importable while the spec is evaluated, so
+# collect_submodules() below can enumerate it even when the package is not
+# pip-installed in the build environment.
+sys.path.insert(0, str(Path.cwd()))
+
 datas = []
 
-# Bundled cat skins (cat.zip, cat1.zip, girl1.zip, ...).
-images_dir = Path("mycat") / "images"
-if images_dir.is_dir():
-    for p in sorted(images_dir.iterdir()):
-        if p.is_file():
-            datas.append((str(p), "mycat/images"))
+# Bundled cat chars (cat.zip, classic.zip, ...). The folder was renamed
+# images/ -> chars/; support both so older tags keep building and the runtime
+# char_catalog (which now looks in mycat/chars) finds them.
+for skin_dirname in ("chars", "images"):
+    skin_dir = Path("mycat") / skin_dirname
+    if skin_dir.is_dir():
+        for p in sorted(skin_dir.iterdir()):
+            if p.is_file():
+                datas.append((str(p), f"mycat/{skin_dirname}"))
 
 # LLM prompt template — handle both the current spelling (PROMPT.j2) and the
 # legacy mis-spelling (PROMT.j2) so older tags also build.
@@ -47,10 +57,13 @@ a = Analysis(
     pathex=['.'],
     binaries=[],
     datas=datas,
-    # No hiddenimports — PyInstaller's static analysis walks the imports
-    # in mycat/main.py and pulls in whichever optional modules are
-    # actually referenced in the checked-out source.
-    hiddenimports=[],
+    # Collect the whole `mycat` package explicitly. In the frozen exe the
+    # entry runs as `__main__` (empty `__package__`), so main.py imports its
+    # submodules dynamically via `importlib.import_module("mycat.llm")` — a
+    # string import PyInstaller's static analysis cannot follow. Without this
+    # the exe dies at startup with `ModuleNotFoundError: No module named
+    # 'mycat.llm'`.
+    hiddenimports=collect_submodules('mycat'),
     hookspath=[],
     runtime_hooks=[],
     excludes=[],


### PR DESCRIPTION
## Summary

The prebuilt **0.1.7 Windows/macOS executables don't launch** — they crash at startup with:

```
ModuleNotFoundError: No module named 'mycat.llm'
```

**Root cause.** In the frozen exe the entry (`mycat/main.py`) runs as `__main__`, so `__package__` is empty and `main.py` takes its fallback path, importing every submodule dynamically: `importlib.import_module("mycat.llm")`. PyInstaller's static analysis can't follow string-based dynamic imports (and the `from . import …` branch is a relative import that doesn't resolve for a top-level script), so **nothing under `mycat.*` was bundled**. The spec trusted static analysis (`hiddenimports=[]`).

**A second bug surfaced once imports worked:** the spec bundles skins from `mycat/images/`, but that folder was renamed to `mycat/chars/`, so the exe shipped **with no cats** (`Found 0 ZIP archive(s)` → `Char 'cat' not found`).

## Changes (`mycat.spec` only)

- `hiddenimports=collect_submodules('mycat')` — bundle the whole package. The source tree is put on `sys.path` first so it resolves whether or not `mycat` is pip-installed in the build env.
- Bundle chars from `mycat/chars/` (renamed from `images/`); both names supported so older tags keep building.

## Test plan

- [x] Local PyInstaller build (`pyinstaller --noconfirm mycat.spec`) succeeds.
- [x] Built binary starts with **no** `ModuleNotFoundError` — log shows `(mycat.llm) Initializing LLM vendor`.
- [x] `mycat.*` modules present in the bundle (29 in the PYZ, incl. `mycat.llm`).
- [x] Chars bundled: log shows `Found 2 ZIP archive(s): cat, classic` → `Loaded interactive char 'cat'`.
- [ ] CI release build produces a Windows `.exe` / macOS `.app` that launches (needs a tag build to confirm on the real OSes).