### PR TITLE
Release 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+## [0.1.8] - 2026-07-06
+
 ### Added
 - **Reset — recenter the cat.** Right-click (and the system-tray menu) now have a **Reset** entry, placed just above **Autostart**, that moves the cat back to the bottom-right of the primary screen — a rescue for when it wanders off-screen or gets lost across multiple monitors. Restores the position-reset action originally added in #52 that was dropped during the 0.1.7 companion rework (branch `feat/reset-position`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.7"
+version = "0.1.8"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Cuts **0.1.8**: bumps `pyproject.toml` (0.1.7 → 0.1.8) and finalizes the changelog. Pushing the `0.1.8` tag after this merges will build the Windows/macOS binaries and publish the GitHub Release + PyPI package.

Includes:
- **Reset menu action** (#57)
- **Frozen-exe fix** — Windows/macOS binaries launch again (#58)

## Test plan
- [x] version = "0.1.8" in pyproject.toml
- [x] CHANGELOG Unreleased rolled into `## [0.1.8] - 2026-07-06`
- [ ] Tag `0.1.8` → release-binaries + publish workflows green