### PR TITLE
Change defaults: white plane, new reminder text, tooltip off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Changed
+- **New defaults for fresh installs.** The reminder plane now defaults to **white** (was pink), the default reminder message is **"Do you feed mycat?"** (was "Reminder!"), and the Activity **Enable Tooltip** toggle starts **off** (was on). Existing configs keep whatever they already saved (branch `feat/default-tweaks`).
+
 ## [0.1.8] - 2026-07-06
 
 ### Added

--- a/mycat/focus.py
+++ b/mycat/focus.py
@@ -68,7 +68,7 @@ def format_elapsed(seconds: float) -> str:
 @dataclass
 class FocusSettings:
     focus_minutes: int = 25  # a run this long earns a 🍅; anything shorter is a 🍌
-    tooltip_enabled: bool = True  # show the live stats tooltip when hovering the cat
+    tooltip_enabled: bool = False  # show the live stats tooltip when hovering the cat
 
 
 def load_focus_settings(cfg_file: Path = CFG_FILE) -> FocusSettings:

--- a/mycat/reminder.py
+++ b/mycat/reminder.py
@@ -33,7 +33,7 @@ CFG_FILE = CFG_DIR / "config.ini"
 DIRECTION_LTR = "ltr"  # plane flies left -> right, banner trailing on the left
 DIRECTION_RTL = "rtl"  # plane flies right -> left, banner trailing on the right
 
-DEFAULT_TEXT = "Reminder!"
+DEFAULT_TEXT = "Do you feed mycat?"
 # How the flyby duration scales: 1.0 = the leisurely default in FlybyWindow.
 DEFAULT_SPEED = 1.0
 
@@ -51,7 +51,7 @@ class Reminder:
     # One of "pink" / "white" / "blue" / "red" (or any QColor-valid hex). The
     # FlybyWindow recolours a single shared plane sprite via multiply-blend, so
     # all colour variants stay geometrically identical.
-    plane_color: str = "pink"
+    plane_color: str = "white"
     # Plane width in screen pixels; the height scales by the sprite's aspect
     # ratio (after alpha-bbox crop) so the plane never gets squashed.
     plane_width: int = 160
@@ -91,7 +91,7 @@ def load_reminder() -> Reminder | None:
             repeat_daily=section.getboolean("repeat_daily", fallback=False),
             enabled=section.getboolean("enabled", fallback=True),
             speed=section.getfloat("speed", fallback=DEFAULT_SPEED),
-            plane_color=section.get("plane_color", "pink"),
+            plane_color=section.get("plane_color", "white"),
             plane_width=section.getint("plane_width", fallback=160),
             plane=section.get("plane", "plane1"),
             mode=section.get("mode", "in"),

--- a/mycat/reminder_ui.py
+++ b/mycat/reminder_ui.py
@@ -80,13 +80,13 @@ PLANE_COLORS = {
 
 
 def _resolve_plane_color(name: str) -> QtGui.QColor:
-    """Map a colour name (or hex) to a QColor; fall back to pink if unknown."""
+    """Map a colour name (or hex) to a QColor; fall back to white if unknown."""
     if name in PLANE_COLORS:
         return PLANE_COLORS[name]
     qc = QtGui.QColor(name)
     if qc.isValid():
         return qc
-    return PLANE_COLORS["pink"]
+    return PLANE_COLORS["white"]
 
 
 def _tinted_pixmap(base: QtGui.QPixmap, tint: QtGui.QColor) -> QtGui.QPixmap:
@@ -227,7 +227,7 @@ class FlybyWindow(QtWidgets.QWidget):
 
         # Plane colour — applied to the sprite via multiply-blend. Same shape,
         # four liveries, all chosen client-side.
-        self._plane_color = _resolve_plane_color(getattr(reminder, "plane_color", "pink"))
+        self._plane_color = _resolve_plane_color(getattr(reminder, "plane_color", "white"))
 
         # Chosen plane sprite (assets/planes/<name>.png, falling back to the
         # bundled plane.png). Tint baked in here so per-frame drawing is just a
@@ -940,7 +940,7 @@ class ReminderDialog(QtWidgets.QDialog):
     def _build_reminder(self) -> Reminder:
         text = self._text_edit.text().strip() or reminder_mod.DEFAULT_TEXT
         direction = self._direction.currentData()
-        plane_color = self._color.currentData() or "pink"
+        plane_color = self._color.currentData() or "white"
         plane_width = self._plane_width_spin.value()
         plane = self.plane_combo.currentData() or "plane1"
         now = datetime.now()


### PR DESCRIPTION
## Summary

Three default-value tweaks (fresh installs only — existing `config.ini` values are respected):

- **Reminder plane** defaults to **white** (was pink) — `reminder.py` `plane_color` default + the colour fallbacks in `reminder_ui.py`.
- **Default reminder message** is **"Do you feed mycat?"** (was "Reminder!") — `reminder.py` `DEFAULT_TEXT`.
- **Activity → Enable Tooltip** starts **off** (was on) — `focus.py` `FocusSettings.tooltip_enabled = False`.

## Test plan
- [x] `ruff check` clean
- [x] Fresh objects verified: `Reminder().plane_color == "white"`, `Reminder().text == "Do you feed mycat?"`, `FocusSettings().tooltip_enabled is False`.
- [x] `PLANE_COLORS` dict (both `pink` and `white`) intact.