### PR TITLE
Release 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Changed
+- **New defaults for fresh installs.** The reminder plane now defaults to **white** (was pink), the default reminder message is **"Do you feed mycat?"** (was "Reminder!"), and the Activity **Enable Tooltip** toggle starts **off** (was on). Existing configs keep whatever they already saved (branch `feat/default-tweaks`).
+
 ## [0.1.8] - 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+## [0.1.9] - 2026-07-06
+
 ### Changed
 - **New defaults for fresh installs.** The reminder plane now defaults to **white** (was pink), the default reminder message is **"Do you feed mycat?"** (was "Reminder!"), and the Activity **Enable Tooltip** toggle starts **off** (was on). Existing configs keep whatever they already saved (branch `feat/default-tweaks`).
+
+### Fixed
+- **Keyboard and mouse-click counts now work on `pip install` and the prebuilt exe.** The Activity diary counts key presses and clicks via `pynput`, but it was an *optional* extra (`mycat[basic]`) — so a plain `pip install mycat` and the bundled Windows/macOS executables shipped without it, and the counts silently stayed at zero (only the cursor path was recorded). `pynput` is now a base dependency, so the counts work out of the box; the PyInstaller `pynput` hook bundles the platform backend into the exe. It still degrades to cursor-only where global hooks can't run — Wayland, or macOS without Input Monitoring permission (branch `chore/release-0.1.9`).
 
 ## [0.1.8] - 2026-07-06
 

--- a/mycat/focus.py
+++ b/mycat/focus.py
@@ -68,7 +68,7 @@ def format_elapsed(seconds: float) -> str:
 @dataclass
 class FocusSettings:
     focus_minutes: int = 25  # a run this long earns a 🍅; anything shorter is a 🍌
-    tooltip_enabled: bool = True  # show the live stats tooltip when hovering the cat
+    tooltip_enabled: bool = False  # show the live stats tooltip when hovering the cat
 
 
 def load_focus_settings(cfg_file: Path = CFG_FILE) -> FocusSettings:

--- a/mycat/reminder.py
+++ b/mycat/reminder.py
@@ -33,7 +33,7 @@ CFG_FILE = CFG_DIR / "config.ini"
 DIRECTION_LTR = "ltr"  # plane flies left -> right, banner trailing on the left
 DIRECTION_RTL = "rtl"  # plane flies right -> left, banner trailing on the right
 
-DEFAULT_TEXT = "Reminder!"
+DEFAULT_TEXT = "Do you feed mycat?"
 # How the flyby duration scales: 1.0 = the leisurely default in FlybyWindow.
 DEFAULT_SPEED = 1.0
 
@@ -51,7 +51,7 @@ class Reminder:
     # One of "pink" / "white" / "blue" / "red" (or any QColor-valid hex). The
     # FlybyWindow recolours a single shared plane sprite via multiply-blend, so
     # all colour variants stay geometrically identical.
-    plane_color: str = "pink"
+    plane_color: str = "white"
     # Plane width in screen pixels; the height scales by the sprite's aspect
     # ratio (after alpha-bbox crop) so the plane never gets squashed.
     plane_width: int = 160
@@ -91,7 +91,7 @@ def load_reminder() -> Reminder | None:
             repeat_daily=section.getboolean("repeat_daily", fallback=False),
             enabled=section.getboolean("enabled", fallback=True),
             speed=section.getfloat("speed", fallback=DEFAULT_SPEED),
-            plane_color=section.get("plane_color", "pink"),
+            plane_color=section.get("plane_color", "white"),
             plane_width=section.getint("plane_width", fallback=160),
             plane=section.get("plane", "plane1"),
             mode=section.get("mode", "in"),

--- a/mycat/reminder_ui.py
+++ b/mycat/reminder_ui.py
@@ -80,13 +80,13 @@ PLANE_COLORS = {
 
 
 def _resolve_plane_color(name: str) -> QtGui.QColor:
-    """Map a colour name (or hex) to a QColor; fall back to pink if unknown."""
+    """Map a colour name (or hex) to a QColor; fall back to white if unknown."""
     if name in PLANE_COLORS:
         return PLANE_COLORS[name]
     qc = QtGui.QColor(name)
     if qc.isValid():
         return qc
-    return PLANE_COLORS["pink"]
+    return PLANE_COLORS["white"]
 
 
 def _tinted_pixmap(base: QtGui.QPixmap, tint: QtGui.QColor) -> QtGui.QPixmap:
@@ -227,7 +227,7 @@ class FlybyWindow(QtWidgets.QWidget):
 
         # Plane colour — applied to the sprite via multiply-blend. Same shape,
         # four liveries, all chosen client-side.
-        self._plane_color = _resolve_plane_color(getattr(reminder, "plane_color", "pink"))
+        self._plane_color = _resolve_plane_color(getattr(reminder, "plane_color", "white"))
 
         # Chosen plane sprite (assets/planes/<name>.png, falling back to the
         # bundled plane.png). Tint baked in here so per-frame drawing is just a
@@ -940,7 +940,7 @@ class ReminderDialog(QtWidgets.QDialog):
     def _build_reminder(self) -> Reminder:
         text = self._text_edit.text().strip() or reminder_mod.DEFAULT_TEXT
         direction = self._direction.currentData()
-        plane_color = self._color.currentData() or "pink"
+        plane_color = self._color.currentData() or "white"
         plane_width = self._plane_width_spin.value()
         plane = self.plane_combo.currentData() or "plane1"
         now = datetime.now()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.8"
+version = "0.1.9"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -20,6 +20,12 @@ classifiers = [
 dependencies = [
     "pillow>=12.0.0",
     "pyside6>=6.10.0",
+    # Global key/click COUNTS via pynput (the key identity is discarded in the
+    # hook — only an integer survives). A base dependency so the counts work
+    # out of the box on plain `pip install mycat` and in the prebuilt exe.
+    # Degrades to cursor-only where global hooks can't run (Wayland, or macOS
+    # without Input Monitoring permission).
+    "pynput>=1.7",
 ]
 
 [dependency-groups]
@@ -30,10 +36,9 @@ dev = [
 
 # Optional: store API keys in the OS keyring instead of plaintext config.
 [project.optional-dependencies]
-# Global key/click COUNTS via pynput (the key identity is discarded in the
-# hook — only an integer survives). Optional: the base install already records
-# cursor path, and where global hooks can't run (Wayland, missing macOS Input
-# Monitoring permission) this tier degrades to cursor-only anyway.
+# `pynput` is now a base dependency (see [project.dependencies]); `basic` is
+# kept only as a no-op alias so older `pip install mycat[basic]` commands still
+# resolve.
 basic = ["pynput>=1.7"]
 secure = ["keyring>=24"]
 # ICS calendar reminders: RRULE expansion (the daily standup) is a swamp not

--- a/tests/test_activity_dialog.py
+++ b/tests/test_activity_dialog.py
@@ -259,12 +259,12 @@ def test_save_persists_and_applies_tooltip_toggle(tmp_path, qapp, monkeypatch):
     focus_saved = []
     monkeypatch.setattr("mycat.activity.save_activity_settings", lambda settings, **kw: None)
     monkeypatch.setattr("mycat.focus.save_focus_settings", lambda settings, **kw: focus_saved.append(settings))
-    assert dialog.tooltip_box.isChecked()  # on by default
-    dialog.tooltip_box.setChecked(False)
+    assert not dialog.tooltip_box.isChecked()  # off by default
+    dialog.tooltip_box.setChecked(True)
     dialog.save_settings()
-    assert focus_saved[0].tooltip_enabled is False  # persisted
-    assert controller.settings.tooltip_enabled is False  # applied live
-    assert "tooltip ✗" in dialog.status_label.text()
+    assert focus_saved[0].tooltip_enabled is True  # persisted
+    assert controller.settings.tooltip_enabled is True  # applied live
+    assert "tooltip ✓" in dialog.status_label.text()
 
 
 def test_brief_run_is_a_banana(tmp_path, qapp):

--- a/tests/test_focus.py
+++ b/tests/test_focus.py
@@ -12,10 +12,10 @@ def test_focus_goal_round_trip(tmp_path):
     loaded = load_focus_settings(cfg_file=cfg)
     assert loaded.focus_minutes == 30
     assert loaded.tooltip_enabled is False
-    # Defaults (no file): 25-minute Pomodoro, hover tooltip on.
+    # Defaults (no file): 25-minute Pomodoro, hover tooltip off.
     default = load_focus_settings(cfg_file=tmp_path / "none.ini")
     assert default.focus_minutes == 25
-    assert default.tooltip_enabled is True
+    assert default.tooltip_enabled is False
 
 
 class FakeNow:
@@ -99,10 +99,11 @@ def test_tooltip_toggle_controls_the_hover_tooltip(tmp_path, qapp):
     col = FakeCollector()
     controller.attach_collector(col)
     col.run = run_stats(now(), keys=100)
-    # On (default): the tooltip carries the live stats.
+    # On: the tooltip carries the live stats.
+    controller.settings.tooltip_enabled = True
     controller.refresh_visuals()
     assert window.tip and "⌨ 100" in window.tip
-    # Off: the tooltip is cleared (empty string also kills the hover-show).
+    # Off (default): the tooltip is cleared (empty string also kills the hover-show).
     controller.settings.tooltip_enabled = False
     controller.refresh_visuals()
     assert window.tip == ""


### PR DESCRIPTION
## Summary

Cuts **0.1.9**. Bundles everything queued for this release into one PR (as requested).

### Fix — keyboard/mouse-click counts (Windows exe + pip)
The Activity diary counts key presses and clicks via `pynput`, but it was an **optional** extra (`mycat[basic]`). So a plain `pip install mycat` and the **prebuilt Windows/macOS executables shipped without it**, and the counts silently stayed at zero (only the cursor path was recorded).

**Fix:** `pynput` is now a **base dependency** — so pip installs and the CI exe build both include it. PyInstaller's bundled `pynput` hook packs the platform backend automatically. Degrades to cursor-only where global hooks can't run (Wayland, or macOS without Input Monitoring permission).

### Also included (from #60, superseded by this PR)
New defaults for fresh installs: **white** reminder plane, **"Do you feed mycat?"** message, Activity **Enable Tooltip off**.

### Release
- `pyproject.toml` version 0.1.8 → **0.1.9**
- CHANGELOG rolled into `## [0.1.9] - 2026-07-06`

## Test plan
- [x] `ruff check` clean
- [x] Local PyInstaller build bundles `pynput` incl. the **`_util.win32`** backend (46 pynput entries in the PYZ)
- [x] Built exe logs `Activity collector started (mouse=True keyboard=True)` — pynput engages at runtime, no errors
- [x] Fresh-install defaults verified (white / "Do you feed mycat?" / tooltip off)
- [ ] After merge: push tag `0.1.9` → release-binaries + publish workflows (this is the release step)