### PR TITLE
Release 0.1.10 — fix Linux pip install (pynput/evdev)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+## [0.1.10] - 2026-07-06
+
+### Fixed
+- **`pip install mycat` no longer fails to build on Linux.** 0.1.9 made `pynput` a hard dependency to turn on the key/click counts, but on Linux `pynput` pulls `evdev` — a C extension with no wheel — so the install died compiling it on machines without a compiler and Python headers (`fatal error: Python.h`). `pynput` is now a base dependency only on **Windows/macOS**, where it installs cleanly and the counts work out of the box (including the prebuilt exe). On **Linux** it is opt-in: `pip install mycat[basic]`.
+
+### Changed
+- **Docs.** Moved the "make your own cat" guide out of README into a step-by-step Quick start in `docs/CHARS.md`; README now links to it and stays focused on install options and CLI keys (branch `docs/chars-guide`).
+
 ## [0.1.9] - 2026-07-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ On **Linux** also install the Qt platform plugin once:
 sudo apt install -y libxcb-cursor0
 ```
 
-For keystroke/click **counts** in the activity diary (never which keys), install
-the optional extra: `pip install mycat[basic]`. Without it the diary still
-records cursor path — only the counts need it.
+The activity diary can **count** key presses and clicks (never *which* keys). On
+**Windows/macOS** that works out of the box; on **Linux** it's opt-in —
+`pip install mycat[basic]` (it pulls `evdev`, which needs a compiler). Without it
+the diary still records the cursor path.
 
 Upgrade or remove later with `pip install -U mycat` / `pip uninstall mycat`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.9"
+version = "0.1.10"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,11 +21,12 @@ dependencies = [
     "pillow>=12.0.0",
     "pyside6>=6.10.0",
     # Global key/click COUNTS via pynput (the key identity is discarded in the
-    # hook — only an integer survives). A base dependency so the counts work
-    # out of the box on plain `pip install mycat` and in the prebuilt exe.
-    # Degrades to cursor-only where global hooks can't run (Wayland, or macOS
-    # without Input Monitoring permission).
-    "pynput>=1.7",
+    # hook — only an integer survives). Base dependency on Windows/macOS so the
+    # counts work out of the box on `pip install mycat` and in the prebuilt exe.
+    # NOT on Linux: there pynput hard-requires `evdev`, a C extension with no
+    # wheel, so a plain `pip install mycat` would fail to build without a
+    # compiler + Python headers. Linux users opt in with `mycat[basic]`.
+    "pynput>=1.7; sys_platform != 'linux'",
 ]
 
 [dependency-groups]
@@ -36,9 +37,9 @@ dev = [
 
 # Optional: store API keys in the OS keyring instead of plaintext config.
 [project.optional-dependencies]
-# `pynput` is now a base dependency (see [project.dependencies]); `basic` is
-# kept only as a no-op alias so older `pip install mycat[basic]` commands still
-# resolve.
+# On Windows/macOS `pynput` is a base dependency; on Linux it lives here so it
+# stays opt-in (it pulls the `evdev` C extension, which needs a compiler). Linux
+# users who want key/click counts: `pip install mycat[basic]`.
 basic = ["pynput>=1.7"]
 secure = ["keyring>=24"]
 # ICS calendar reminders: RRULE expansion (the daily standup) is a swamp not


### PR DESCRIPTION
## Summary

**Regression fix.** 0.1.9 made `pynput` a hard dependency to enable the key/click counts. But on **Linux** `pynput` hard-requires **`evdev`** — a C extension with no wheel — so a plain `pip install mycat` now dies compiling it on any machine without a compiler + Python headers:

```
fatal error: Python.h: No such file or directory
ERROR: Could not build wheels for evdev
```

**Fix:** `pynput` is a base dependency only on **Windows/macOS** (`sys_platform != 'linux'`), where it installs cleanly and the counts work out of the box — including the prebuilt exe. On **Linux** it's opt-in: `pip install mycat[basic]`. `evdev` on Linux was the whole reason `pynput` was optional originally.

Also rolls in the docs move (#62 — char guide → `docs/CHARS.md`) and bumps `0.1.9 → 0.1.10`.

## Test plan
- [x] Built the wheel; `Requires-Dist: pynput>=1.7; sys_platform != "linux"` (so Linux `pip install mycat` pulls only `pillow` + `pyside6` — no `pynput`, no `evdev`)
- [x] `pynput>=1.7; extra == "basic"` kept for Linux opt-in
- [x] CI runs on ubuntu and doesn't need `pynput` (tests use fakes; no unguarded `import pynput`)
- [x] Windows/macOS still get `pynput` (pip + exe) → counts intact
- [ ] After merge: tag `0.1.10` → release-binaries + publish