### PR TITLE
ci: build a macOS Intel (x86_64) release binary

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,8 +1,8 @@
 name: Release binaries
 
 # Triggered by the same tag pattern as publish.yml (PyPI). On tag push we
-# build native binaries for Windows + macOS in parallel, then attach them
-# to the GitHub Release matching that tag.
+# build native binaries for Windows + macOS (Apple Silicon arm64 + Intel x64)
+# in parallel, then attach them to the GitHub Release matching that tag.
 #
 # Also dispatchable manually so the workflow can be tested without burning
 # a real release tag — the dispatch run uploads artefacts but skips the
@@ -58,8 +58,7 @@ jobs:
           if-no-files-found: error
 
   build-macos:
-    # macos-14 is Apple Silicon (arm64). For Intel Macs, add a second job on
-    # macos-13 with the same steps + ``-macos-x64.zip`` suffix.
+    # macos-14 is Apple Silicon (arm64). The Intel (x64) build is build-macos-intel.
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v5
@@ -97,11 +96,52 @@ jobs:
           path: dist/mycat-*-macos-arm64.zip
           if-no-files-found: error
 
+  build-macos-intel:
+    # macos-13 is the last Intel (x86_64) macOS runner GitHub offers. Mirrors
+    # build-macos exactly; only the runner arch and the ``-macos-x64`` suffix
+    # differ.
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -e .
+          pip install openai
+
+      - name: Build with PyInstaller
+        run: pyinstaller --noconfirm mycat.spec
+
+      - name: Zip .app bundle
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+          else
+            VERSION="dev-${GITHUB_SHA::7}"
+          fi
+          cd dist
+          # ditto is the recommended way to zip a macOS bundle — preserves
+          # extended attrs/resource forks unlike plain `zip -r`.
+          ditto -c -k --keepParent mycat.app "mycat-${VERSION}-macos-x64.zip"
+          ls -la
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mycat-macos-intel
+          path: dist/mycat-*-macos-x64.zip
+          if-no-files-found: error
+
   release:
     # Only attach to a Release on real tag pushes — dispatch runs just
     # produce downloadable artefacts.
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-windows, build-macos]
+    needs: [build-windows, build-macos, build-macos-intel]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -114,6 +154,7 @@ jobs:
           files: |
             artifacts/mycat-windows/*
             artifacts/mycat-macos/*
+            artifacts/mycat-macos-intel/*
           fail_on_unmatched_files: true
           # Auto-generated notes from PRs/commits since the previous tag.
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Added
+- **Prebuilt macOS Intel (x86_64) binary.** The release workflow now also builds `mycat-<version>-macos-x64.zip` on an Intel runner (`macos-13`), alongside the existing Apple Silicon (`-macos-arm64`) and Windows builds, so Intel Macs get a native download (branch `ci/macos-intel-x64`).
+
 ## [0.1.11] - 2026-07-06
 
 ### Added


### PR DESCRIPTION
## Summary
Adds a `build-macos-intel` job (runner `macos-13`, Intel) to the release-binaries workflow, mirroring the Apple Silicon job but emitting `mycat-<version>-macos-x64.zip`. It's wired into the `release` job's `needs` + attached `files`, so future tagged releases ship **three** binaries: Apple Silicon (`-macos-arm64`), Intel (`-macos-x64`), and Windows.

Version is unchanged — macOS/Windows binaries are GitHub Release assets, independent of the PyPI version.

`macos-13` is the last Intel macOS runner GitHub provides; the arm64 build stays on `macos-14`.

## Test plan
- [ ] YAML validates; workflow parses (jobs: build-windows, build-macos, build-macos-intel, release).
- [ ] `workflow_dispatch` run on this branch produces the `mycat-macos-intel` artifact.
- [ ] The 0.1.11 GitHub Release is backfilled with `mycat-0.1.11-macos-x64.zip` (done outside this PR, no re-tag).
- [ ] Next real tag attaches all three binaries automatically.