### PR TITLE
ci(deb): version non-tag builds from pyproject.toml

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -44,7 +44,10 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
           else
-            VERSION="0.0.0~dev${GITHUB_SHA::7}"
+            # Non-tag (manual dispatch) build: take the version from pyproject so a
+            # dispatched build of a release commit yields a correctly-versioned
+            # package — e.g. to backfill a release that predates this workflow.
+            VERSION="$(grep -m1 -E '^version *= *' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')"
           fi
           PKG="mycat_${VERSION}_amd64"
           root="pkg/${PKG}"


### PR DESCRIPTION
## Summary
A manual `workflow_dispatch` build of `build-deb.yml` isn't a tag, so it stamped the package version as `0.0.0~dev<sha>`. This reads the version from `pyproject.toml` on non-tag builds instead, so dispatching a build of a release commit produces a correctly-versioned `.deb`.

Needed to **backfill the 0.1.11 release** with a proper `mycat_0.1.11_amd64.deb` (the .deb workflow postdates the 0.1.11 tag, so it can't be tag-triggered for it). Tag builds are unchanged.

## Test plan
- [x] `grep|sed` extracts `0.1.11` from pyproject.toml locally.
- [x] YAML parses.
- [ ] Dispatch on main yields `mycat_0.1.11_amd64.deb`; attach to the 0.1.11 Release.