### PR TITLE
ci: fix Intel macOS runner (macos-13 retired → macos-15-intel)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -97,10 +97,11 @@ jobs:
           if-no-files-found: error
 
   build-macos-intel:
-    # macos-13 is the last Intel (x86_64) macOS runner GitHub offers. Mirrors
+    # macos-15-intel is GitHub's x86_64 runner (macos-13 was retired Dec 2025;
+    # macos-15-intel is the last Intel image, supported until ~Aug 2027). Mirrors
     # build-macos exactly; only the runner arch and the ``-macos-x64`` suffix
     # differ.
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ## Unreleased
 
 ### Added
-- **Prebuilt macOS Intel (x86_64) binary.** The release workflow now also builds `mycat-<version>-macos-x64.zip` on an Intel runner (`macos-13`), alongside the existing Apple Silicon (`-macos-arm64`) and Windows builds, so Intel Macs get a native download (branch `ci/macos-intel-x64`).
+- **Prebuilt macOS Intel (x86_64) binary.** The release workflow now also builds `mycat-<version>-macos-x64.zip` on GitHub's Intel runner (`macos-15-intel`), alongside the existing Apple Silicon (`-macos-arm64`) and Windows builds, so Intel Macs get a native download (branches `ci/macos-intel-x64`, `fix/intel-runner-macos-15`).
 - **Prebuilt Debian package (`.deb`) for Linux.** A new CI workflow wraps the PyInstaller onefile binary in a `mycat_<version>_amd64.deb` (installs `/usr/bin/mycat`, a `.desktop` launcher, and a cat-head icon) and attaches it to each GitHub Release. Install with `sudo apt install ./mycat_<version>_amd64.deb`; it's self-contained (bundles its own Python + Qt), depending only on common system libs like `libxcb-cursor0` (branch `ci/linux-deb`).
 
 ## [0.1.11] - 2026-07-06


### PR DESCRIPTION
## Summary
`macos-13` (Intel) was retired by GitHub in December 2025, so the `build-macos-intel` job added in #65 queued forever with no runner ever picking it up. Switch to **`macos-15-intel`** — GitHub's current (and last) x86_64 macOS image, supported until ~August 2027.

Refs: [macos-13 deprecation](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).

## Test plan
- [x] YAML parses.
- [ ] Dispatch on main: the `build-macos-intel` job actually runs (not stuck queued) and produces `mycat-macos-intel`.
- [ ] Backfill the 0.1.11 Release with `mycat-0.1.11-macos-x64.zip`.