### PR TITLE
ci: version-less release asset names + Linux AppImage

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -10,9 +10,6 @@ on:
     tags:
       - "*.*.*"
       - "v*"
-  pull_request:
-    paths:
-      - ".github/workflows/build-appimage.yml"
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,0 +1,70 @@
+name: Build AppImage
+
+# Same tag trigger as the other release workflows. Packs the PyInstaller onefile
+# Linux binary into a portable, self-contained AppImage (a single user-writable
+# file that runs on most distros and can update itself in place) and attaches it
+# to the GitHub Release. Also dispatchable to produce the AppImage as an artefact.
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+      - "v*"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write   # attach the AppImage to the GitHub Release
+
+jobs:
+  build-appimage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -e .
+          # openai is optional, but a frozen binary can't pip-install later —
+          # bundling it here makes --openai work out of the box.
+          pip install openai
+
+      - name: Build with PyInstaller
+        run: pyinstaller --noconfirm mycat.spec
+
+      - name: Assemble AppDir and build AppImage
+        run: |
+          set -euo pipefail
+          mkdir -p AppDir/usr/bin AppDir/usr/share/icons/hicolor/256x256/apps
+          install -m0755 dist/mycat AppDir/usr/bin/mycat
+          # The .desktop and icon must sit at the AppDir root (Icon=mycat ->
+          # AppDir/mycat.png), and a copy under hicolor is good practice.
+          install -m0644 packaging/mycat.desktop AppDir/mycat.desktop
+          install -m0644 packaging/mycat.png AppDir/mycat.png
+          install -m0644 packaging/mycat.png AppDir/usr/share/icons/hicolor/256x256/apps/mycat.png
+          printf '#!/bin/sh\nHERE="$(dirname "$(readlink -f "$0")")"\nexec "$HERE/usr/bin/mycat" "$@"\n' > AppDir/AppRun
+          chmod +x AppDir/AppRun
+
+          wget -qO appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x appimagetool
+          # --appimage-extract-and-run avoids needing FUSE on the runner.
+          ARCH=x86_64 ./appimagetool --appimage-extract-and-run AppDir mycat-x86_64.AppImage
+          ls -la mycat-x86_64.AppImage
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mycat-appimage
+          path: mycat-x86_64.AppImage
+          if-no-files-found: error
+
+      - name: Attach AppImage to the GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: mycat-x86_64.AppImage
+          fail_on_unmatched_files: true

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -10,6 +10,9 @@ on:
     tags:
       - "*.*.*"
       - "v*"
+  pull_request:
+    paths:
+      - ".github/workflows/build-appimage.yml"
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -60,19 +60,21 @@ jobs:
           install -m0644 packaging/mycat.png "$root/usr/share/icons/hicolor/256x256/apps/mycat.png"
           sed "s/@VERSION@/${VERSION}/" packaging/control.in > "$root/DEBIAN/control"
           dpkg-deb --root-owner-group --build "$root"
-          mv "pkg/${PKG}.deb" "${PKG}.deb"
-          echo "::group::deb info";     dpkg-deb --info "${PKG}.deb";     echo "::endgroup::"
-          echo "::group::deb contents"; dpkg-deb --contents "${PKG}.deb"; echo "::endgroup::"
+          # Internal control keeps the real version; the file name is version-less
+          # so /releases/latest/download/mycat-amd64.deb is a stable link.
+          mv "pkg/${PKG}.deb" "mycat-amd64.deb"
+          echo "::group::deb info";     dpkg-deb --info "mycat-amd64.deb";     echo "::endgroup::"
+          echo "::group::deb contents"; dpkg-deb --contents "mycat-amd64.deb"; echo "::endgroup::"
 
       - uses: actions/upload-artifact@v4
         with:
           name: mycat-deb
-          path: mycat_*_amd64.deb
+          path: mycat-amd64.deb
           if-no-files-found: error
 
       - name: Attach .deb to the GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: mycat_*_amd64.deb
+          files: mycat-amd64.deb
           fail_on_unmatched_files: true

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -43,18 +43,14 @@ jobs:
       - name: Rename artefact
         shell: bash
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-          else
-            VERSION="dev-${GITHUB_SHA::7}"
-          fi
-          mv dist/mycat.exe "dist/mycat-${VERSION}-windows-x64.exe"
+          # Version-less name so /releases/latest/download/<name> is a stable link.
+          mv dist/mycat.exe "dist/mycat-windows-x64.exe"
           ls -la dist/
 
       - uses: actions/upload-artifact@v4
         with:
           name: mycat-windows
-          path: dist/mycat-*-windows-x64.exe
+          path: dist/mycat-windows-x64.exe
           if-no-files-found: error
 
   build-macos:
@@ -79,21 +75,17 @@ jobs:
 
       - name: Zip .app bundle
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-          else
-            VERSION="dev-${GITHUB_SHA::7}"
-          fi
           cd dist
           # ditto is the recommended way to zip a macOS bundle — preserves
-          # extended attrs/resource forks unlike plain `zip -r`.
-          ditto -c -k --keepParent mycat.app "mycat-${VERSION}-macos-arm64.zip"
+          # extended attrs/resource forks unlike plain `zip -r`. Version-less
+          # name so /releases/latest/download/<name> is a stable link.
+          ditto -c -k --keepParent mycat.app "mycat-macos-arm64.zip"
           ls -la
 
       - uses: actions/upload-artifact@v4
         with:
           name: mycat-macos
-          path: dist/mycat-*-macos-arm64.zip
+          path: dist/mycat-macos-arm64.zip
           if-no-files-found: error
 
   build-macos-intel:
@@ -121,21 +113,17 @@ jobs:
 
       - name: Zip .app bundle
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/}"
-          else
-            VERSION="dev-${GITHUB_SHA::7}"
-          fi
           cd dist
           # ditto is the recommended way to zip a macOS bundle — preserves
-          # extended attrs/resource forks unlike plain `zip -r`.
-          ditto -c -k --keepParent mycat.app "mycat-${VERSION}-macos-x64.zip"
+          # extended attrs/resource forks unlike plain `zip -r`. Version-less
+          # name so /releases/latest/download/<name> is a stable link.
+          ditto -c -k --keepParent mycat.app "mycat-macos-x64.zip"
           ls -la
 
       - uses: actions/upload-artifact@v4
         with:
           name: mycat-macos-intel
-          path: dist/mycat-*-macos-x64.zip
+          path: dist/mycat-macos-x64.zip
           if-no-files-found: error
 
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project are documented in this file.
 ## Unreleased
 
 ### Added
-- **Prebuilt macOS Intel (x86_64) binary.** The release workflow now also builds `mycat-<version>-macos-x64.zip` on GitHub's Intel runner (`macos-15-intel`), alongside the existing Apple Silicon (`-macos-arm64`) and Windows builds, so Intel Macs get a native download (branches `ci/macos-intel-x64`, `fix/intel-runner-macos-15`).
-- **Prebuilt Debian package (`.deb`) for Linux.** A new CI workflow wraps the PyInstaller onefile binary in a `mycat_<version>_amd64.deb` (installs `/usr/bin/mycat`, a `.desktop` launcher, and a cat-head icon) and attaches it to each GitHub Release. Install with `sudo apt install ./mycat_<version>_amd64.deb`; it's self-contained (bundles its own Python + Qt), depending only on common system libs like `libxcb-cursor0` (branch `ci/linux-deb`).
+- **Prebuilt macOS Intel (x86_64) binary.** The release workflow now also builds `mycat-macos-x64.zip` on GitHub's Intel runner (`macos-15-intel`), alongside the existing Apple Silicon (`-macos-arm64`) and Windows builds, so Intel Macs get a native download (branches `ci/macos-intel-x64`, `fix/intel-runner-macos-15`).
+- **Prebuilt Debian package (`.deb`) for Linux.** A new CI workflow wraps the PyInstaller onefile binary in a `mycat-amd64.deb` (installs `/usr/bin/mycat`, a `.desktop` launcher, and a cat-head icon) and attaches it to each GitHub Release. Install with `sudo apt install ./mycat-amd64.deb`; it's self-contained (bundles its own Python + Qt), depending only on common system libs like `libxcb-cursor0` (branch `ci/linux-deb`).
+- **Prebuilt Linux AppImage.** A new CI workflow packs the same onefile binary into a portable `mycat-x86_64.AppImage` — a single user-writable file that runs on most distros (needs FUSE) and is the format used for one-click self-updates. Attached to each GitHub Release (branch `ci/versionless-names-appimage`).
+
+### Changed
+- **Release asset filenames are now version-less** (`mycat-windows-x64.exe`, `mycat-macos-arm64.zip`, `mycat-macos-x64.zip`, `mycat-amd64.deb`, `mycat-x86_64.AppImage`), so `https://github.com/yumiaura/myCat/releases/latest/download/<name>` is a stable link that always fetches the current build — used by the README download buttons and the in-app updater (branch `ci/versionless-names-appimage`).
 
 ## [0.1.11] - 2026-07-06
 


### PR DESCRIPTION
## Summary
Foundation for the download buttons and the in-app updater.

- **Version-less asset names** across all release workflows: `mycat-windows-x64.exe`, `mycat-macos-arm64.zip`, `mycat-macos-x64.zip`, `mycat-amd64.deb`. Now `https://github.com/yumiaura/myCat/releases/latest/download/<name>` is a stable link. The `.deb` keeps its real version inside the control file (apt reads that, not the filename).
- **New `build-appimage.yml`**: packs the PyInstaller onefile binary into a portable `mycat-x86_64.AppImage` (AppDir + `appimagetool`, `--appimage-extract-and-run` so no FUSE on the runner). The AppImage is the clean self-updating Linux format — a single user-writable file.

## Test plan
- [x] All three workflow YAMLs parse.
- [ ] AppImage actually builds in CI (validating via a temporary `pull_request` trigger, removed before merge).
- [ ] After merge: dispatch to backfill 0.1.11 with the version-less assets + AppImage.