### PR TITLE
ci: name Linux assets mycat-linux-amd64.deb / mycat-linux-x86_64.AppImage

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -53,18 +53,18 @@ jobs:
           wget -qO appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod +x appimagetool
           # --appimage-extract-and-run avoids needing FUSE on the runner.
-          ARCH=x86_64 ./appimagetool --appimage-extract-and-run AppDir mycat-x86_64.AppImage
-          ls -la mycat-x86_64.AppImage
+          ARCH=x86_64 ./appimagetool --appimage-extract-and-run AppDir mycat-linux-x86_64.AppImage
+          ls -la mycat-linux-x86_64.AppImage
 
       - uses: actions/upload-artifact@v4
         with:
           name: mycat-appimage
-          path: mycat-x86_64.AppImage
+          path: mycat-linux-x86_64.AppImage
           if-no-files-found: error
 
       - name: Attach AppImage to the GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: mycat-x86_64.AppImage
+          files: mycat-linux-x86_64.AppImage
           fail_on_unmatched_files: true

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -61,20 +61,20 @@ jobs:
           sed "s/@VERSION@/${VERSION}/" packaging/control.in > "$root/DEBIAN/control"
           dpkg-deb --root-owner-group --build "$root"
           # Internal control keeps the real version; the file name is version-less
-          # so /releases/latest/download/mycat-amd64.deb is a stable link.
-          mv "pkg/${PKG}.deb" "mycat-amd64.deb"
-          echo "::group::deb info";     dpkg-deb --info "mycat-amd64.deb";     echo "::endgroup::"
-          echo "::group::deb contents"; dpkg-deb --contents "mycat-amd64.deb"; echo "::endgroup::"
+          # so /releases/latest/download/mycat-linux-amd64.deb is a stable link.
+          mv "pkg/${PKG}.deb" "mycat-linux-amd64.deb"
+          echo "::group::deb info";     dpkg-deb --info "mycat-linux-amd64.deb";     echo "::endgroup::"
+          echo "::group::deb contents"; dpkg-deb --contents "mycat-linux-amd64.deb"; echo "::endgroup::"
 
       - uses: actions/upload-artifact@v4
         with:
           name: mycat-deb
-          path: mycat-amd64.deb
+          path: mycat-linux-amd64.deb
           if-no-files-found: error
 
       - name: Attach .deb to the GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: mycat-amd64.deb
+          files: mycat-linux-amd64.deb
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project are documented in this file.
 
 ### Added
 - **Prebuilt macOS Intel (x86_64) binary.** The release workflow now also builds `mycat-macos-x64.zip` on GitHub's Intel runner (`macos-15-intel`), alongside the existing Apple Silicon (`-macos-arm64`) and Windows builds, so Intel Macs get a native download (branches `ci/macos-intel-x64`, `fix/intel-runner-macos-15`).
-- **Prebuilt Debian package (`.deb`) for Linux.** A new CI workflow wraps the PyInstaller onefile binary in a `mycat-amd64.deb` (installs `/usr/bin/mycat`, a `.desktop` launcher, and a cat-head icon) and attaches it to each GitHub Release. Install with `sudo apt install ./mycat-amd64.deb`; it's self-contained (bundles its own Python + Qt), depending only on common system libs like `libxcb-cursor0` (branch `ci/linux-deb`).
-- **Prebuilt Linux AppImage.** A new CI workflow packs the same onefile binary into a portable `mycat-x86_64.AppImage` — a single user-writable file that runs on most distros (needs FUSE) and is the format used for one-click self-updates. Attached to each GitHub Release (branch `ci/versionless-names-appimage`).
+- **Prebuilt Debian package (`.deb`) for Linux.** A new CI workflow wraps the PyInstaller onefile binary in a `mycat-linux-amd64.deb` (installs `/usr/bin/mycat`, a `.desktop` launcher, and a cat-head icon) and attaches it to each GitHub Release. Install with `sudo apt install ./mycat-linux-amd64.deb`; it's self-contained (bundles its own Python + Qt), depending only on common system libs like `libxcb-cursor0` (branch `ci/linux-deb`).
+- **Prebuilt Linux AppImage.** A new CI workflow packs the same onefile binary into a portable `mycat-linux-x86_64.AppImage` — a single user-writable file that runs on most distros (needs FUSE) and is the format used for one-click self-updates. Attached to each GitHub Release (branch `ci/versionless-names-appimage`).
 
 ### Changed
-- **Release asset filenames are now version-less** (`mycat-windows-x64.exe`, `mycat-macos-arm64.zip`, `mycat-macos-x64.zip`, `mycat-amd64.deb`, `mycat-x86_64.AppImage`), so `https://github.com/yumiaura/myCat/releases/latest/download/<name>` is a stable link that always fetches the current build — used by the README download buttons and the in-app updater (branch `ci/versionless-names-appimage`).
+- **Release asset filenames are now version-less** (`mycat-windows-x64.exe`, `mycat-macos-arm64.zip`, `mycat-macos-x64.zip`, `mycat-linux-amd64.deb`, `mycat-linux-x86_64.AppImage`), so `https://github.com/yumiaura/myCat/releases/latest/download/<name>` is a stable link that always fetches the current build — used by the README download buttons and the in-app updater (branch `ci/versionless-names-appimage`).
 
 ## [0.1.11] - 2026-07-06
 


### PR DESCRIPTION
## Summary
Add an explicit `linux` to the Linux release asset filenames for consistency with `mycat-windows-x64.exe` / `mycat-macos-*.zip`:
- `mycat-amd64.deb` → `mycat-linux-amd64.deb`
- `mycat-x86_64.AppImage` → `mycat-linux-x86_64.AppImage`

The `.deb` keeps its real version inside the control file. README/translation buttons already use the new names (#69). The 0.1.11 release assets are renamed to match (outside this PR).

## Test plan
- [x] YAML parses.
- [x] 0.1.11 release assets renamed; latest/download links updated.