### PR TITLE
docs(readme): uniform Download buttons, aligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,28 @@ Pick whichever is easiest — the cat runs on **Windows, macOS and Linux**.
 
 Grab the build for your OS — each button downloads the **latest release**:
 
-<p>
-  <a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-windows-x64.exe"><img src="https://img.shields.io/badge/Download-Windows-0078D6?logo=windows&logoColor=white" alt="Download for Windows"></a>
-  <br>
-  <a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-macos-arm64.zip"><img src="https://img.shields.io/badge/Download-macOS%20Apple%20Silicon-000000?logo=apple&logoColor=white" alt="Download for macOS (Apple Silicon)"></a>
-  <br>
-  <a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-macos-x64.zip"><img src="https://img.shields.io/badge/Download-macOS%20Intel-555555?logo=apple&logoColor=white" alt="Download for macOS (Intel)"></a>
-  <br>
-  <a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-Linux%20.deb-A81D33?logo=debian&logoColor=white" alt="Download Linux .deb"></a>
-  <br>
-  <a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-Linux%20AppImage-FCC624?logo=linux&logoColor=black" alt="Download Linux AppImage"></a>
-</p>
+<table>
+  <tr>
+    <td>🪟&nbsp;&nbsp;<b>Windows</b></td>
+    <td><a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-windows-x64.exe"><img src="https://img.shields.io/badge/Download-2ea44f?style=for-the-badge&logo=github&logoColor=white" alt="Download for Windows"></a></td>
+  </tr>
+  <tr>
+    <td>🍎&nbsp;&nbsp;<b>macOS</b> (Apple Silicon)</td>
+    <td><a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-macos-arm64.zip"><img src="https://img.shields.io/badge/Download-2ea44f?style=for-the-badge&logo=github&logoColor=white" alt="Download for macOS (Apple Silicon)"></a></td>
+  </tr>
+  <tr>
+    <td>🍎&nbsp;&nbsp;<b>macOS</b> (Intel)</td>
+    <td><a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-macos-x64.zip"><img src="https://img.shields.io/badge/Download-2ea44f?style=for-the-badge&logo=github&logoColor=white" alt="Download for macOS (Intel)"></a></td>
+  </tr>
+  <tr>
+    <td>🐧&nbsp;&nbsp;<b>Linux</b> (.deb)</td>
+    <td><a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-linux-amd64.deb"><img src="https://img.shields.io/badge/Download-2ea44f?style=for-the-badge&logo=github&logoColor=white" alt="Download Linux .deb"></a></td>
+  </tr>
+  <tr>
+    <td>🐧&nbsp;&nbsp;<b>Linux</b> (AppImage)</td>
+    <td><a href="https://github.com/yumiaura/myCat/releases/latest/download/mycat-linux-x86_64.AppImage"><img src="https://img.shields.io/badge/Download-2ea44f?style=for-the-badge&logo=github&logoColor=white" alt="Download Linux AppImage"></a></td>
+  </tr>
+</table>
 
 Then run it:
 


### PR DESCRIPTION
## Summary
Fixes the two things you flagged on the download buttons:
- **Windows had no icon** — shields dropped the Microsoft logo from simple-icons, so `logo=windows` rendered nothing. Now the platform is shown with an emoji icon (🪟 / 🍎 / 🐧) as the row label.
- **Uneven widths** — replaced the ragged per-platform badges with an aligned table: platform label on the left, an **identical green Download button** on the right. All buttons are the same size and the right column lines up.

README.md only for now — say the word and I'll bring the RU/CN/ID translations to the same layout.

## Test plan
- [x] Download badge renders (green, GitHub icon).
- [ ] Eyeball the rendered table on the PR.