### PR TITLE
Release 0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## Unreleased
+## [0.1.12] - 2026-07-06
 
 ### Added
 - **Prebuilt macOS Intel (x86_64) binary.** The release workflow now also builds `mycat-macos-x64.zip` on GitHub's Intel runner (`macos-15-intel`), alongside the existing Apple Silicon (`-macos-arm64`) and Windows builds, so Intel Macs get a native download (branches `ci/macos-intel-x64`, `fix/intel-runner-macos-15`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.11"
+version = "0.1.12"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Cut 0.1.12. Bumps `pyproject` to 0.1.12 and finalizes the CHANGELOG.

Ships everything merged since 0.1.11: in-app **Update…** self-updater, Linux **.deb** + **AppImage** builds, macOS **Intel** binary, version-less asset names, README **download buttons** + hide-to-tray.

## Test plan
- [x] Full suite `175 passed`; version reads 0.1.12.
- [ ] Tag `0.1.12` builds all 5 platforms + publishes PyPI (after merge).