### PR TITLE
Release 0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## Unreleased
+## [0.1.13] - 2026-07-07
 
 ### Changed
 - **Tray menu: a single Open/Close toggle, and Quit lives only in the tray.** The cat's right-click "Hide" is renamed **Close** (still tucks it into the tray). The tray entry now flips with state: **Open** when the cat is hidden, **Close** when it's on screen. **Quit** is only in the tray menu now (branch `feat/tray-open-close-menu`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.12"
+version = "0.1.13"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cut 0.1.13. Ships: tray Open/Close toggle + Quit only in tray, the cat-head app/tray icon (mycat/assets/icon.png), and a bundled emoji fallback font (no tofu on bare systems). Full suite 177 passed.