### PR TITLE
Windows self-update: ping (not timeout) so the relaunch actually happens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Fixed
+- **Windows self-update relaunch (again).** The swap script runs in a detached, console-less process, where `timeout` errors out — so the wait/retry delays never actually happened and the app closed without reopening. It now uses `ping` for the delays (works with no console) and retries the swap up to 30×, with a step-by-step `%TEMP%\mycat-update.log`. Since an update runs the *currently installed* version's code, this takes effect for updates **from 0.1.15 onward** (branch `fix/windows-update-relaunch`).
+
 ## [0.1.14] - 2026-07-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Changed
+- **Only Windows/macOS self-update; pip / `.deb` / AppImage are just notified.** "Update…" downloads and restarts automatically only on the Windows `.exe` and macOS `.app`. On pip, source, `.deb` and AppImage it now just says an update is available with how to get it (`pip install --upgrade mycat`, `git pull`, or "download the new .deb/AppImage") plus an **Open releases** link. The "you're up to date" message also links to the releases page (branch `fix/windows-update-relaunch`).
+
 ### Fixed
 - **Windows self-update relaunch (again).** The swap script runs in a detached, console-less process, where `timeout` errors out — so the wait/retry delays never actually happened and the app closed without reopening. It now uses `ping` for the delays (works with no console) and retries the swap up to 30×, with a step-by-step `%TEMP%\mycat-update.log`. Since an update runs the *currently installed* version's code, this takes effect for updates **from 0.1.15 onward** (branch `fix/windows-update-relaunch`).
 

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -1345,25 +1345,35 @@ class PixelCatWindow(QtWidgets.QWidget):
 
         threading.Thread(target=check, name="mycat-update-check", daemon=True).start()
 
+    def open_releases_box(self, title: str, text: str, informative: str) -> None:
+        """A message box with an 'Open releases' button linking to GitHub."""
+        box = QtWidgets.QMessageBox(self)
+        box.setWindowTitle(title)
+        box.setText(text)
+        box.setInformativeText(informative)
+        box.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
+        open_button = box.addButton("Open releases", QtWidgets.QMessageBox.ButtonRole.ActionRole)
+        box.addButton(QtWidgets.QMessageBox.StandardButton.Close)
+        box.exec()
+        if box.clickedButton() is open_button:
+            QtGui.QDesktopServices.openUrl(QtCore.QUrl(updater.RELEASES_PAGE))
+
     def on_update_checked(self, kind: str, current: str, latest: str) -> None:
         if not latest:
-            QtWidgets.QMessageBox.information(
-                self, "mycat", f"You're on the latest version ({current})."
+            # Up to date — reassure, and still offer the releases page.
+            self.open_releases_box(
+                "mycat", f"You're on the latest version ({current}). 🐱", "Everything's up to date."
             )
             return
         if not updater.can_self_update(kind):
-            command = updater.source_update_command()
-            box = QtWidgets.QMessageBox(self)
-            box.setWindowTitle("Update available")
-            box.setText(f"mycat {latest} is available (you have {current}).")
-            box.setInformativeText(f"Update with:\n\n    {command}")
-            box.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
-            open_button = box.addButton("Open releases", QtWidgets.QMessageBox.ButtonRole.ActionRole)
-            box.addButton(QtWidgets.QMessageBox.StandardButton.Close)
-            box.exec()
-            if box.clickedButton() is open_button:
-                QtGui.QDesktopServices.openUrl(QtCore.QUrl(updater.RELEASES_PAGE))
+            # pip / deb / AppImage / source: just tell them, with how-to + a link.
+            self.open_releases_box(
+                "Update available",
+                f"mycat {latest} is available (you have {current}).",
+                f"Update with:\n\n    {updater.update_hint(kind)}",
+            )
             return
+        # Windows / macOS: download the new build and restart.
         reply = QtWidgets.QMessageBox.question(
             self,
             "Update mycat",

--- a/mycat/updater.py
+++ b/mycat/updater.py
@@ -48,13 +48,18 @@ def install_kind() -> str:
 
 
 def can_self_update(kind: str) -> bool:
-    """True for the frozen kinds we can actually replace + relaunch."""
-    return kind in ("appimage", "deb", "macos", "windows")
+    """Kinds that download + swap + relaunch on their own. Only the Windows exe
+    and macOS .app; pip/deb/AppImage installs are only *told* an update exists
+    (their package manager / a fresh download should apply it)."""
+    return kind in ("macos", "windows")
 
 
-def source_update_command() -> str:
-    """How to update a non-frozen install: ``git pull`` from a git checkout,
-    else ``pip install --upgrade mycat``."""
+def update_hint(kind: str) -> str:
+    """A one-line 'how to update' for the kinds that don't self-update."""
+    if kind == "deb":
+        return "Download the new .deb from the releases page and install it."
+    if kind == "appimage":
+        return "Download the new AppImage from the releases page."
     if (Path(__file__).resolve().parent.parent / ".git").is_dir():
         return "git pull"
     return "pip install --upgrade mycat"
@@ -105,51 +110,19 @@ def download(url: str, dest: str, progress=None) -> None:
 
 
 def staging_path(kind: str) -> str:
-    """Where to download the new build before swapping it in.
-
-    For the AppImage we stage next to the running file so the final swap is an
-    atomic same-filesystem rename; everything else stages in the temp dir.
-    """
-    if kind == "appimage":
-        current = os.environ["APPIMAGE"]
-        return os.path.join(os.path.dirname(current), ".mycat-update.AppImage")
+    """Where to download the new build before swapping it in (temp dir)."""
     return os.path.join(tempfile.gettempdir(), asset_name(kind))
 
 
 def apply_and_relaunch(kind: str, downloaded: str) -> None:
     """Swap in ``downloaded`` and spawn the new build. The caller must quit the
     app immediately afterwards so the old process exits."""
-    if kind == "appimage":
-        apply_appimage(downloaded)
-    elif kind == "deb":
-        apply_deb(downloaded)
-    elif kind == "macos":
+    if kind == "macos":
         apply_macos(downloaded)
     elif kind == "windows":
         apply_windows(downloaded)
     else:
         raise ValueError(f"cannot self-update install kind {kind!r}")
-
-
-def apply_appimage(downloaded: str) -> None:
-    target = os.environ["APPIMAGE"]
-    make_executable(downloaded)
-    # Same directory as the running file -> atomic replace; the running mount
-    # keeps the old inode until this process exits.
-    os.replace(downloaded, target)
-    subprocess.Popen([target], close_fds=True, start_new_session=True)  # noqa: S603
-    logger.info("AppImage updated in place: %s", target)
-
-
-def apply_deb(downloaded: str) -> None:
-    # /usr/bin/mycat is root-owned: install through polkit. apt replaces the
-    # file in place; the running process keeps its old inode until it exits.
-    subprocess.run(  # noqa: S603
-        ["pkexec", "apt-get", "install", "-y", "--only-upgrade", "--allow-downgrades", downloaded],
-        check=True,
-    )
-    subprocess.Popen([sys.executable], close_fds=True, start_new_session=True)  # noqa: S603
-    logger.info("deb installed via pkexec; relaunching %s", sys.executable)
 
 
 def apply_macos(zip_path: str) -> None:
@@ -223,6 +196,7 @@ def apply_windows(downloaded: str) -> None:
 __all__ = [
     "install_kind",
     "can_self_update",
+    "update_hint",
     "asset_name",
     "asset_url",
     "download",

--- a/mycat/updater.py
+++ b/mycat/updater.py
@@ -180,29 +180,35 @@ def apply_windows(downloaded: str) -> None:
     pid = os.getpid()
     log = os.path.join(tempfile.gettempdir(), "mycat-update.log")
     script = os.path.join(tempfile.gettempdir(), "mycat-update.bat")
-    # Wait for this process to exit, then KEEP RETRYING the overwrite: a onefile
-    # build stays locked by its bootloader for a moment after the app PID is
-    # gone, so a single `move` right away fails and nothing relaunches. Retry for
-    # ~15 s, then start the (now updated) exe. Delayed expansion for the counter.
+    # Wait for this process (and its bootloader) to exit and release the exe, then
+    # KEEP RETRYING the overwrite: a onefile build stays locked for a moment after
+    # the app PID is gone, so a single `move` right away fails and nothing
+    # relaunches. Delays use `ping`, not `timeout`: this swapper runs detached with
+    # no console, and `timeout` errors out ("input redirection is not supported")
+    # without one — which was breaking the wait/retry loops entirely.
     body = (
         "@echo off\r\n"
         "setlocal enabledelayedexpansion\r\n"
         f'set "LOG={log}"\r\n'
-        'echo update swapper started > "%LOG%"\r\n'
+        f'set "NEW={downloaded}"\r\n'
+        f'set "EXE={exe}"\r\n'
+        'echo swapper started %DATE% %TIME% > "%LOG%"\r\n'
         ":wait\r\n"
         f'tasklist /FI "PID eq {pid}" 2>nul | find "{pid}" >nul\r\n'
-        "if not errorlevel 1 ( timeout /t 1 /nobreak >nul & goto wait )\r\n"
-        f'echo pid {pid} gone, swapping >> "%LOG%"\r\n'
+        "if not errorlevel 1 ( ping -n 2 127.0.0.1 >nul & goto wait )\r\n"
+        'echo app exited >> "%LOG%"\r\n'
         "set /a TRIES=0\r\n"
         ":swap\r\n"
-        f'move /Y "{downloaded}" "{exe}" >nul 2>>"%LOG%"\r\n'
-        "if not errorlevel 1 goto start\r\n"
+        'move /Y "%NEW%" "%EXE%" >nul 2>>"%LOG%"\r\n'
+        "if not errorlevel 1 goto launch\r\n"
         "set /a TRIES+=1\r\n"
-        "if !TRIES! LSS 15 ( timeout /t 1 /nobreak >nul & goto swap )\r\n"
-        'echo move failed after retries >> "%LOG%"\r\n'
-        ":start\r\n"
-        f'echo starting >> "%LOG%"\r\n'
-        f'start "" "{exe}"\r\n'
+        'echo move attempt !TRIES! failed >> "%LOG%"\r\n'
+        "if !TRIES! LSS 30 ( ping -n 2 127.0.0.1 >nul & goto swap )\r\n"
+        'echo gave up swapping after !TRIES! tries >> "%LOG%"\r\n'
+        ":launch\r\n"
+        'echo launching "%EXE%" >> "%LOG%"\r\n'
+        'start "" "%EXE%"\r\n'
+        'echo done >> "%LOG%"\r\n'
         'del "%~f0"\r\n'
     )
     with open(script, "w", encoding="utf-8") as handle:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -9,11 +9,18 @@ def test_install_kind_is_source_when_not_frozen():
 
 
 def test_can_self_update():
-    assert updater.can_self_update("appimage")
-    assert updater.can_self_update("deb")
+    # Only Windows/macOS download + relaunch; the rest just get notified.
     assert updater.can_self_update("macos")
     assert updater.can_self_update("windows")
+    assert not updater.can_self_update("appimage")
+    assert not updater.can_self_update("deb")
     assert not updater.can_self_update("source")
+
+
+def test_update_hint():
+    assert updater.update_hint("deb").lower().startswith("download")
+    assert "AppImage" in updater.update_hint("appimage")
+    assert updater.update_hint("source") in ("git pull", "pip install --upgrade mycat")
 
 
 def test_asset_names():
@@ -35,6 +42,6 @@ def test_staging_path_for_temp_kinds():
     assert updater.staging_path("deb").endswith("mycat-linux-amd64.deb")
 
 
-def test_source_update_command_is_git_pull_in_checkout():
+def test_update_hint_is_git_pull_in_checkout():
     # The test suite runs from the git checkout, so it should suggest git pull.
-    assert updater.source_update_command() == "git pull"
+    assert updater.update_hint("source") == "git pull"


### PR DESCRIPTION
## Summary
The Windows swap script runs in a **detached, console-less** process. There, `timeout` fails with *"input redirection is not supported"* and returns immediately, so the wait-for-exit and move-retry loops never actually waited — the app closed and nothing relaunched.

- Delays now use `ping -n 2 127.0.0.1 >nul` (works with no console).
- Retries the exe swap up to 30× until the bootloader releases the lock.
- Logs each step to `%TEMP%\mycat-update.log`.

**Note:** an update runs the *currently installed* version's updater code, so this fix takes effect for updates **from 0.1.15 onward** (0.1.13→0.1.14 and 0.1.14→0.1.15 ran the older, broken code).

## Test plan
- [x] ruff clean; updater tests pass; batch string renders correctly.
- [ ] On a real Windows 0.1.15 build: Update → downloads → app relaunches into the new version.