### PR TITLE
Release 0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## Unreleased
+## [0.1.15] - 2026-07-07
 
 ### Changed
 - **Only Windows/macOS self-update; pip / `.deb` / AppImage are just notified.** "Update…" downloads and restarts automatically only on the Windows `.exe` and macOS `.app`. On pip, source, `.deb` and AppImage it now just says an update is available with how to get it (`pip install --upgrade mycat`, `git pull`, or "download the new .deb/AppImage") plus an **Open releases** link. The "you're up to date" message also links to the releases page (branch `fix/windows-update-relaunch`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.14"
+version = "0.1.15"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cut 0.1.15. Ships the Windows self-update relaunch fix (ping, not timeout) and the update-flow rework: only Windows/macOS self-update; pip/deb/AppImage notify with a link; up-to-date links to releases. Full suite 182 passed.