### PR TITLE
Update check: don't report 'up to date' when the check failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Fixed
+- **"Update…" no longer poses as up-to-date when the check fails.** The version check catches *every* error (offline, or GitHub's unauthenticated API rate-limiting the IP) and used to fall through to "You're on the latest version" — so a failed check looked like good news and real updates were never offered. It now tells apart three outcomes: a reached-and-newer release (offer/notify), reached-and-current ("you're up to date"), and couldn't-reach ("Couldn't check for updates right now — try again in a bit"). (branch `fix/update-check-honest-message`)
+
 ## [0.1.15] - 2026-07-07
 
 ### Changed

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -509,7 +509,7 @@ def harden_pixmap(pixmap: QtGui.QPixmap, threshold: int = 128) -> QtGui.QPixmap:
 class UpdateSignals(QtCore.QObject):
     """Marshals the self-update worker threads back onto the GUI thread."""
 
-    checked = QtCore.Signal(str)          # latest tag if newer, else ""
+    checked = QtCore.Signal(str)          # latest release tag, or "" if the check couldn't reach GitHub
     progress = QtCore.Signal(int, int)    # bytes done, total (0 = unknown)
     applied = QtCore.Signal()             # new build swapped in + spawned
     failed = QtCore.Signal(str)           # error message
@@ -1338,8 +1338,11 @@ class PixelCatWindow(QtWidgets.QWidget):
         signals.failed.connect(self.on_update_failed)
 
         def check() -> None:
+            # Emit the raw latest tag (or "" when GitHub couldn't be reached) and
+            # let on_update_checked decide up-to-date vs. newer vs. check-failed —
+            # so a rate-limited/offline check never poses as "you're up to date".
             try:
-                signals.checked.emit(update_check.newer_release(current) or "")
+                signals.checked.emit(update_check.latest_release_tag() or "")
             except Exception as exc:  # noqa: BLE001 - surfaced to the user
                 signals.failed.emit(str(exc))
 
@@ -1360,6 +1363,17 @@ class PixelCatWindow(QtWidgets.QWidget):
 
     def on_update_checked(self, kind: str, current: str, latest: str) -> None:
         if not latest:
+            # The check couldn't reach GitHub (offline, or the API rate-limited
+            # this IP). Don't claim we're up to date — say the check failed and
+            # point at the releases page so they can look for themselves.
+            self.open_releases_box(
+                "Update check",
+                "Couldn't check for updates right now.",
+                "GitHub may be unreachable or rate-limited — try again in a bit, "
+                "or open the releases page to check by hand.",
+            )
+            return
+        if update_check.parse_version(latest) <= update_check.parse_version(current):
             # Up to date — reassure, and still offer the releases page.
             self.open_releases_box(
                 "mycat", f"You're on the latest version ({current}). 🐱", "Everything's up to date."


### PR DESCRIPTION
## Summary
The in-app version check catches **every** failure (offline, GitHub's unauthenticated API rate-limiting the IP, TLS) and returned `None`. The GUI treated `None` as "no newer version" and showed **"You're on the latest version (X)"** — so a *failed* check looked like reassurance and a real update was never offered. This is the reported "says you're on the latest 0.1.12 while 0.1.15 exists" symptom (reproduced here as an HTTP 403 rate-limit).

Now `open_update` emits the raw latest tag (or `""` when GitHub couldn't be reached), and `on_update_checked` splits three outcomes:
- **reached & newer** → offer self-update (win/mac) or notify + link (pip/deb/appimage)
- **reached & current** → "You're on the latest version 🐱"
- **couldn't reach** → "Couldn't check for updates right now — try again in a bit" + releases link

No behaviour change when the check succeeds. Forward-only: takes effect for builds from the next release onward.

## Test plan
- [x] `ruff check mycat/main.py` clean
- [x] full suite: 182 passed
- [ ] Olya confirms the wording / whether to also add certifi (frozen-build TLS)