### PR TITLE
Release 0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## Unreleased
+## [0.1.16] - 2026-07-07
 
 ### Fixed
 - **"Update…" no longer poses as up-to-date when the check fails.** The version check catches *every* error (offline, or GitHub's unauthenticated API rate-limiting the IP) and used to fall through to "You're on the latest version" — so a failed check looked like good news and real updates were never offered. It now tells apart three outcomes: a reached-and-newer release (offer/notify), reached-and-current ("you're up to date"), and couldn't-reach ("Couldn't check for updates right now — try again in a bit"). (branch `fix/update-check-honest-message`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.15"
+version = "0.1.16"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cut 0.1.16. Ships the update-check honest-message fix: a failed check no longer reports 'You're on the latest version'. Full suite 182 passed.