### PR TITLE
Add AI-generated custom characters from reference images

### DIFF
--- a/docs/CHARS.md
+++ b/docs/CHARS.md
@@ -1,5 +1,28 @@
 # Make your own mycat char
 
+## Generate a custom chibi cat with OpenAI
+
+Right-click the desktop cat and choose **Chars → Create custom with AI…**. Add
+one to three reference photos of the same person, enter a character name and an
+OpenAI API key, then generate. myCat sends resized copies of the references in
+one Image API request and stores only the resulting character pack locally;
+selecting the saved character later does not call the API again.
+
+Use **Additional details** for optional visual direction such as glasses,
+accessories, colors, poses, or requested lettering on clothing. These details
+are included in the same generation request, so they do not create an extra API
+call.
+
+Generated characters appear beside the bundled characters. Remove one with
+**Chars → Delete custom**. Deleting is local and does not make an API request.
+The key can be remembered in the operating-system keyring when the optional
+`mycat[secure]` dependency and a supported keyring backend are available;
+otherwise use `OPENAI_API_KEY` or enter it for each generation.
+
+The generator uses `gpt-image-1.5` because these packs need a transparent PNG
+background. Reference photos are resized in memory to reduce image-input usage
+and are not copied to the myCat data directory.
+
 A char is a single `<name>.zip`. The simplest is one animated **GIF** - see the
 Quick start below. The full format turns the cat into a small **state machine**:
 a base "awake" pose whose pupils follow the cursor, plus optional expressions and

--- a/mycat/ai_char.py
+++ b/mycat/ai_char.py
@@ -1,0 +1,241 @@
+"""Generate a persistent myCat character from 1-3 reference photos.
+
+Only the generated PNG is stored in the final char pack.  Reference photos are
+resized in memory before upload and are never copied into myCat's data folder.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import os
+import re
+import unicodedata
+import urllib.error
+import urllib.request
+import uuid
+import zipfile
+from pathlib import Path
+
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+from . import char_catalog
+
+API_URL = "https://api.openai.com/v1/images/edits"
+MODEL = "gpt-image-1.5"
+MAX_REFERENCES = 3
+MAX_REFERENCE_EDGE = 1536
+MAX_ADDITIONAL_INSTRUCTIONS = 2000
+TIMEOUT_SECONDS = 180.0
+SECRET_NAME = "openai_image_api_key"
+
+PROMPT = """Create one original desktop companion character inspired by the same person in the reference photos.
+Transform their recognizable hair, colors, outfit details, and overall vibe into a cute chibi kitten girl: clearly a
+small feline character with cat ears, paws, tail, whiskers, and a compact full body. Preserve identity cues without
+making a photorealistic portrait. Polished kawaii digital illustration, expressive friendly pose, clean silhouette,
+soft shading, centered, full character fully visible, no crop, no props, no scenery, no frame, no logo. Do not add
+writing unless the user's additional visual instructions explicitly request it.
+Isolate the character on a truly transparent background with clean alpha edges. This will be a small always-on-top
+desktop mascot, so prioritize readability at thumbnail size."""
+
+
+class AICharError(RuntimeError):
+    """A user-facing generation or packaging error."""
+
+
+def slugify(name: str) -> str:
+    """Return a conservative char id that is safe as a file name."""
+    normalized = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii").lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", normalized).strip("-")
+    if not slug:
+        raise AICharError("Enter a name containing at least one letter or number.")
+    return f"custom-{slug[:48]}"
+
+
+def _reference_png(path: Path) -> bytes:
+    try:
+        with Image.open(path) as source:
+            image = ImageOps.exif_transpose(source).convert("RGB")
+    except (OSError, UnidentifiedImageError) as exc:
+        raise AICharError(f"Cannot read image: {path.name}") from exc
+    image.thumbnail((MAX_REFERENCE_EDGE, MAX_REFERENCE_EDGE), Image.Resampling.LANCZOS)
+    output = io.BytesIO()
+    image.save(output, "PNG", optimize=True)
+    return output.getvalue()
+
+
+def prepare_references(paths: list[Path]) -> list[tuple[str, bytes]]:
+    if not 1 <= len(paths) <= MAX_REFERENCES:
+        raise AICharError("Choose between 1 and 3 reference images.")
+    return [(f"reference-{index}.png", _reference_png(Path(path))) for index, path in enumerate(paths, 1)]
+
+
+def build_prompt(additional_instructions: str = "") -> str:
+    """Append optional visual direction without weakening pack requirements."""
+    details = additional_instructions.strip()
+    if len(details) > MAX_ADDITIONAL_INSTRUCTIONS:
+        raise AICharError(f"Additional details must be {MAX_ADDITIONAL_INSTRUCTIONS} characters or fewer.")
+    if not details:
+        return PROMPT
+    return (
+        f"{PROMPT}\n\n"
+        "Additional visual instructions from the user (apply these carefully while preserving the transparent "
+        "background, full-body composition, and chibi kitten design):\n"
+        f"{details}"
+    )
+
+
+def _multipart(fields: dict[str, str], images: list[tuple[str, bytes]]) -> tuple[bytes, str]:
+    boundary = f"mycat-{uuid.uuid4().hex}"
+    body = io.BytesIO()
+
+    def write(value: bytes) -> None:
+        body.write(value)
+        body.write(b"\r\n")
+
+    for name, value in fields.items():
+        write(f"--{boundary}".encode())
+        write(f'Content-Disposition: form-data; name="{name}"'.encode())
+        write(b"")
+        write(value.encode("utf-8"))
+    for filename, data in images:
+        write(f"--{boundary}".encode())
+        write(f'Content-Disposition: form-data; name="image[]"; filename="{filename}"'.encode())
+        write(b"Content-Type: image/png")
+        write(b"")
+        write(data)
+    body.write(f"--{boundary}--\r\n".encode())
+    return body.getvalue(), f"multipart/form-data; boundary={boundary}"
+
+
+def request_image(
+    api_key: str,
+    references: list[tuple[str, bytes]],
+    *,
+    quality: str = "low",
+    additional_instructions: str = "",
+) -> bytes:
+    if not api_key.strip():
+        raise AICharError("Enter an OpenAI API key or set OPENAI_API_KEY.")
+    if quality not in {"low", "medium"}:
+        raise AICharError("Unsupported image quality.")
+    body, content_type = _multipart(
+        {
+            "model": MODEL,
+            "prompt": build_prompt(additional_instructions),
+            "size": "1024x1536",
+            "quality": quality,
+            "background": "transparent",
+            "output_format": "png",
+            "input_fidelity": "high",
+        },
+        references,
+    )
+    request = urllib.request.Request(
+        API_URL,
+        data=body,
+        headers={"Authorization": f"Bearer {api_key.strip()}", "Content-Type": content_type},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace") if exc.fp else str(exc.reason)
+        try:
+            parsed = json.loads(detail)
+            detail = parsed.get("error", {}).get("message") or detail
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        raise AICharError(f"OpenAI error ({exc.code}): {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise AICharError(f"Could not reach OpenAI: {exc.reason}") from exc
+    except (TimeoutError, OSError) as exc:
+        raise AICharError(f"Image generation failed: {exc}") from exc
+
+    try:
+        payload = json.loads(raw)
+        encoded = payload["data"][0]["b64_json"]
+        result = base64.b64decode(encoded, validate=True)
+        with Image.open(io.BytesIO(result)) as image:
+            image.verify()
+    except (KeyError, IndexError, TypeError, ValueError, json.JSONDecodeError, UnidentifiedImageError) as exc:
+        raise AICharError("OpenAI returned an invalid image response.") from exc
+    return result
+
+
+def _normalized_character_png(image_bytes: bytes) -> bytes:
+    with Image.open(io.BytesIO(image_bytes)) as source:
+        image = source.convert("RGBA")
+    alpha_box = image.getchannel("A").getbbox()
+    if alpha_box:
+        image = image.crop(alpha_box)
+    image.thumbnail((600, 900), Image.Resampling.LANCZOS)
+    output = io.BytesIO()
+    image.save(output, "PNG", optimize=True)
+    return output.getvalue()
+
+
+def install_character(display_name: str, image_bytes: bytes) -> tuple[str, Path]:
+    char_id = slugify(display_name)
+    destination = char_catalog.ensure_user_chars_dir() / f"{char_id}.zip"
+    temporary = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+    config = {
+        "name": display_name.strip(),
+        "max_width": 240,
+        "max_height": 400,
+        "blink": {"enabled": False},
+    }
+    png = _normalized_character_png(image_bytes)
+    try:
+        with zipfile.ZipFile(temporary, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr("static.png", png)
+            archive.writestr("config.json", json.dumps(config, ensure_ascii=False, indent=2))
+        os.replace(temporary, destination)
+    except (OSError, RuntimeError, ValueError, zipfile.BadZipFile) as exc:
+        raise AICharError(f"Could not save the character: {exc}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+    char_catalog.record_installed(
+        char_id,
+        version="1",
+        source="openai:image",
+        sha256=hashlib.sha256(destination.read_bytes()).hexdigest(),
+        size_bytes=destination.stat().st_size,
+    )
+    return char_id, destination
+
+
+def generate_character(
+    display_name: str,
+    reference_paths: list[Path],
+    api_key: str | None = None,
+    *,
+    quality: str = "low",
+    additional_instructions: str = "",
+) -> tuple[str, Path]:
+    references = prepare_references(reference_paths)
+    generated = request_image(
+        api_key or os.getenv("OPENAI_API_KEY", ""),
+        references,
+        quality=quality,
+        additional_instructions=additional_instructions,
+    )
+    return install_character(display_name, generated)
+
+
+__all__ = [
+    "AICharError",
+    "MAX_REFERENCES",
+    "MAX_ADDITIONAL_INSTRUCTIONS",
+    "MODEL",
+    "SECRET_NAME",
+    "generate_character",
+    "build_prompt",
+    "install_character",
+    "prepare_references",
+    "request_image",
+    "slugify",
+]

--- a/mycat/ai_char_ui.py
+++ b/mycat/ai_char_ui.py
@@ -1,0 +1,227 @@
+"""Qt dialog for creating a custom AI-generated desktop character."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from . import ai_char, char_catalog, secret_store
+from .ui_theme import LIGHT_QSS
+
+
+class GenerationSignals(QtCore.QObject):
+    completed = QtCore.Signal(str, str)
+    failed = QtCore.Signal(str)
+
+
+class GenerationWorker(QtCore.QRunnable):
+    def __init__(
+        self,
+        name: str,
+        paths: list[Path],
+        api_key: str,
+        quality: str,
+        additional_instructions: str = "",
+    ) -> None:
+        super().__init__()
+        self.name = name
+        self.paths = paths
+        self.api_key = api_key
+        self.quality = quality
+        self.additional_instructions = additional_instructions
+        self.signals = GenerationSignals()
+
+    def run(self) -> None:
+        try:
+            char_id, path = ai_char.generate_character(
+                self.name,
+                self.paths,
+                self.api_key,
+                quality=self.quality,
+                additional_instructions=self.additional_instructions,
+            )
+        except Exception as exc:  # noqa: BLE001 - error is shown in the dialog
+            self.signals.failed.emit(str(exc))
+        else:
+            self.signals.completed.emit(char_id, str(path))
+
+
+class AICharDialog(QtWidgets.QDialog):
+    character_created = QtCore.Signal(str)
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Create a custom cat with AI")
+        self.setMinimumWidth(520)
+        self.setStyleSheet(LIGHT_QSS)
+        self.pool = QtCore.QThreadPool(self)
+        self.reference_paths: list[Path] = []
+
+        intro = QtWidgets.QLabel(
+            "Choose 1–3 photos of the same person. OpenAI will turn their visual features "
+            "into one chibi kitten desktop character. The reference photos are not stored by myCat."
+        )
+        intro.setWordWrap(True)
+
+        self.name_edit = QtWidgets.QLineEdit()
+        self.name_edit.setPlaceholderText("Example: Mina chibi cat")
+        self.key_edit = QtWidgets.QLineEdit()
+        self.key_edit.setEchoMode(QtWidgets.QLineEdit.EchoMode.Password)
+        saved_key = secret_store.get_secret(ai_char.SECRET_NAME)
+        self.key_edit.setText(saved_key or os.getenv("OPENAI_API_KEY", ""))
+        self.key_edit.setPlaceholderText("sk-… (or OPENAI_API_KEY)")
+
+        self.remember_box = QtWidgets.QCheckBox("Remember key in the operating system keyring")
+        self.remember_box.setChecked(bool(saved_key))
+        self.remember_box.setEnabled(secret_store.keyring_available())
+        if not self.remember_box.isEnabled():
+            self.remember_box.setToolTip("Install mycat[secure] and configure an OS keyring to enable this.")
+
+        self.quality_combo = QtWidgets.QComboBox()
+        self.quality_combo.addItem("Low — lower cost, recommended for a desktop mascot", "low")
+        self.quality_combo.addItem("Medium — more detail, higher cost", "medium")
+
+        self.details_edit = QtWidgets.QPlainTextEdit()
+        self.details_edit.setPlaceholderText(
+            'Optional. Example: "Add round glasses and make the blouse say LOVE in red letters."'
+        )
+        self.details_edit.setMaximumHeight(90)
+        self.details_edit.setToolTip(
+            f"Optional visual instructions, up to {ai_char.MAX_ADDITIONAL_INSTRUCTIONS} characters."
+        )
+
+        self.reference_list = QtWidgets.QListWidget()
+        self.reference_list.setIconSize(QtCore.QSize(64, 64))
+        self.reference_list.setMinimumHeight(110)
+        add_btn = QtWidgets.QPushButton("Add photos…")
+        remove_btn = QtWidgets.QPushButton("Remove selected")
+        add_btn.clicked.connect(self.add_references)
+        remove_btn.clicked.connect(self.remove_selected)
+        photo_buttons = QtWidgets.QHBoxLayout()
+        photo_buttons.addWidget(add_btn)
+        photo_buttons.addWidget(remove_btn)
+        photo_buttons.addStretch(1)
+
+        form = QtWidgets.QFormLayout()
+        form.addRow("Character name", self.name_edit)
+        form.addRow("OpenAI API key", self.key_edit)
+        form.addRow("", self.remember_box)
+        form.addRow("Quality", self.quality_combo)
+        form.addRow("Additional details", self.details_edit)
+
+        self.status_label = QtWidgets.QLabel("")
+        self.status_label.setWordWrap(True)
+        self.generate_btn = QtWidgets.QPushButton("Generate and save")
+        close_btn = QtWidgets.QPushButton("Close")
+        self.generate_btn.clicked.connect(self.generate)
+        close_btn.clicked.connect(self.reject)
+        buttons = QtWidgets.QHBoxLayout()
+        buttons.addStretch(1)
+        buttons.addWidget(self.generate_btn)
+        buttons.addWidget(close_btn)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(intro)
+        layout.addLayout(form)
+        layout.addWidget(QtWidgets.QLabel("Reference photos (maximum 3)"))
+        layout.addWidget(self.reference_list)
+        layout.addLayout(photo_buttons)
+        layout.addWidget(self.status_label)
+        layout.addLayout(buttons)
+
+    def set_status(self, text: str, *, error: bool = False) -> None:
+        self.status_label.setStyleSheet("color: #c0392b;" if error else "color: #555555;")
+        self.status_label.setText(text)
+
+    def add_references(self) -> None:
+        remaining = ai_char.MAX_REFERENCES - len(self.reference_paths)
+        if remaining <= 0:
+            self.set_status("You already selected the maximum of 3 photos.", error=True)
+            return
+        names, _ = QtWidgets.QFileDialog.getOpenFileNames(
+            self,
+            "Choose reference photos",
+            "",
+            "Images (*.png *.jpg *.jpeg *.webp);;All files (*)",
+        )
+        for name in names[:remaining]:
+            path = Path(name)
+            if path in self.reference_paths:
+                continue
+            self.reference_paths.append(path)
+            icon = QtGui.QIcon(str(path))
+            item = QtWidgets.QListWidgetItem(icon, path.name)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, str(path))
+            item.setToolTip(str(path))
+            self.reference_list.addItem(item)
+        if len(names) > remaining:
+            self.set_status("Only the first 3 photos were added.")
+
+    def remove_selected(self) -> None:
+        for item in self.reference_list.selectedItems():
+            path = Path(item.data(QtCore.Qt.ItemDataRole.UserRole))
+            if path in self.reference_paths:
+                self.reference_paths.remove(path)
+            self.reference_list.takeItem(self.reference_list.row(item))
+
+    def generate(self) -> None:
+        name = self.name_edit.text().strip()
+        key = self.key_edit.text().strip() or os.getenv("OPENAI_API_KEY", "")
+        try:
+            char_id = ai_char.slugify(name)
+        except ai_char.AICharError as exc:
+            self.set_status(str(exc), error=True)
+            return
+        if not self.reference_paths:
+            self.set_status("Choose at least one reference photo.", error=True)
+            return
+        if not key:
+            self.set_status("Enter an OpenAI API key.", error=True)
+            return
+        details = self.details_edit.toPlainText().strip()
+        try:
+            ai_char.build_prompt(details)
+        except ai_char.AICharError as exc:
+            self.set_status(str(exc), error=True)
+            return
+        if char_catalog.find_char(char_id) is not None:
+            answer = QtWidgets.QMessageBox.question(
+                self,
+                "Replace character?",
+                f'A character named "{char_id}" already exists. Replace it with a new generation?',
+            )
+            if answer != QtWidgets.QMessageBox.StandardButton.Yes:
+                return
+        if self.remember_box.isChecked():
+            if not secret_store.set_secret(ai_char.SECRET_NAME, key):
+                self.set_status("The keyring could not save the key. Generation will continue.", error=True)
+        elif secret_store.get_secret(ai_char.SECRET_NAME):
+            secret_store.delete_secret(ai_char.SECRET_NAME)
+
+        self.generate_btn.setEnabled(False)
+        self.set_status("Generating… this can take up to two minutes. One API request will be charged.")
+        worker = GenerationWorker(
+            name,
+            list(self.reference_paths),
+            key,
+            self.quality_combo.currentData(),
+            details,
+        )
+        worker.signals.completed.connect(self.on_completed)
+        worker.signals.failed.connect(self.on_failed)
+        self.pool.start(worker)
+
+    def on_completed(self, char_id: str, _path: str) -> None:
+        self.generate_btn.setEnabled(True)
+        self.set_status("Saved. Reusing this character does not call the API again.")
+        self.character_created.emit(char_id)
+        self.accept()
+
+    def on_failed(self, message: str) -> None:
+        self.generate_btn.setEnabled(True)
+        self.set_status(message, error=True)
+
+
+__all__ = ["AICharDialog", "GenerationWorker"]

--- a/mycat/char_catalog.py
+++ b/mycat/char_catalog.py
@@ -156,6 +156,15 @@ def is_user_installed(char_id: str) -> bool:
     return (user_chars_dir() / f"{char_id}.zip").exists()
 
 
+def ai_generated_chars() -> list[str]:
+    """Ids of locally generated characters, based on installed metadata."""
+    return sorted(
+        entry["id"]
+        for entry in load_installed_metadata().get("characters", [])
+        if entry.get("source") == "openai:image" and entry.get("id") and is_user_installed(entry["id"])
+    )
+
+
 __all__ = [
     "INSTALLED_JSON_NAME",
     "bundled_chars_dir",
@@ -169,4 +178,5 @@ __all__ = [
     "record_installed",
     "remove_installed",
     "is_user_installed",
+    "ai_generated_chars",
 ]

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -1187,6 +1187,17 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.available_images = char_catalog.scan_all()
         if len(self.available_images) > 0:
             images_menu = menu.addMenu("Chars")
+            create_action = images_menu.addAction("Create custom with AI…")
+            create_action.triggered.connect(self.open_ai_char)
+            generated_chars = char_catalog.ai_generated_chars()
+            if generated_chars:
+                delete_menu = images_menu.addMenu("Delete custom")
+                for custom_id in generated_chars:
+                    delete_action = delete_menu.addAction(custom_id)
+                    delete_action.triggered.connect(
+                        lambda checked=False, name=custom_id: self.delete_ai_char(name)
+                    )
+            images_menu.addSeparator()
             for img_name in self.available_images:
                 action = images_menu.addAction(img_name)
                 if img_name == self.file_name:
@@ -1218,6 +1229,41 @@ class PixelCatWindow(QtWidgets.QWidget):
             quit_action = menu.addAction("Quit")
             quit_action.triggered.connect(QtWidgets.QApplication.quit)
         menu.exec(self.mapToGlobal(pos))
+
+    def open_ai_char(self) -> None:
+        """Open the reference-photo generator and select its saved result."""
+        try:
+            if __package__:
+                from .ai_char_ui import AICharDialog
+            else:
+                import importlib
+
+                AICharDialog = importlib.import_module("mycat.ai_char_ui").AICharDialog
+            dialog = AICharDialog(self)
+            dialog.character_created.connect(self._load_image)
+            dialog.exec()
+        except Exception as exc:  # noqa: BLE001 - keep the desktop companion alive
+            logger.exception("Failed to open AI character generator")
+            QtWidgets.QMessageBox.warning(self, "AI character", str(exc))
+
+    def delete_ai_char(self, char_id: str) -> None:
+        """Delete a generated pack locally; this never makes an API request."""
+        answer = QtWidgets.QMessageBox.question(
+            self,
+            "Delete custom character?",
+            f'Delete "{char_id}" from this computer? This cannot be undone.',
+        )
+        if answer != QtWidgets.QMessageBox.StandardButton.Yes:
+            return
+        was_active = self.file_name == char_id
+        if not char_catalog.remove_installed(char_id):
+            QtWidgets.QMessageBox.warning(self, "Delete custom character", "The character could not be deleted.")
+            return
+        self.available_images = char_catalog.scan_all()
+        if was_active:
+            fallback = "cat" if char_catalog.find_char("cat") else next(iter(self.available_images), "")
+            if fallback:
+                self._load_image(fallback)
 
     def open_llm_settings(self) -> None:
         """Open the LLM vendor settings dialog (vendor, model, test, save)."""

--- a/tests/test_ai_char.py
+++ b/tests/test_ai_char.py
@@ -1,0 +1,97 @@
+"""AI character generation: validation, API request, and local persistence."""
+
+import base64
+import io
+import json
+import zipfile
+
+import pytest
+from PIL import Image
+
+from mycat import ai_char, char_catalog
+
+
+def png_bytes(size=(40, 60), color=(200, 100, 80, 255)):
+    output = io.BytesIO()
+    Image.new("RGBA", size, color).save(output, "PNG")
+    return output.getvalue()
+
+
+def test_slugify_is_safe_and_namespaced():
+    assert ai_char.slugify("Jennie Gatita!") == "custom-jennie-gatita"
+    with pytest.raises(ai_char.AICharError):
+        ai_char.slugify("✨")
+
+
+def test_prepare_references_accepts_one_to_three_and_resizes(tmp_path):
+    paths = []
+    for index in range(3):
+        path = tmp_path / f"photo-{index}.jpg"
+        Image.new("RGB", (2000, 1000), (index, 20, 30)).save(path, "JPEG")
+        paths.append(path)
+    prepared = ai_char.prepare_references(paths)
+    assert len(prepared) == 3
+    with Image.open(io.BytesIO(prepared[0][1])) as image:
+        assert max(image.size) == ai_char.MAX_REFERENCE_EDGE
+    with pytest.raises(ai_char.AICharError):
+        ai_char.prepare_references([])
+    with pytest.raises(ai_char.AICharError):
+        ai_char.prepare_references(paths + [paths[0]])
+
+
+def test_build_prompt_adds_optional_visual_details():
+    prompt = ai_char.build_prompt("Add round glasses and red LOVE lettering on the blouse.")
+    assert "round glasses" in prompt
+    assert "red LOVE lettering" in prompt
+    assert "transparent background" in prompt
+    assert ai_char.build_prompt("  ") == ai_char.PROMPT
+    with pytest.raises(ai_char.AICharError):
+        ai_char.build_prompt("x" * (ai_char.MAX_ADDITIONAL_INSTRUCTIONS + 1))
+
+
+def test_request_image_sends_all_references(monkeypatch):
+    generated = png_bytes()
+    captured = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return json.dumps({"data": [{"b64_json": base64.b64encode(generated).decode()}]}).encode()
+
+    def fake_urlopen(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr(ai_char.urllib.request, "urlopen", fake_urlopen)
+    result = ai_char.request_image(
+        "secret",
+        [("a.png", generated), ("b.png", generated)],
+        additional_instructions="Add glasses and red lettering.",
+    )
+    assert result == generated
+    body = captured["request"].data
+    assert body.count(b'name="image[]"') == 2
+    assert b'name="model"' in body and ai_char.MODEL.encode() in body
+    assert b'name="background"' in body and b"transparent" in body
+    assert b"Add glasses and red lettering." in body
+    assert captured["request"].get_header("Authorization") == "Bearer secret"
+
+
+def test_install_and_delete_generated_character(monkeypatch, tmp_path):
+    monkeypatch.setattr(char_catalog, "user_chars_dir", lambda: tmp_path)
+    char_id, path = ai_char.install_character("Mina Cat", png_bytes())
+    assert char_id == "custom-mina-cat"
+    assert path.exists()
+    with zipfile.ZipFile(path) as archive:
+        assert set(archive.namelist()) == {"static.png", "config.json"}
+        assert json.loads(archive.read("config.json"))["name"] == "Mina Cat"
+    assert char_catalog.ai_generated_chars() == [char_id]
+    assert char_catalog.remove_installed(char_id) is True
+    assert not path.exists()
+    assert char_catalog.ai_generated_chars() == []


### PR DESCRIPTION
## Summary

Adds an opt-in workflow for generating custom myCat characters from one to three reference images with the OpenAI Image API.

Users can:

- select 1–3 reference images of the same person;
- add optional visual instructions such as glasses, colors, accessories, or lettering;
- choose low or medium generation quality;
- save and reuse the result as a standard local character pack; and
- delete AI-generated characters without affecting bundled or shop characters.

## Motivation

Creating a valid character pack currently requires manually preparing images and ZIP contents. This provides an accessible path for users who want a personal desktop companion while keeping compatibility with the existing character-pack loader.

## Privacy and API usage

- No request is made until the user clicks **Generate and save**.
- Reference images are resized in memory and are not copied into myCat's data directory.
- One Image API request is made per generation; optional visual details are part of that same request.
- Reusing, selecting, or deleting a saved character does not call the API.
- The API key can be stored in the optional operating-system keyring and is never included in generated packs.

## Implementation

- Uses the OpenAI image edits endpoint with multiple reference images.
- Requests a transparent PNG and packages it as `static.png` plus `config.json`.
- Uses atomic file replacement to avoid corrupting an existing character.
- Runs generation outside the Qt UI thread.
- Adds no required OpenAI SDK dependency; the request uses the Python standard library.
- Tracks generated characters through the existing installed-character metadata.

## Validation

- `ruff check mycat tests`
- `pytest -q`: **188 passed, 3 skipped**
- macOS arm64 PyInstaller build and offscreen startup smoke test

## Screenshots
### Generated desktop character
<img width="460" height="460" alt="235065808" src="https://github.com/user-attachments/assets/971177d9-1de9-41f2-9348-c66f143eccab" />

  <img width="264" alt="Captura de pantalla 2026-07-09 a la(s) 4 07 32 p m" src="https://github.com/user-attachments/assets/1bec007a-eb5c-469a-a732-a1cd37c6cf27" />

<img width="580" height="723" alt="Captura de pantalla 2026-07-09 a la(s) 4 19 39 p m" src="https://github.com/user-attachments/assets/f94c141f-d339-4827-a476-a5725e27c9be" />

  <img width="420" alt="image" src="https://github.com/user-attachments/assets/848ff041-55b0-417c-aaf7-2759cc6a6c9a" />
  <img width="555" alt="Captura de pantalla 2026-07-09 a la(s) 4 51 43 p m" src="https://github.com/user-attachments/assets/6a67eb02-8ec0-4da9-a93c-0a16543f3679" />

## Notes for reviewers

The feature is completely opt-in and does not change startup behavior or make background API requests.
