### PR TITLE
release: mycat 0.1.17 — AI custom characters + Windows update fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased]
+## [0.1.17] - 2026-07-11
+
+### Added
+- **Create a custom cat with AI, from your own photos.** Right-click → *Chars → Create custom with AI…*, pick 1–3 reference photos of the same person plus optional visual details (glasses, colours, a bit of lettering), and OpenAI's image model turns them into a chibi cat character saved as an ordinary local char you can reuse or delete. Opt-in and privacy-conscious: no request until you click *Generate and save*, reference photos are resized in memory and never stored, and your OpenAI key can live in the OS keyring (never in the generated pack). No new required dependency — the request uses the standard library (feature by @sts19813, #89).
 
 ### Fixed
 - **Windows self-update no longer hangs on a black window.** After downloading the new build, the app called `QApplication.quit()` from inside the progress dialog's modal event loop — which doesn't break it, so the process never exited, and the update swapper waited forever for the old PID to vanish (the visible `find "<pid>"` console). The app now hard-exits after launching the swapper, so the swap + relaunch always completes. The swapper also runs with a hidden console (`CREATE_NO_WINDOW`) instead of `DETACHED_PROCESS`, so no black window flashes up or lingers (branch `fix/windows-update-hang`).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you like it, maybe I'll share an [AnimeGirl](https://github.com/yumiaura/myca
 <img width="280" height="200" alt="image" src="https://github.com/user-attachments/assets/0a1d078e-77f4-4f16-a09f-a94c5deff086" />
 <img width="280" height="200" alt="image" src="https://github.com/user-attachments/assets/d9f4cce9-bf3c-4d64-a28e-1cac7d050a8c" />
 
-### Create your own cat with AI 🎨
+### 🎨 Create your own cat with AI 
 
 Turn a few photos into your own cat. Right-click → **Chars → Create custom with AI…**,
 add 1–3 photos of the same person plus any optional details (glasses, colours, a bit of
@@ -39,8 +39,6 @@ image request.
 <br />
 <img width="270" alt="Generated cat on the desktop" src="https://github.com/user-attachments/assets/848ff041-55b0-417c-aaf7-2759cc6a6c9a" />
 <img width="220" alt="Generated cat" src="https://github.com/user-attachments/assets/1bec007a-eb5c-469a-a732-a1cd37c6cf27" />
-
-
 
 ## 🚀 Quick start
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ If you like it, maybe I'll share an [AnimeGirl](https://github.com/yumiaura/myca
 <img width="280" height="200" alt="image" src="https://github.com/user-attachments/assets/0a1d078e-77f4-4f16-a09f-a94c5deff086" />
 <img width="280" height="200" alt="image" src="https://github.com/user-attachments/assets/d9f4cce9-bf3c-4d64-a28e-1cac7d050a8c" />
 
+### Create your own cat with AI 🎨
+
+Turn a few photos into your own cat. Right-click → **Chars → Create custom with AI…**,
+add 1–3 photos of the same person plus any optional details (glasses, colours, a bit of
+lettering), and OpenAI turns them into a chibi cat character. It's saved as an ordinary
+local char you can reuse or delete anytime — the reference photos are resized in memory
+and **never stored** by myCat. Bring your own OpenAI API key; each generation is a single
+image request.
+
+<img width="270" alt="Create custom cat with AI — dialog" src="https://github.com/user-attachments/assets/f94c141f-d339-4827-a476-a5725e27c9be" />
+<img width="270" alt="AI character — options" src="https://github.com/user-attachments/assets/6a67eb02-8ec0-4da9-a93c-0a16543f3679" />
+<br />
+<img width="270" alt="Generated cat on the desktop" src="https://github.com/user-attachments/assets/848ff041-55b0-417c-aaf7-2759cc6a6c9a" />
+<img width="220" alt="Generated cat" src="https://github.com/user-attachments/assets/1bec007a-eb5c-469a-a732-a1cd37c6cf27" />
+
 
 
 ## 🚀 Quick start
@@ -89,6 +104,7 @@ mycat                 # or, without installing:  python3 mycat/main.py
 - **Animated overlay** 🐱 - a frameless, always-on-top, draggable cat. Right-click for the menu (switch char, quit).
 - **Reminder** 🛩️ - set a message and a time (one-shot or daily) and the cat flies a little banner plane across the top of your screen. Right-click → *Reminder…* to set the message, direction, plane and color.
 - **Chat (Ollama)** 💬 - talk to the cat through a **local [Ollama](https://ollama.com) model**, no account or API key needed (see below).
+- **Create with AI** 🎨 - turn 1–3 photos into a custom chibi cat character with your own OpenAI key (right-click → *Chars → Create custom with AI…*). Reference photos are never stored; the result is an ordinary local char you can reuse or delete.
 
 ## 💬 Chat with the cat (Ollama)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.16"
+version = "0.1.17"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Cuts **0.1.17**, the first versioned release to ship:
- **AI custom characters** — the opt-in *Chars → Create custom with AI…* generator (feature by @sts19813, #89): 1–3 reference photos → a chibi cat char via the user's own OpenAI key, saved as an ordinary local char. No request until *Generate and save*; reference photos are never stored; no new required dependency.
- **The three Windows self-update fixes** (previously under `Unreleased`): no more black-console hang, truncated-download corruption, or "Failed to load Python DLL" on relaunch.

Contents: version bump `0.1.16 → 0.1.17`, CHANGELOG finalised for 0.1.17, and a README "Create your own cat with AI" section.

## Test plan

- [x] `pytest` — **191 passed** (offscreen)
- [x] Diff is docs/version/changelog only — the feature itself is already in `main` via #89
- [ ] On tag `0.1.17`: Publish (PyPI) + Release binaries + .deb + AppImage all green, 5 assets attached