### PR TITLE
tweak: "char" wording in the generator + empty default negatives

### DIFF
--- a/mycat/ai_backends.py
+++ b/mycat/ai_backends.py
@@ -59,26 +59,20 @@ LOCAL_CFG = 6.0
 IMG2IMG_DENOISE = 0.62           # keep some of the photo, but become a cat
 
 # A compact, tag-style base prompt that Stable-Diffusion checkpoints follow
-# better than OpenAI's prose, plus a strong SFW negative (many local checkpoints
-# lean NSFW).
+# better than OpenAI's prose. The negatives default to empty — the user fills
+# them in the dialog if they want.
 LOCAL_PROMPT = (
     "masterpiece, best quality, anime, chibi, kawaii chibi kitten girl, cat ears, "
     "cat paws, cat tail, whiskers, cute big eyes, full body, standing, centered, "
     "simple plain background, soft shading"
 )
-LOCAL_NEGATIVE = (
-    "nsfw, nude, nipples, revealing clothing, sexual, lowres, bad anatomy, "
-    "bad hands, extra limbs, deformed, blurry, watermark, signature, text, "
-    "cropped, out of frame"
-)
+LOCAL_NEGATIVE = ""
 
 
 # OpenAI keeps its prose default; these are just the *initial* text — the dialog
 # lets the user edit each and persists their own version.
 OPENAI_DEFAULT_PROMPT = ai_char.PROMPT
-OPENAI_DEFAULT_NEGATIVE = (
-    "nudity, sexual content, extra limbs, deformed hands, watermark, signature, unwanted text"
-)
+OPENAI_DEFAULT_NEGATIVE = ""
 
 
 def combine_prompt(prompt: str, negative: str) -> str:

--- a/mycat/ai_char_ui.py
+++ b/mycat/ai_char_ui.py
@@ -25,7 +25,7 @@ BACKEND_LABELS = [
     ("ComfyUI — self-hosted", "comfyui"),
 ]
 MODE_LABELS = [
-    ("img2img — turn my photos into a cat", "img2img"),
+    ("img2img — turn my photos into a char", "img2img"),
     ("txt2img — from the prompt only", "txt2img"),
 ]
 
@@ -87,7 +87,7 @@ class AICharDialog(QtWidgets.QDialog):
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
-        self.setWindowTitle("Generate a custom cat with AI")
+        self.setWindowTitle("Generate a custom char with AI")
         self.setMinimumWidth(540)
         self.setStyleSheet(LIGHT_QSS)
         self.pool = QtCore.QThreadPool(self)
@@ -96,13 +96,13 @@ class AICharDialog(QtWidgets.QDialog):
         self.current_kind = self.settings.get("backend", "openai")
 
         intro = QtWidgets.QLabel(
-            "Turn 1–3 photos of the same person into a cute chibi cat, or generate one "
+            "Turn 1–3 photos of the same person into a custom char, or generate one "
             "from the prompt. Reference photos are not stored by myCat."
         )
         intro.setWordWrap(True)
 
         self.name_edit = QtWidgets.QLineEdit()
-        self.name_edit.setPlaceholderText("Example: Mina chibi cat")
+        self.name_edit.setPlaceholderText("Example: Mina chibi char")
 
         self.backend_combo = QtWidgets.QComboBox()
         for label, data in BACKEND_LABELS:


### PR DESCRIPTION
## Summary
- The generator dialog says **char** (character) instead of **cat** — title ("Generate a custom char with AI"), the img2img mode label, the intro and the name placeholder. The feature can generate any character, not only cats.
- The **default negative prompts are now empty** (`LOCAL_NEGATIVE` / `OPENAI_DEFAULT_NEGATIVE`); the negative field stays, users just fill it themselves.

## Test plan
- [x] `ruff check` clean
- [x] `pytest tests/test_ai_backends.py` — passing
- [x] Dialog title = "Generate a custom char with AI"; default negatives empty