### PR TITLE
ci: stamp the real version into the macOS app (fixes stale icon / 0.0.0 version)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -73,6 +73,19 @@ jobs:
       - name: Build with PyInstaller
         run: pyinstaller --noconfirm mycat.spec
 
+      - name: Stamp the app version into Info.plist
+        run: |
+          # The spec ships a 0.0.0 placeholder; write the real version so macOS
+          # sees a new version on each update and refreshes the app icon/metadata
+          # (a stale bundle version makes LaunchServices keep the cached icon).
+          VERSION=$(python -c "import importlib.metadata as m; print(m.version('mycat'))")
+          PLIST=dist/mycat.app/Contents/Info.plist
+          for key in CFBundleShortVersionString CFBundleVersion; do
+            /usr/libexec/PlistBuddy -c "Set :$key $VERSION" "$PLIST" \
+              || /usr/libexec/PlistBuddy -c "Add :$key string $VERSION" "$PLIST"
+          done
+          echo "Stamped mycat.app version = $VERSION"
+
       - name: Zip .app bundle
         run: |
           cd dist
@@ -110,6 +123,19 @@ jobs:
 
       - name: Build with PyInstaller
         run: pyinstaller --noconfirm mycat.spec
+
+      - name: Stamp the app version into Info.plist
+        run: |
+          # The spec ships a 0.0.0 placeholder; write the real version so macOS
+          # sees a new version on each update and refreshes the app icon/metadata
+          # (a stale bundle version makes LaunchServices keep the cached icon).
+          VERSION=$(python -c "import importlib.metadata as m; print(m.version('mycat'))")
+          PLIST=dist/mycat.app/Contents/Info.plist
+          for key in CFBundleShortVersionString CFBundleVersion; do
+            /usr/libexec/PlistBuddy -c "Set :$key $VERSION" "$PLIST" \
+              || /usr/libexec/PlistBuddy -c "Add :$key string $VERSION" "$PLIST"
+          done
+          echo "Stamped mycat.app version = $VERSION"
 
       - name: Zip .app bundle
         run: |


### PR DESCRIPTION
## Summary

The macOS `.app` shipped with `CFBundleShortVersionString = 0.0.0` on **every** release — the `mycat.spec` placeholder was commented "overwritten by CI at build time", but no CI step actually did it. Consequences:
- **About mycat** showed `0.0.0`.
- Since the bundle version never changed between updates, **macOS/LaunchServices kept the cached app icon** — so a new/updated icon showed up as the *old* one.

Both macOS jobs (`arm64` + `x64`) now stamp the real package version (and `CFBundleVersion`) into `Contents/Info.plist` right after the PyInstaller build, via `PlistBuddy`.

The source icon (`mycat/assets/icon.png`) and the generated `.icns` are already correct — this was a bundle-metadata problem, not an icon problem.

## Test plan
- [x] `yaml.safe_load` parses the workflow
- [ ] Next release: `About mycat` shows the real version; the app icon updates (no more stale icon after an update)