### PR TITLE
fix: "char" labels + empty default negatives + macOS app version

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -73,6 +73,19 @@ jobs:
       - name: Build with PyInstaller
         run: pyinstaller --noconfirm mycat.spec
 
+      - name: Stamp the app version into Info.plist
+        run: |
+          # The spec ships a 0.0.0 placeholder; write the real version so macOS
+          # sees a new version on each update and refreshes the app icon/metadata
+          # (a stale bundle version makes LaunchServices keep the cached icon).
+          VERSION=$(python -c "import importlib.metadata as m; print(m.version('mycat'))")
+          PLIST=dist/mycat.app/Contents/Info.plist
+          for key in CFBundleShortVersionString CFBundleVersion; do
+            /usr/libexec/PlistBuddy -c "Set :$key $VERSION" "$PLIST" \
+              || /usr/libexec/PlistBuddy -c "Add :$key string $VERSION" "$PLIST"
+          done
+          echo "Stamped mycat.app version = $VERSION"
+
       - name: Zip .app bundle
         run: |
           cd dist
@@ -110,6 +123,19 @@ jobs:
 
       - name: Build with PyInstaller
         run: pyinstaller --noconfirm mycat.spec
+
+      - name: Stamp the app version into Info.plist
+        run: |
+          # The spec ships a 0.0.0 placeholder; write the real version so macOS
+          # sees a new version on each update and refreshes the app icon/metadata
+          # (a stale bundle version makes LaunchServices keep the cached icon).
+          VERSION=$(python -c "import importlib.metadata as m; print(m.version('mycat'))")
+          PLIST=dist/mycat.app/Contents/Info.plist
+          for key in CFBundleShortVersionString CFBundleVersion; do
+            /usr/libexec/PlistBuddy -c "Set :$key $VERSION" "$PLIST" \
+              || /usr/libexec/PlistBuddy -c "Add :$key string $VERSION" "$PLIST"
+          done
+          echo "Stamped mycat.app version = $VERSION"
 
       - name: Zip .app bundle
         run: |

--- a/mycat/ai_backends.py
+++ b/mycat/ai_backends.py
@@ -59,26 +59,20 @@ LOCAL_CFG = 6.0
 IMG2IMG_DENOISE = 0.62           # keep some of the photo, but become a cat
 
 # A compact, tag-style base prompt that Stable-Diffusion checkpoints follow
-# better than OpenAI's prose, plus a strong SFW negative (many local checkpoints
-# lean NSFW).
+# better than OpenAI's prose. The negatives default to empty — the user fills
+# them in the dialog if they want.
 LOCAL_PROMPT = (
     "masterpiece, best quality, anime, chibi, kawaii chibi kitten girl, cat ears, "
     "cat paws, cat tail, whiskers, cute big eyes, full body, standing, centered, "
     "simple plain background, soft shading"
 )
-LOCAL_NEGATIVE = (
-    "nsfw, nude, nipples, revealing clothing, sexual, lowres, bad anatomy, "
-    "bad hands, extra limbs, deformed, blurry, watermark, signature, text, "
-    "cropped, out of frame"
-)
+LOCAL_NEGATIVE = ""
 
 
 # OpenAI keeps its prose default; these are just the *initial* text — the dialog
 # lets the user edit each and persists their own version.
 OPENAI_DEFAULT_PROMPT = ai_char.PROMPT
-OPENAI_DEFAULT_NEGATIVE = (
-    "nudity, sexual content, extra limbs, deformed hands, watermark, signature, unwanted text"
-)
+OPENAI_DEFAULT_NEGATIVE = ""
 
 
 def combine_prompt(prompt: str, negative: str) -> str:

--- a/mycat/ai_char_ui.py
+++ b/mycat/ai_char_ui.py
@@ -25,7 +25,7 @@ BACKEND_LABELS = [
     ("ComfyUI — self-hosted", "comfyui"),
 ]
 MODE_LABELS = [
-    ("img2img — turn my photos into a cat", "img2img"),
+    ("img2img — turn my photos into a char", "img2img"),
     ("txt2img — from the prompt only", "txt2img"),
 ]
 
@@ -87,7 +87,7 @@ class AICharDialog(QtWidgets.QDialog):
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
-        self.setWindowTitle("Generate a custom cat with AI")
+        self.setWindowTitle("Generate a custom char with AI")
         self.setMinimumWidth(540)
         self.setStyleSheet(LIGHT_QSS)
         self.pool = QtCore.QThreadPool(self)
@@ -96,13 +96,13 @@ class AICharDialog(QtWidgets.QDialog):
         self.current_kind = self.settings.get("backend", "openai")
 
         intro = QtWidgets.QLabel(
-            "Turn 1–3 photos of the same person into a cute chibi cat, or generate one "
+            "Turn 1–3 photos of the same person into a custom char, or generate one "
             "from the prompt. Reference photos are not stored by myCat."
         )
         intro.setWordWrap(True)
 
         self.name_edit = QtWidgets.QLineEdit()
-        self.name_edit.setPlaceholderText("Example: Mina chibi cat")
+        self.name_edit.setPlaceholderText("Example: Mina chibi char")
 
         self.backend_combo = QtWidgets.QComboBox()
         for label, data in BACKEND_LABELS:


### PR DESCRIPTION
Combines the two open tweaks into one PR (supersedes #93 and #94).

## Generator dialog
- Says **char** (character) instead of **cat**: window title ("Generate a custom char with AI"), the img2img mode label, the intro, and the name placeholder.
- **Default negative prompts are now empty** (`LOCAL_NEGATIVE` / `OPENAI_DEFAULT_NEGATIVE`) — so **Reset to default** clears the negative field (previously it restored a pre-filled negative). The field stays; users fill it themselves.

## macOS app version / icon
- CI now stamps the real version into the `.app`'s `Info.plist` (`CFBundleShortVersionString` + `CFBundleVersion`). The spec shipped a `0.0.0` placeholder that CI never overwrote, so every macOS release had version `0.0.0` — which made macOS keep the **cached (old) app icon** across updates and show the wrong "About" version. (The icon source and generated `.icns` were already correct.)

## Test plan
- [x] `ruff check mycat tests` clean
- [x] `pytest` green (backend tests)
- [x] Dialog: title says "char"; default negatives empty; **Reset clears the negative**
- [x] Workflow YAML parses; both macOS jobs stamp the version