### PR TITLE
release: mycat 0.1.19 — macOS fast startup + restore after Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.1.19] - 2026-07-11
+
+### Fixed
+- **The macOS app starts fast now.** It was built as a PyInstaller *onefile* `.app`, which re-extracted its whole ~50 MB archive to a temp dir on every launch (and Gatekeeper rescanned it) — so startup took ~30 s. The macOS build is now *onedir*: the files live in `Contents/` and it starts near-instantly (Windows/Linux stay onefile) (branch `fix/macos-startup-restore`).
+- **A cat hidden with Close can be brought back on macOS.** macOS re-launches don't start a second process — LaunchServices just activates the running app — so the "second launch raises the cat" safety net never fired there. The cat now reappears when the app is reactivated (Dock icon / Cmd-Tab), and the tray's toggle shows its correct **Open** / **Close** label (branch `fix/macos-startup-restore`).
+
 ## [0.1.18] - 2026-07-11
 
 ### Added

--- a/mycat.spec
+++ b/mycat.spec
@@ -108,31 +108,39 @@ if icon_png.is_file():
         print(f"mycat.spec: could not build the app icon ({icon_error})")
         app_icon = None
 
-exe = EXE(
-    pyz,
-    a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
-    [],
-    name='mycat',
-    icon=app_icon if sys.platform == 'win32' else None,  # .ico; macOS uses BUNDLE
-    debug=False,
-    bootloader_ignore_signals=False,
-    strip=False,
-    upx=False,
-    upx_exclude=[],
-    runtime_tmpdir=None,
-    console=False,                # no console window — pure GUI
-    disable_windowed_traceback=False,
-    target_arch=None,
-    codesign_identity=None,
-    entitlements_file=None,
-)
-
 if sys.platform == 'darwin':
-    app = BUNDLE(
+    # macOS: onedir -> .app. A onefile .app re-extracts its whole ~50 MB archive
+    # to a temp dir on EVERY launch (and Gatekeeper rescans the extracted dylibs),
+    # which made startup take ~30 s. A onedir bundle keeps the files in Contents/
+    # and starts near-instantly.
+    exe = EXE(
+        pyz,
+        a.scripts,
+        [],
+        exclude_binaries=True,
+        name='mycat',
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=False,
+        console=False,
+        disable_windowed_traceback=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+    )
+    coll = COLLECT(
         exe,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        strip=False,
+        upx=False,
+        upx_exclude=[],
+        name='mycat',
+    )
+    app = BUNDLE(
+        coll,
         name='mycat.app',
         icon=app_icon,
         bundle_identifier='app.mycat',
@@ -141,4 +149,28 @@ if sys.platform == 'darwin':
             'CFBundleShortVersionString': '0.0.0',  # overwritten by CI at build time
             'NSHumanReadableCopyright': '© yumiaura',
         },
+    )
+else:
+    # Windows / Linux: onefile -> a single self-contained executable (the .exe,
+    # and the binary the .deb / AppImage wrap).
+    exe = EXE(
+        pyz,
+        a.scripts,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        [],
+        name='mycat',
+        icon=app_icon if sys.platform == 'win32' else None,  # .ico
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=False,
+        upx_exclude=[],
+        runtime_tmpdir=None,
+        console=False,                # no console window — pure GUI
+        disable_windowed_traceback=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
     )

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -1906,6 +1906,22 @@ def start_activation_server(name: str, window):
     return server
 
 
+def install_macos_reopen(app, window):
+    """Bring a tray-hidden cat back when the app is reactivated on macOS.
+
+    macOS re-launches don't start a second process — LaunchServices just
+    activates the already-running app — so the single-instance socket never
+    fires there and clicking the Dock icon otherwise does nothing. Show the
+    window again whenever the app becomes active while hidden.
+    """
+    def on_state(state) -> None:
+        if state == QtCore.Qt.ApplicationState.ApplicationActive and not window.isVisible():
+            window.show()
+            window.raise_()
+
+    app.applicationStateChanged.connect(on_state)
+
+
 def ensure_emoji_font(app) -> None:
     """Give emoji glyphs a fallback so they don't render as tofu boxes on systems
     with no emoji font (common on minimal Linux `pip install`s).
@@ -2105,10 +2121,13 @@ def setup_tray(app, window):
         login_action.setChecked(autostart.is_enabled())
         login_action.toggled.connect(autostart.set_enabled)
     menu.addSeparator()
-    # Dynamic label: "Open" when the cat is hidden, "Close" when it's on screen.
     toggle_action = menu.addAction("Close")
     toggle_action.triggered.connect(toggle_window)
     menu.addAction("Quit", QtWidgets.QApplication.quit)
+    # Dynamic label: "Open" when the cat is hidden, "Close" when it's on screen.
+    menu.aboutToShow.connect(
+        lambda: toggle_action.setText("Open" if not window.isVisible() else "Close")
+    )
     tray.setContextMenu(menu)
 
     def sync_toggle_label():
@@ -2254,6 +2273,8 @@ def main() -> None:
         # Safety net: let a second launch raise this window, so a cat hidden to a
         # tray the panel doesn't render can always be brought back with `mycat`.
         window.activation_server = start_activation_server(SINGLE_INSTANCE_NAME, window)
+        if sys.platform == "darwin" and window.tray_icon is not None:
+            install_macos_reopen(app, window)
         # Live in the tray: hiding/closing windows no longer quits the app —
         # only the explicit Quit action does. With no tray to quit from, keep
         # the old behaviour so the user is never stuck with an invisible process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.18"
+version = "0.1.19"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
macOS-only fixes, then cut **0.1.19**:
- **Fast startup** — the macOS `.app` is now built **onedir** instead of onefile, so it no longer re-extracts its whole ~50 MB archive to a temp dir on every launch (which took ~30 s). Verified in a CI build: `Contents/MacOS/mycat` is a 3.4 MB bootloader with a `Contents/Frameworks/` beside it. Windows/Linux stay onefile.
- **Restore after Close** — on macOS a re-launch doesn't start a second process (LaunchServices activates the running app), so the "second launch raises the cat" socket never fired. The cat now reappears when the app is reactivated (Dock icon / Cmd-Tab), and the tray's Open/Close item shows the right label.

## Test plan
- [x] `pytest` — 207 passed; `ruff` clean; `mycat.spec` parses
- [x] CI test build: macOS `.app` is onedir (3.4 MB bootloader + Frameworks/), Info.plist version stamped
- [ ] On tag `0.1.19`: all 4 release workflows green, 5 assets