### PR TITLE
docs: add code review audit

### DIFF
--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,0 +1,22 @@
+# Code review — 2026-07-12
+
+## High priority
+
+1. `shop_api.py` accepts catalog character IDs as file names. Validate IDs as strict slugs and ensure resolved download/preview destinations remain below their intended cache or characters directory.
+2. Do not forward a bearer token to arbitrary absolute download URLs or CDN redirects from the catalog. Send authorization only to the configured trusted API origin.
+3. The shop is implemented but its only menu entry is commented out in `main.py`; either expose and secure it or remove the dormant path before release.
+
+## Medium priority
+
+1. Enforce compressed and uncompressed ZIP, frame-count, and decoded-pixel limits before loading character packs to avoid archive/image decompression denial-of-service.
+2. Stream and size-limit preview downloads, validate image content before passing it to Qt, and honor/remove the unused catalog cache TTL.
+3. ComfyUI uploads reference photos to its server input directory without cleanup. Tell users clearly and add cleanup when the target server supports it.
+4. Validate persisted generation settings (notably `steps`) and fall back safely when config is malformed.
+
+## Maintainability
+
+`main.py` currently combines overlay rendering, application state, menus, and feature-controller wiring. Incrementally extract context-menu actions, character rendering/state, and bootstrap/controller wiring into focused modules.
+
+## Test environment
+
+The suite currently reports 203 passing and 4 environment-dependent failures: three calendar tests need `mycat[calendar]`; one updater test assumes import from a git checkout.


### PR DESCRIPTION
## Summary
- Adds `docs/CODE_REVIEW.md` with the 2026-07-12 audit: shop path/token risks, dormant shop menu, pack/preview limits, ComfyUI cleanup, settings validation, and `main.py` maintainability notes.
- Captures the current test-suite note (203 passing; 4 environment-dependent failures).

Closes #100

## Test plan
- [ ] Review `docs/CODE_REVIEW.md` for accuracy against current `shop_api.py` / `main.py` / pack loading
- [ ] Confirm no runtime code changes in this PR (docs only)

Made with [Cursor](https://cursor.com)