### PR TITLE
fix: unlock GitHub private options when token is present

### DIFF
--- a/mycat/github_ui.py
+++ b/mycat/github_ui.py
@@ -8,6 +8,7 @@ until the token is entered and verified with "Test".
 """
 
 import logging
+import os
 
 from PySide6 import QtCore, QtWidgets
 
@@ -39,6 +40,7 @@ class GitHubDialog(QtWidgets.QDialog):
 
         settings = notifier.settings
         self.token_verified = bool(settings.token_verified and settings.resolve_token())
+        self.has_token = bool(settings.resolve_token())
         layout = QtWidgets.QVBoxLayout(self)
 
         self.enabled_box = QtWidgets.QCheckBox("Enabled — announces GitHub activity")
@@ -75,11 +77,11 @@ class GitHubDialog(QtWidgets.QDialog):
             self.category_boxes[key] = box
             inbox_layout.addWidget(box)
         self.inbox_box.setToolTip(
-            "Enter a token above and press Test to unlock these. They are served only with a\n"
+            "Enter a token to configure these options; Test verifies it. They are served only with a\n"
             "token (read-only Notifications scope is enough); requests go straight to api.github.com."
         )
         layout.addWidget(self.inbox_box)
-        self.set_inbox_enabled(self.token_verified)
+        self.set_inbox_enabled(self.has_token)
 
         self.status_label = QtWidgets.QLabel("")
         self.status_label.setWordWrap(True)
@@ -107,9 +109,11 @@ class GitHubDialog(QtWidgets.QDialog):
             self.category_boxes[key].setEnabled(enabled)
 
     def on_token_changed(self, text: str) -> None:
-        # Editing the token invalidates any prior verification.
+        # Editing the token invalidates verification, but users can still choose
+        # their private categories before running the optional connection test.
         self.token_verified = False
-        self.set_inbox_enabled(False)
+        self.has_token = bool(text.strip()) or bool(os.getenv(self.notifier.settings.token_env))
+        self.set_inbox_enabled(self.has_token)
 
     def set_status(self, text: str, ok: bool | None = None) -> None:
         """Status line: green when ok, red when not, neutral otherwise."""
@@ -142,7 +146,9 @@ class GitHubDialog(QtWidgets.QDialog):
         private_on = sum(1 for key, label in INBOX_CHOICES if self.category_boxes[key].isChecked())
         state = "on" if settings.enabled else "off"
         who = settings.me_login or "no username"
-        token_note = "token verified" if self.token_verified else "no token"
+        token_note = "token verified" if self.token_verified else (
+            "token not verified" if settings.resolve_token() else "no token"
+        )
         self.set_status(
             f"Saved ({state}): {who} · {public_on} public + {private_on} private options · {token_note}.",
             ok=True,
@@ -186,7 +192,7 @@ class GitHubDialog(QtWidgets.QDialog):
         if mode == "verify":
             if result.get("error") or int(result.get("status", 0)) != 200:
                 self.token_verified = False
-                self.set_inbox_enabled(False)
+                self.set_inbox_enabled(bool(self.collect_settings().resolve_token()))
                 self.set_status("Token rejected — check the PAT (read-only Notifications scope).", ok=False)
                 return
             login = str(result.get("login", ""))

--- a/tests/test_github_ui.py
+++ b/tests/test_github_ui.py
@@ -1,0 +1,25 @@
+"""GitHub notification settings dialog behaviour."""
+
+from mycat.github_notify import GitHubSettings
+from mycat.github_ui import GitHubDialog, INBOX_CHOICES
+
+
+class _Notifier:
+    def __init__(self, settings):
+        self.settings = settings
+
+
+def test_private_options_unlock_when_a_saved_token_is_present(qapp, monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    dialog = GitHubDialog(_Notifier(GitHubSettings(token="token")))
+
+    assert all(dialog.category_boxes[key].isEnabled() for key, _ in INBOX_CHOICES)
+
+
+def test_private_options_unlock_while_typing_a_token(qapp, monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    dialog = GitHubDialog(_Notifier(GitHubSettings()))
+
+    assert not any(dialog.category_boxes[key].isEnabled() for key, _ in INBOX_CHOICES)
+    dialog.token_edit.setText("token")
+    assert all(dialog.category_boxes[key].isEnabled() for key, _ in INBOX_CHOICES)

--- a/tests/test_github_ui.py
+++ b/tests/test_github_ui.py
@@ -1,7 +1,7 @@
 """GitHub notification settings dialog behaviour."""
 
 from mycat.github_notify import GitHubSettings
-from mycat.github_ui import GitHubDialog, INBOX_CHOICES
+from mycat.github_ui import INBOX_CHOICES, GitHubDialog
 
 
 class _Notifier:


### PR DESCRIPTION
## Summary
- Private inbox category checkboxes unlock when a token is present (saved, typed, or from the env), not only after a successful Test.
- Test still verifies the PAT; a rejected token no longer locks the options if a token value remains.
- Adds UI tests for saved-token and typing unlock paths.

Closes #101

## Test plan
- [x] `QT_QPA_PLATFORM=offscreen pytest tests/test_github_ui.py` (new tests)
- [ ] Open GitHub settings with a saved PAT — private options enabled without pressing Test
- [ ] Clear token field — private options disable; type a token — they re-enable
- [ ] Press Test with a bad PAT — status shows rejected; options stay enabled while text remains
- [ ] Save still works; status line shows `token not verified` vs `token verified` vs `no token`

Made with [Cursor](https://cursor.com)