### PR TITLE
feat: optional plain background removal for self-hosted AI chars

### DIFF
--- a/mycat/ai_backends.py
+++ b/mycat/ai_backends.py
@@ -355,7 +355,7 @@ GENERATION_DEFAULTS = {
     "comfyui_url": "",
     "comfyui_checkpoint": "sd15.safetensors",
     "steps": str(LOCAL_STEPS),
-    "remove_background": "false",
+    "background_removal": "none",
     "openai_prompt": OPENAI_DEFAULT_PROMPT,
     "openai_negative": OPENAI_DEFAULT_NEGATIVE,
     "selfhosted_prompt": LOCAL_PROMPT,
@@ -365,8 +365,11 @@ GENERATION_DEFAULTS = {
 
 def load_generation_settings() -> dict:
     """Read the [generation] section of config.ini, filled in with defaults."""
+    from . import ai_char
+
     settings = dict(GENERATION_DEFAULTS)
     parser = configparser.ConfigParser()
+    legacy_remove_background = None
     if CFG_FILE.exists():
         try:
             parser.read(CFG_FILE)
@@ -376,6 +379,12 @@ def load_generation_settings() -> dict:
             for key in GENERATION_DEFAULTS:
                 if parser.has_option(CFG_SECTION, key):
                     settings[key] = parser.get(CFG_SECTION, key)
+            if parser.has_option(CFG_SECTION, "remove_background"):
+                legacy_remove_background = parser.get(CFG_SECTION, "remove_background")
+    settings["background_removal"] = ai_char.normalize_background_removal(
+        settings.get("background_removal"),
+        legacy_remove_background=legacy_remove_background,
+    )
     return settings
 
 

--- a/mycat/ai_backends.py
+++ b/mycat/ai_backends.py
@@ -365,8 +365,6 @@ GENERATION_DEFAULTS = {
 
 def load_generation_settings() -> dict:
     """Read the [generation] section of config.ini, filled in with defaults."""
-    from . import ai_char
-
     settings = dict(GENERATION_DEFAULTS)
     parser = configparser.ConfigParser()
     legacy_remove_background = None

--- a/mycat/ai_backends.py
+++ b/mycat/ai_backends.py
@@ -11,10 +11,12 @@ Backends:
   (identity-preserving), ``txt2img`` generates from the prompt alone. Returns a
   transparent PNG.
 - **a1111** — a self-hosted AUTOMATIC1111 Stable Diffusion WebUI (``/sdapi/v1``).
-  ``txt2img`` / ``img2img``. Opaque output (the WebUI has no background remover).
+  ``txt2img`` / ``img2img``. Its opaque output can optionally be post-processed
+  to remove a simple corner-connected background.
 - **comfyui** — a self-hosted ComfyUI server. A small built-in workflow does
   ``txt2img`` / ``img2img`` with core nodes only, so it works on any ComfyUI.
-  Opaque output.
+  Its opaque output can optionally be post-processed to remove a simple
+  corner-connected background.
 
 Both modes are offered for every backend, and the self-hosted backends can list
 their checkpoints so the settings dialog can show a model picker.
@@ -353,6 +355,7 @@ GENERATION_DEFAULTS = {
     "comfyui_url": "",
     "comfyui_checkpoint": "sd15.safetensors",
     "steps": str(LOCAL_STEPS),
+    "remove_background": "false",
     "openai_prompt": OPENAI_DEFAULT_PROMPT,
     "openai_negative": OPENAI_DEFAULT_NEGATIVE,
     "selfhosted_prompt": LOCAL_PROMPT,

--- a/mycat/ai_char.py
+++ b/mycat/ai_char.py
@@ -231,12 +231,13 @@ BACKGROUND_REMOVAL_PLAIN = "plain"
 DEFAULT_BACKGROUND_REMOVAL = BACKGROUND_REMOVAL_NONE
 
 
-def _background_removal_none(image_bytes: bytes) -> bytes:
+def keep_background(image_bytes: bytes) -> bytes:
+    """Leave opaque self-hosted output unchanged."""
     return image_bytes
 
 
 BACKGROUND_REMOVAL_METHODS: dict[str, tuple[str, BackgroundRemovalFn]] = {
-    BACKGROUND_REMOVAL_NONE: ("True", _background_removal_none),
+    BACKGROUND_REMOVAL_NONE: ("Keep", keep_background),
     BACKGROUND_REMOVAL_PLAIN: ("Remove", remove_plain_background),
 }
 
@@ -322,6 +323,7 @@ __all__ = [
     "prepare_references",
     "apply_background_removal",
     "background_removal_choices",
+    "keep_background",
     "normalize_background_removal",
     "remove_plain_background",
     "BACKGROUND_REMOVAL_METHODS",

--- a/mycat/ai_char.py
+++ b/mycat/ai_char.py
@@ -6,6 +6,7 @@ resized in memory before upload and are never copied into myCat's data folder.
 
 from __future__ import annotations
 
+from collections import deque
 import base64
 import hashlib
 import io
@@ -180,6 +181,48 @@ def _normalized_character_png(image_bytes: bytes) -> bytes:
     return output.getvalue()
 
 
+def remove_plain_background(image_bytes: bytes, *, tolerance: int = 48) -> bytes:
+    """Make a corner-connected, near-uniform background transparent.
+
+    This conservative post-processing option is for locally generated mascots
+    on a simple background. Only pixels connected to an image corner and close
+    to that corner's colour are removed; interior detail is left untouched.
+    """
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as source:
+            image = source.convert("RGBA")
+    except (OSError, UnidentifiedImageError) as exc:
+        raise AICharError("Cannot remove the background from an invalid image.") from exc
+
+    width, height = image.size
+    if not width or not height:
+        return image_bytes
+    pixels = image.load()
+    visited: set[tuple[int, int]] = set()
+    queue: deque[tuple[int, int, tuple[int, int, int]]] = deque()
+    for x, y in ((0, 0), (width - 1, 0), (0, height - 1), (width - 1, height - 1)):
+        if (x, y) not in visited:
+            visited.add((x, y))
+            queue.append((x, y, pixels[x, y][:3]))
+
+    limit = tolerance * tolerance * 3
+    while queue:
+        x, y, background = queue.popleft()
+        red, green, blue, alpha = pixels[x, y]
+        distance = sum((value - reference) ** 2 for value, reference in zip((red, green, blue), background))
+        if alpha == 0 or distance > limit:
+            continue
+        pixels[x, y] = (red, green, blue, 0)
+        for next_x, next_y in ((x - 1, y), (x + 1, y), (x, y - 1), (x, y + 1)):
+            if 0 <= next_x < width and 0 <= next_y < height and (next_x, next_y) not in visited:
+                visited.add((next_x, next_y))
+                queue.append((next_x, next_y, background))
+
+    output = io.BytesIO()
+    image.save(output, "PNG", optimize=True)
+    return output.getvalue()
+
+
 def install_character(display_name: str, image_bytes: bytes) -> tuple[str, Path]:
     char_id = slugify(display_name)
     destination = char_catalog.ensure_user_chars_dir() / f"{char_id}.zip"
@@ -238,6 +281,7 @@ __all__ = [
     "build_prompt",
     "install_character",
     "prepare_references",
+    "remove_plain_background",
     "request_image",
     "slugify",
 ]

--- a/mycat/ai_char.py
+++ b/mycat/ai_char.py
@@ -7,6 +7,7 @@ resized in memory before upload and are never copied into myCat's data folder.
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Callable
 import base64
 import hashlib
 import io
@@ -223,6 +224,44 @@ def remove_plain_background(image_bytes: bytes, *, tolerance: int = 48) -> bytes
     return output.getvalue()
 
 
+BackgroundRemovalFn = Callable[[bytes], bytes]
+
+BACKGROUND_REMOVAL_NONE = "none"
+BACKGROUND_REMOVAL_PLAIN = "plain"
+DEFAULT_BACKGROUND_REMOVAL = BACKGROUND_REMOVAL_NONE
+
+
+def _background_removal_none(image_bytes: bytes) -> bytes:
+    return image_bytes
+
+
+BACKGROUND_REMOVAL_METHODS: dict[str, tuple[str, BackgroundRemovalFn]] = {
+    BACKGROUND_REMOVAL_NONE: ("True", _background_removal_none),
+    BACKGROUND_REMOVAL_PLAIN: ("Remove", remove_plain_background),
+}
+
+
+def background_removal_choices() -> list[tuple[str, str]]:
+    """Return (label, method id) pairs for UI selectors."""
+    return [(label, method_id) for method_id, (label, _) in BACKGROUND_REMOVAL_METHODS.items()]
+
+
+def normalize_background_removal(value: str | None, *, legacy_remove_background: str | None = None) -> str:
+    """Resolve a persisted or legacy setting to a known background-removal method id."""
+    if value and value in BACKGROUND_REMOVAL_METHODS:
+        return value
+    if legacy_remove_background and legacy_remove_background.lower() == "true":
+        return BACKGROUND_REMOVAL_PLAIN
+    return DEFAULT_BACKGROUND_REMOVAL
+
+
+def apply_background_removal(image_bytes: bytes, method: str) -> bytes:
+    """Run the selected post-processing method, if any."""
+    normalized = normalize_background_removal(method)
+    _, remover = BACKGROUND_REMOVAL_METHODS[normalized]
+    return remover(image_bytes)
+
+
 def install_character(display_name: str, image_bytes: bytes) -> tuple[str, Path]:
     char_id = slugify(display_name)
     destination = char_catalog.ensure_user_chars_dir() / f"{char_id}.zip"
@@ -281,7 +320,14 @@ __all__ = [
     "build_prompt",
     "install_character",
     "prepare_references",
+    "apply_background_removal",
+    "background_removal_choices",
+    "normalize_background_removal",
     "remove_plain_background",
+    "BACKGROUND_REMOVAL_METHODS",
+    "BACKGROUND_REMOVAL_NONE",
+    "BACKGROUND_REMOVAL_PLAIN",
+    "DEFAULT_BACKGROUND_REMOVAL",
     "request_image",
     "slugify",
 ]

--- a/mycat/ai_char_ui.py
+++ b/mycat/ai_char_ui.py
@@ -159,7 +159,7 @@ class AICharDialog(QtWidgets.QDialog):
         for label, method_id in ai_char.background_removal_choices():
             self.background_combo.addItem(label, method_id)
         self.background_combo.setToolTip(
-            "True keeps the opaque image as generated. Remove clears a corner-connected, near-uniform background."
+            "Keep leaves the opaque image as generated. Remove clears a corner-connected, near-uniform background."
         )
         local_form = QtWidgets.QFormLayout()
         local_form.addRow("Server address", url_row)

--- a/mycat/ai_char_ui.py
+++ b/mycat/ai_char_ui.py
@@ -52,6 +52,8 @@ class GenerationWorker(QtCore.QRunnable):
             references = ai_char.prepare_references(self.paths) if self.paths else []
             backend = ai_backends.make_backend(self.settings, self.api_key)
             image = backend.generate(references)
+            if self.settings.get("remove_background", "false").lower() == "true":
+                image = ai_char.remove_plain_background(image)
             char_id, path = ai_char.install_character(self.name, image)
         except Exception as exc:  # noqa: BLE001 - error is shown in the dialog
             logger.warning("Character generation failed (backend=%s, mode=%s): %s", kind, mode, exc)
@@ -150,10 +152,16 @@ class AICharDialog(QtWidgets.QDialog):
         self.steps_spin = QtWidgets.QSpinBox()
         self.steps_spin.setRange(1, 80)
         self.steps_spin.setValue(int(self.settings.get("steps", ai_backends.LOCAL_STEPS)))
+        self.remove_background_box = QtWidgets.QCheckBox("Remove a plain background after generation")
+        self.remove_background_box.setChecked(self.settings.get("remove_background", "false").lower() == "true")
+        self.remove_background_box.setToolTip(
+            "Makes a corner-connected, near-uniform background transparent. Best for a simple, contrasting background."
+        )
         local_form = QtWidgets.QFormLayout()
         local_form.addRow("Server address", url_row)
         local_form.addRow("Checkpoint", self.checkpoint_combo)
         local_form.addRow("Steps", self.steps_spin)
+        local_form.addRow("", self.remove_background_box)
         self.local_group = QtWidgets.QGroupBox("Self-hosted server")
         self.local_group.setLayout(local_form)
 
@@ -297,6 +305,7 @@ class AICharDialog(QtWidgets.QDialog):
         settings["openai_model"] = self.model_combo.currentData()
         settings["quality"] = self.quality_combo.currentData()
         settings["steps"] = str(self.steps_spin.value())
+        settings["remove_background"] = "true" if self.remove_background_box.isChecked() else "false"
         return settings
 
     # --- model list -----------------------------------------------------------

--- a/mycat/ai_char_ui.py
+++ b/mycat/ai_char_ui.py
@@ -52,8 +52,11 @@ class GenerationWorker(QtCore.QRunnable):
             references = ai_char.prepare_references(self.paths) if self.paths else []
             backend = ai_backends.make_backend(self.settings, self.api_key)
             image = backend.generate(references)
-            if self.settings.get("remove_background", "false").lower() == "true":
-                image = ai_char.remove_plain_background(image)
+            method = ai_char.normalize_background_removal(
+                self.settings.get("background_removal"),
+                legacy_remove_background=self.settings.get("remove_background"),
+            )
+            image = ai_char.apply_background_removal(image, method)
             char_id, path = ai_char.install_character(self.name, image)
         except Exception as exc:  # noqa: BLE001 - error is shown in the dialog
             logger.warning("Character generation failed (backend=%s, mode=%s): %s", kind, mode, exc)
@@ -152,16 +155,17 @@ class AICharDialog(QtWidgets.QDialog):
         self.steps_spin = QtWidgets.QSpinBox()
         self.steps_spin.setRange(1, 80)
         self.steps_spin.setValue(int(self.settings.get("steps", ai_backends.LOCAL_STEPS)))
-        self.remove_background_box = QtWidgets.QCheckBox("Remove a plain background after generation")
-        self.remove_background_box.setChecked(self.settings.get("remove_background", "false").lower() == "true")
-        self.remove_background_box.setToolTip(
-            "Makes a corner-connected, near-uniform background transparent. Best for a simple, contrasting background."
+        self.background_combo = QtWidgets.QComboBox()
+        for label, method_id in ai_char.background_removal_choices():
+            self.background_combo.addItem(label, method_id)
+        self.background_combo.setToolTip(
+            "True keeps the opaque image as generated. Remove clears a corner-connected, near-uniform background."
         )
         local_form = QtWidgets.QFormLayout()
         local_form.addRow("Server address", url_row)
         local_form.addRow("Checkpoint", self.checkpoint_combo)
         local_form.addRow("Steps", self.steps_spin)
-        local_form.addRow("", self.remove_background_box)
+        local_form.addRow("Background", self.background_combo)
         self.local_group = QtWidgets.QGroupBox("Self-hosted server")
         self.local_group.setLayout(local_form)
 
@@ -247,6 +251,13 @@ class AICharDialog(QtWidgets.QDialog):
         self.combo_select(self.model_combo, self.settings.get("openai_model", ai_backends.OPENAI_MODELS[0]))
         self.combo_select(self.quality_combo, self.settings.get("quality", "low"))
         self.load_local_fields(self.current_kind)
+        self.combo_select(
+            self.background_combo,
+            ai_char.normalize_background_removal(
+                self.settings.get("background_removal"),
+                legacy_remove_background=self.settings.get("remove_background"),
+            ),
+        )
         self.load_prompt_fields(self.current_kind)
         self.update_visibility()
 
@@ -305,7 +316,7 @@ class AICharDialog(QtWidgets.QDialog):
         settings["openai_model"] = self.model_combo.currentData()
         settings["quality"] = self.quality_combo.currentData()
         settings["steps"] = str(self.steps_spin.value())
-        settings["remove_background"] = "true" if self.remove_background_box.isChecked() else "false"
+        settings["background_removal"] = self.background_combo.currentData()
         return settings
 
     # --- model list -----------------------------------------------------------

--- a/tests/test_ai_char.py
+++ b/tests/test_ai_char.py
@@ -106,3 +106,17 @@ def test_remove_plain_background_keeps_the_character_opaque():
     with Image.open(io.BytesIO(ai_char.remove_plain_background(output.getvalue()))) as result:
         assert result.getpixel((0, 0))[3] == 0
         assert result.getpixel((3, 3)) == (220, 20, 60, 255)
+
+
+def test_background_removal_registry_and_legacy_migration():
+    assert ai_char.background_removal_choices() == [
+        ("True", "none"),
+        ("Remove", "plain"),
+    ]
+    assert ai_char.normalize_background_removal("plain") == "plain"
+    assert ai_char.normalize_background_removal("unknown") == "none"
+    assert ai_char.normalize_background_removal(None, legacy_remove_background="true") == "plain"
+    assert ai_char.normalize_background_removal("none", legacy_remove_background="true") == "none"
+
+    image = png_bytes()
+    assert ai_char.apply_background_removal(image, "none") == image

--- a/tests/test_ai_char.py
+++ b/tests/test_ai_char.py
@@ -95,3 +95,14 @@ def test_install_and_delete_generated_character(monkeypatch, tmp_path):
     assert char_catalog.remove_installed(char_id) is True
     assert not path.exists()
     assert char_catalog.ai_generated_chars() == []
+
+
+def test_remove_plain_background_keeps_the_character_opaque():
+    image = Image.new("RGBA", (7, 7), "white")
+    image.putpixel((3, 3), (220, 20, 60, 255))
+    output = io.BytesIO()
+    image.save(output, "PNG")
+
+    with Image.open(io.BytesIO(ai_char.remove_plain_background(output.getvalue()))) as result:
+        assert result.getpixel((0, 0))[3] == 0
+        assert result.getpixel((3, 3)) == (220, 20, 60, 255)

--- a/tests/test_ai_char.py
+++ b/tests/test_ai_char.py
@@ -110,7 +110,7 @@ def test_remove_plain_background_keeps_the_character_opaque():
 
 def test_background_removal_registry_and_legacy_migration():
     assert ai_char.background_removal_choices() == [
-        ("True", "none"),
+        ("Keep", "none"),
         ("Remove", "plain"),
     ]
     assert ai_char.normalize_background_removal("plain") == "plain"


### PR DESCRIPTION
## Summary
- Adds optional post-process background removal for opaque A1111/ComfyUI outputs via an extensible method registry.
- Self-hosted dialog uses a **Background** selector: `Keep` / `Remove`, persisted as `background_removal`.
- Migrates the legacy `remove_background=true/false` checkbox setting; unit tests cover removal and registry/legacy paths.

Closes #102

## Test plan
- [x] `QT_QPA_PLATFORM=offscreen pytest tests/test_ai_char.py` — includes background-removal + registry tests
- [ ] Generate with A1111/ComfyUI on a simple background with Background = Keep — opaque as before
- [ ] Same generation with Background = Remove — near-uniform corner background becomes transparent; character stays opaque
- [ ] Setting persists across reopen of the AI character dialog
- [ ] Adding a new entry to `BACKGROUND_REMOVAL_METHODS` appears in the combo without UI changes