### PR TITLE
docs: update CONTRIBUTING for the real test suite and ruff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,19 +49,25 @@ Thank you for considering contributing to this cute desktop pet project! 🐱
 ## Code Style
 
 - Follow PEP 8 for Python code style
+- Lint with [ruff](https://docs.astral.sh/ruff/): `ruff check .` (CI fails on findings)
 - Use type hints where possible (already implemented in most places)
 - Add docstrings to all public functions and classes
 - Keep functions focused and not too long
 
 ## Testing
 
-Currently there are no automated tests, but contributions in this area are very welcome!
+The test suite lives in `tests/` and runs on pytest. Qt runs headless through
+the offscreen platform (set up in `tests/conftest.py`), so no display is
+needed:
 
-Consider adding tests for:
-- Sprite loading and parsing
-- Configuration save/load
-- Window behavior (position, transparency)
-- Command-line argument parsing
+```bash
+pip install ruff pytest
+python -m pytest -q
+```
+
+CI runs `ruff check .` and the test suite on Python 3.10 and 3.12 for every
+pull request — please run both locally before opening one, and add tests for
+new features and bug fixes.
 
 ## Documentation
 


### PR DESCRIPTION
CONTRIBUTING.md still said "Currently there are no automated tests", but the pytest suite in `tests/` has been running in CI for a while (ruff + pytest on Python 3.10/3.12).

- The Testing section now describes the actual suite and how to run it locally; no display needed since `tests/conftest.py` sets the offscreen Qt platform.
- Code Style now mentions the `ruff check .` lint that CI enforces.

Docs-only change.