### PR TITLE
fix: autostart .desktop entry breaks when the install path contains a space

### DIFF
--- a/mycat/autostart.py
+++ b/mycat/autostart.py
@@ -18,10 +18,17 @@ WIN_RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
 
 
 def launch_command() -> str:
-    """Command that starts mycat — the installed console script, else python -m."""
+    """Command that starts mycat — the installed console script, else python -m.
+
+    The path is always quoted: the .desktop Exec line is word-split on
+    spaces, so an unquoted script path with a space in it (e.g. a home
+    directory like ``/home/anna maria``) breaks the autostart entry. The
+    same string goes into the Windows Run key, where unquoted paths with
+    spaces are ambiguous.
+    """
     exe = shutil.which("mycat")
     if exe:
-        return exe
+        return f'"{exe}"'
     return f'"{sys.executable}" -m mycat'
 
 

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -11,6 +11,35 @@ def test_launch_command_is_nonempty():
     assert autostart.launch_command()
 
 
+def test_launch_command_quotes_installed_script_path(monkeypatch):
+    exe = "/home/anna maria/.local/bin/mycat"
+    monkeypatch.setattr(autostart.shutil, "which", lambda _name: exe)
+    assert autostart.launch_command() == f'"{exe}"'
+
+
+def test_launch_command_fallback_quotes_python(monkeypatch):
+    monkeypatch.setattr(autostart.shutil, "which", lambda _name: None)
+    command = autostart.launch_command()
+    assert command.startswith(f'"{sys.executable}"')
+    assert command.endswith("-m mycat")
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux XDG autostart")
+def test_linux_desktop_exec_survives_space_in_path(monkeypatch, tmp_path):
+    import shlex
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    exe = "/home/anna maria/.local/bin/mycat"
+    monkeypatch.setattr(autostart.shutil, "which", lambda _name: exe)
+
+    autostart.set_enabled(True)
+    text = autostart.linux_desktop_path().read_text()
+    exec_value = next(
+        line for line in text.splitlines() if line.startswith("Exec=")
+    ).removeprefix("Exec=")
+    assert shlex.split(exec_value) == [exe]
+
+
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux XDG autostart")
 def test_linux_enable_disable_roundtrip(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))


### PR DESCRIPTION
Found a small one in the autostart toggle.

`launch_command()` returns the path from `shutil.which("mycat")` unquoted,
and the `Exec=` line of a `.desktop` file is word-split on spaces. If the
console script sits in a path with a space — say a home directory like
`/home/anna maria`, so the script is `/home/anna maria/.local/bin/mycat` —
GLib parses the line as

```
>>> GLib.shell_parse_argv("/home/anna maria/.local/bin/mycat")
['/home/anna', 'maria/.local/bin/mycat']
```

and refuses to load the entry: `gio launch` reports "Unable to load
application information", and on login the autostart silently does nothing.

I reproduced it end to end (GLib 2.80): a marker script in `/tmp/space dir/`
never runs from the unquoted entry, the same entry with a quoted `Exec=`
starts it fine, and an unquoted entry for a path without spaces also works —
so the space really is the trigger.

The `python -m` fallback one line below already quotes `sys.executable` for
exactly this reason; the `which()` branch just missed the same treatment.
Fix: always quote the path — quoting is harmless when there are no spaces.

Tests: three new cases in `tests/test_autostart.py` — the `which()` path
comes back quoted, the fallback stays quoted, and the `Exec=` line generated
by `linux_set()` word-splits back to exactly the script path (via `shlex`,
which follows the same POSIX splitting rules). The existing enable/disable
roundtrip still passes.
