### PR TITLE
feat: opt-in keyboard heatmap in the Activity tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.1.22] - Unreleased
+
+### Added
+- **Opt-in keyboard heatmap in the Activity tab.** A new **Keyboard** button next to *Save* opens an on-screen Latin QWERTY board that colours each key cold-blue (rarely pressed) to hot-red (most pressed) for the current session. Collecting the counts is a separate opt-in that lives in the heatmap window and is **off by default**; only aggregate per-key counts are kept, in memory, never the order/timing/text and never on disk (they reset on restart). Counting is by logical character folded onto the Latin board, so a Cyrillic layout maps to nothing and isn't shown. The Activity toggle row was relabelled to **Enable: Tracking / Mouse / Keyboard / Tooltip** (branch `feat/keyboard-heatmap`).
+
 ## [0.1.21] - Unreleased
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
-## [0.1.22] - Unreleased
+## [0.1.22] - 2026-07-19
 
 ### Added
 - **Opt-in keyboard heatmap in the Activity tab.** A new **Heatmap** button next to *Save* (enabled only while the toggle is on) opens an on-screen Latin QWERTY board that colours each key on a blue→red scale — blue = 1 press, red = the most presses on a single key this session — with a matching gradient legend under the board. Collecting the counts is a separate **Heatmap** toggle in the Activity *Enable:* row, **off by default**; only aggregate per-key counts are kept, in memory, never the order/timing/text and never on disk (they reset on restart). Counting is by logical character folded onto the Latin board, so a Cyrillic layout maps to nothing and isn't shown. The toggle row now reads **Enable: Tracking / Mouse / Keyboard / Heatmap / Tooltip** (branch `feat/keyboard-heatmap`).
 
-## [0.1.21] - Unreleased
+## [0.1.21] - 2026-07-19
 
 ### Changed
 - **CONTRIBUTING documents the real test suite and lint.** The guide still said there were no automated tests; it now describes the `pytest` suite in `tests/` (headless via the offscreen Qt platform, so no display is needed) and the `ruff check .` lint that CI enforces on Python 3.10 / 3.12 (by @iderex, #106, branch `docs/contributing-tests-ruff`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ## [0.1.22] - Unreleased
 
 ### Added
-- **Opt-in keyboard heatmap in the Activity tab.** A new **Keyboard heatmap** button next to *Save* opens an on-screen Latin QWERTY board that colours each key cold-blue (rarely pressed) to hot-red (most pressed) for the current session. Collecting the counts is a separate **Collect keys** toggle in the Activity *Enable:* row, **off by default**; only aggregate per-key counts are kept, in memory, never the order/timing/text and never on disk (they reset on restart). Counting is by logical character folded onto the Latin board, so a Cyrillic layout maps to nothing and isn't shown. The toggle row now reads **Enable: Tracking / Mouse / Keyboard / Collect keys / Tooltip** (branch `feat/keyboard-heatmap`).
+- **Opt-in keyboard heatmap in the Activity tab.** A new **Heatmap** button next to *Save* (enabled only while the toggle is on) opens an on-screen Latin QWERTY board that colours each key on a blue→red scale — blue = 1 press, red = the most presses on a single key this session — with a matching gradient legend under the board. Collecting the counts is a separate **Heatmap** toggle in the Activity *Enable:* row, **off by default**; only aggregate per-key counts are kept, in memory, never the order/timing/text and never on disk (they reset on restart). Counting is by logical character folded onto the Latin board, so a Cyrillic layout maps to nothing and isn't shown. The toggle row now reads **Enable: Tracking / Mouse / Keyboard / Heatmap / Tooltip** (branch `feat/keyboard-heatmap`).
 
 ## [0.1.21] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ## [0.1.22] - Unreleased
 
 ### Added
-- **Opt-in keyboard heatmap in the Activity tab.** A new **Keyboard** button next to *Save* opens an on-screen Latin QWERTY board that colours each key cold-blue (rarely pressed) to hot-red (most pressed) for the current session. Collecting the counts is a separate opt-in that lives in the heatmap window and is **off by default**; only aggregate per-key counts are kept, in memory, never the order/timing/text and never on disk (they reset on restart). Counting is by logical character folded onto the Latin board, so a Cyrillic layout maps to nothing and isn't shown. The Activity toggle row was relabelled to **Enable: Tracking / Mouse / Keyboard / Tooltip** (branch `feat/keyboard-heatmap`).
+- **Opt-in keyboard heatmap in the Activity tab.** A new **Keyboard heatmap** button next to *Save* opens an on-screen Latin QWERTY board that colours each key cold-blue (rarely pressed) to hot-red (most pressed) for the current session. Collecting the counts is a separate **Collect keys** toggle in the Activity *Enable:* row, **off by default**; only aggregate per-key counts are kept, in memory, never the order/timing/text and never on disk (they reset on restart). Counting is by logical character folded onto the Latin board, so a Cyrillic layout maps to nothing and isn't shown. The toggle row now reads **Enable: Tracking / Mouse / Keyboard / Collect keys / Tooltip** (branch `feat/keyboard-heatmap`).
 
 ## [0.1.21] - Unreleased
 

--- a/mycat/activity.py
+++ b/mycat/activity.py
@@ -3,10 +3,13 @@
 
 Hard rules, in order of importance:
 
-1. **Counters, never content.** The keyboard hook increments an integer and
-   discards the key identity in the same callback; the mouse contributes a
-   travelled distance, never a trajectory. Nothing here can reconstruct what
-   was typed or where the cursor went.
+1. **Counters, never content.** The diary keyboard hook increments an integer
+   and discards the key identity in the same callback; the mouse contributes a
+   travelled distance, never a trajectory. Nothing persisted here can
+   reconstruct what was typed or where the cursor went. The one exception is
+   the opt-in keyboard heatmap (``key_heatmap_enabled``, off by default): it
+   keeps aggregate *per-key* counts — but in memory only, never the order,
+   timing or text, and never on disk (gone on restart).
 2. **Local only.** Everything lands in ``activity.db`` next to the focus
    sessions and participates in no network request of any kind.
 3. **Honest wording.** Minutes without input are "away from the computer",
@@ -29,6 +32,7 @@ the diary is on — the cat's eyes track the cursor anyway — so it has no togg
 
 import configparser
 import logging
+import threading
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -36,12 +40,13 @@ from pathlib import Path
 from PySide6 import QtCore, QtGui
 
 if __package__:
-    from . import activity_store, secret_store
+    from . import activity_store, key_heatmap, secret_store
 else:
     import importlib
 
     activity_store = importlib.import_module("mycat.activity_store")
     secret_store = importlib.import_module("mycat.secret_store")
+    key_heatmap = importlib.import_module("mycat.key_heatmap")
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +83,10 @@ class ActivitySettings:
     # the diary is on — the cat's eyes need the cursor anyway — so it has no toggle.
     mouse_enabled: bool = True
     keyboard_enabled: bool = True
+    # Optional, off by default: an in-memory per-key tally for the keyboard
+    # heatmap window. Separate from keyboard_enabled (the diary count track) and
+    # session-only — the counts are never written to disk.
+    key_heatmap_enabled: bool = False
     retention_days: int = DEFAULT_RETENTION_DAYS
     prompted: bool = False  # kept for config compatibility (prompt removed)
 
@@ -117,6 +126,7 @@ def load_activity_settings(cfg_file: Path = CFG_FILE) -> ActivitySettings:
         settings.enabled = section.getboolean("enabled", fallback=True)
         settings.mouse_enabled = section.getboolean("mouse_enabled", fallback=True)
         settings.keyboard_enabled = section.getboolean("keyboard_enabled", fallback=True)
+        settings.key_heatmap_enabled = section.getboolean("key_heatmap_enabled", fallback=False)
         settings.retention_days = section.getint("retention_days", fallback=DEFAULT_RETENTION_DAYS)
         settings.prompted = section.getboolean("prompted", fallback=False)
     except Exception as exc:  # noqa: BLE001 - never let a bad config crash the app
@@ -136,6 +146,7 @@ def save_activity_settings(settings: ActivitySettings, cfg_file: Path = CFG_FILE
         section["enabled"] = "true" if settings.enabled else "false"
         section["mouse_enabled"] = "true" if settings.mouse_enabled else "false"
         section["keyboard_enabled"] = "true" if settings.keyboard_enabled else "false"
+        section["key_heatmap_enabled"] = "true" if settings.key_heatmap_enabled else "false"
         section["retention_days"] = str(settings.retention_days)
         section["prompted"] = "true" if settings.prompted else "false"
         with open(cfg_file, "w") as fh:
@@ -185,6 +196,10 @@ class ActivityCollector(QtCore.QObject):
         self.key_listener = None
         self.mouse_listener = None
         self.xinput = None  # pure-Python X11 counter, the fallback when pynput is absent
+        # Session-only per-key tally for the heatmap. Touched from listener
+        # threads, so guard it with a lock. Never persisted, cleared on restart.
+        self.key_cell_counts: dict[str, int] = {}
+        self.key_counts_lock = threading.Lock()
         self.purged_today = False
         # Idle-edge detection (auto-pomodoro trigger) + current activity run.
         self.last_input_at = None
@@ -198,6 +213,9 @@ class ActivityCollector(QtCore.QObject):
             self.poll_timer.timeout.connect(self.sample)
             if self.settings.mouse_enabled or self.settings.keyboard_enabled:
                 self.start()
+            elif self.settings.key_heatmap_enabled:
+                # Heatmap-only: no disk diary, just the keyboard hook.
+                self.reconcile_hooks()
 
     # -- lifecycle --------------------------------------------------------------
 
@@ -221,21 +239,36 @@ class ActivityCollector(QtCore.QObject):
         logger.info("Activity collector stopped")
 
     def apply_settings(self, settings: ActivitySettings) -> None:
-        # "Enable Tracking" (settings.enabled) drives only the cat's eyes; the
-        # diary runs whenever either count track is on, independent of it.
+        # "Enable Tracking" (settings.enabled) drives only the cat's eyes. The
+        # disk diary runs whenever a count track is on; the keyboard hook also
+        # runs for the session-only heatmap, independent of the diary.
         was_recording = self.settings.mouse_enabled or self.settings.keyboard_enabled
         self.settings = settings
         recording = settings.mouse_enabled or settings.keyboard_enabled
-        if recording and not was_recording:
-            self.start()
+        active = recording or settings.key_heatmap_enabled
+        if recording and not was_recording and hasattr(self, "poll_timer"):
+            self.poll_timer.start()
         elif not recording and was_recording:
-            self.stop()
-        elif recording:
+            self.stop_recording()
+        if active:
             self.reconcile_hooks()
+        else:
+            self.stop_keyboard_hook()
+            self.stop_mouse_hook()
+            self.stop_xinput()
+
+    def stop_recording(self) -> None:
+        """Stop the disk diary (poll timer + flush) but leave the hooks alone."""
+        if hasattr(self, "poll_timer"):
+            self.poll_timer.stop()
+        self.flush()
 
     def reconcile_hooks(self) -> None:
-        """Start/stop the keyboard and mouse click hooks to match the settings."""
-        if self.settings.keyboard_enabled:
+        """Start/stop the keyboard and mouse click hooks to match the settings.
+
+        The keyboard hook also feeds the session heatmap, so it runs when either
+        the diary keyboard count or the heatmap opt-in is on."""
+        if self.settings.keyboard_enabled or self.settings.key_heatmap_enabled:
             self.start_keyboard_hook()
         else:
             self.stop_keyboard_hook()
@@ -243,6 +276,8 @@ class ActivityCollector(QtCore.QObject):
             self.start_mouse_hook()
         else:
             self.stop_mouse_hook()
+        if self.xinput is not None:
+            self.xinput.resolve_chars = self.settings.key_heatmap_enabled
 
     # -- tier 2: key/click counts — pynput (Windows/macOS) or python-xlib (Linux) --
 
@@ -256,8 +291,15 @@ class ActivityCollector(QtCore.QObject):
             return
 
         def on_press(key) -> None:
-            # The key identity is dropped RIGHT HERE — only the count survives.
-            self.bucket_keys += 1
+            # Diary count track: the key identity is dropped RIGHT HERE — only
+            # the running total survives.
+            if self.settings.keyboard_enabled:
+                self.bucket_keys += 1
+            # Optional session heatmap: bucket the key by its Latin-QWERTY cell,
+            # then discard the key. No order, no timing, no text — and only while
+            # the opt-in is on.
+            if self.settings.key_heatmap_enabled:
+                self.record_key_cell(key_heatmap.cell_for_pynput_key(key))
 
         try:
             self.key_listener = keyboard.Listener(on_press=on_press)
@@ -316,20 +358,37 @@ class ActivityCollector(QtCore.QObject):
             logger.warning("key/click counting off — no X11 RECORD (Wayland?); cursor path still recorded")
             return
         counter = xinput_linux.InputCounter(on_key=self.on_xinput_key, on_click=self.on_xinput_click)
+        counter.resolve_chars = self.settings.key_heatmap_enabled
         if counter.start():
             self.xinput = counter
             logger.info("Key/click counting via python-xlib (X11)")
         else:
             logger.warning("key/click counting off — X11 RECORD unavailable; cursor path still recorded")
 
-    def on_xinput_key(self) -> None:
-        # The key identity never leaves the record thread — only the count survives.
+    def on_xinput_key(self, cell: str | None = None) -> None:
+        # Diary count track: only the running total survives.
         if self.settings.keyboard_enabled:
             self.bucket_keys += 1
+        # Optional session heatmap: the record thread already resolved the key to
+        # its Latin-QWERTY cell (only when the opt-in is on); bucket and forget.
+        if self.settings.key_heatmap_enabled:
+            self.record_key_cell(cell)
 
     def on_xinput_click(self) -> None:
         if self.settings.mouse_enabled:
             self.bucket_clicks += 1
+
+    def record_key_cell(self, cell: str | None) -> None:
+        """Add one to a heatmap cell's session tally (thread-safe, in memory)."""
+        if not cell:
+            return
+        with self.key_counts_lock:
+            self.key_cell_counts[cell] = self.key_cell_counts.get(cell, 0) + 1
+
+    def snapshot_key_cells(self) -> dict[str, int]:
+        """A copy of the current per-cell session counts for the heatmap window."""
+        with self.key_counts_lock:
+            return dict(self.key_cell_counts)
 
     def stop_xinput(self) -> None:
         if self.xinput is not None:

--- a/mycat/activity_ui.py
+++ b/mycat/activity_ui.py
@@ -414,7 +414,6 @@ class ActivityDialog(QtWidgets.QDialog):
         button_row.addWidget(self.save_button)
         button_row.addWidget(self.close_button)
         layout.addLayout(button_row)
-        self.keyboard_dialog = None
 
         self.refresh_log()
         self.refresh_now()
@@ -772,15 +771,23 @@ class ActivityDialog(QtWidgets.QDialog):
         self.refresh_log()
 
     def open_keyboard_heatmap(self) -> None:
-        """Open (or re-raise) the live keyboard heatmap window."""
-        if self.keyboard_dialog is None:
-            from .key_heatmap_ui import KeyboardHeatmapDialog
+        """Open (or re-raise) the heatmap window, then close this Activity window.
 
-            self.keyboard_dialog = KeyboardHeatmapDialog(self.collector, parent=self)
-            self.keyboard_dialog.finished.connect(lambda result: setattr(self, "keyboard_dialog", None))
-        self.keyboard_dialog.show()
-        self.keyboard_dialog.raise_()
-        self.keyboard_dialog.activateWindow()
+        The heatmap is parented to the main window (not this dialog) and its
+        single instance is tracked there, so it outlives the Activity window we
+        close right after."""
+        from .key_heatmap_ui import KeyboardHeatmapDialog
+
+        host = self.parent() or self
+        dialog = getattr(host, "keyboard_heatmap_dialog", None)
+        if dialog is None:
+            dialog = KeyboardHeatmapDialog(self.collector, parent=self.parent())
+            host.keyboard_heatmap_dialog = dialog
+            dialog.finished.connect(lambda result, owner=host: setattr(owner, "keyboard_heatmap_dialog", None))
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
+        self.close()
 
     def save_settings(self) -> None:
         """Persist + apply, keeping the dialog open (matches GitHub/Calendar)."""

--- a/mycat/activity_ui.py
+++ b/mycat/activity_ui.py
@@ -255,26 +255,28 @@ class ActivityDialog(QtWidgets.QDialog):
 
         # Three independent toggles: Tracking drives only the cat's eyes, while
         # Mouse and Keyboard are the diary count tracks. None greys out the others.
-        self.enabled_box = QtWidgets.QCheckBox("Enable Tracking")
+        self.enabled_box = QtWidgets.QCheckBox("Tracking")
         self.enabled_box.setToolTip(
             "The cat's eyes follow your cursor; off, it looks at its own nose.\n"
             "Purely visual — it records nothing."
         )
         self.enabled_box.setChecked(settings.enabled)
-        self.mouse_box = QtWidgets.QCheckBox("Enable Mouse")
+        self.mouse_box = QtWidgets.QCheckBox("Mouse")
         self.mouse_box.setToolTip("Mouse click count in the private diary (never targets).")
         self.mouse_box.setChecked(settings.mouse_enabled)
-        self.keyboard_box = QtWidgets.QCheckBox("Enable Keyboard")
-        self.keyboard_box.setToolTip("Keystroke count (never which keys).")
+        self.keyboard_box = QtWidgets.QCheckBox("Keyboard")
+        self.keyboard_box.setToolTip("Keystroke count in the diary (never which keys).")
         self.keyboard_box.setChecked(settings.keyboard_enabled)
         # Independent of the tracking tracks: whether hovering the cat shows the
         # live stats tooltip (driven by the FocusController).
-        self.tooltip_box = QtWidgets.QCheckBox("Enable Tooltip")
+        self.tooltip_box = QtWidgets.QCheckBox("Tooltip")
         self.tooltip_box.setToolTip("Show the live focus/activity stats when you hover over the cat.")
         self.tooltip_box.setChecked(self.tooltip_enabled())
-        # Four toggles share the top row; the destructive Delete-all lives in the
-        # bottom bar (next to Export) so this row never runs out of width.
+        # An "Enable:" label leads the four toggles; the destructive Delete-all
+        # lives in the bottom bar (next to Export) so this row never runs out of
+        # width.
         toggles_row = QtWidgets.QHBoxLayout()
+        toggles_row.addWidget(QtWidgets.QLabel("Enable:"))
         toggles_row.addWidget(self.enabled_box)
         toggles_row.addSpacing(16)
         toggles_row.addWidget(self.mouse_box)
@@ -389,6 +391,10 @@ class ActivityDialog(QtWidgets.QDialog):
         self.delete_button.clicked.connect(self.delete_all)
         button_row.addWidget(self.delete_button)
         button_row.addStretch(1)
+        self.keyboard_button = QtWidgets.QPushButton("Keyboard")
+        self.keyboard_button.setToolTip("Open a live keyboard heatmap of key presses this session.")
+        self.keyboard_button.clicked.connect(self.open_keyboard_heatmap)
+        button_row.addWidget(self.keyboard_button)
         self.save_button = QtWidgets.QPushButton("Save")
         self.close_button = QtWidgets.QPushButton("Close")
         self.save_button.clicked.connect(self.save_settings)
@@ -396,6 +402,7 @@ class ActivityDialog(QtWidgets.QDialog):
         button_row.addWidget(self.save_button)
         button_row.addWidget(self.close_button)
         layout.addLayout(button_row)
+        self.keyboard_dialog = None
 
         self.refresh_log()
         self.refresh_now()
@@ -752,12 +759,26 @@ class ActivityDialog(QtWidgets.QDialog):
             logger.exception("Failed to delete activity history")
         self.refresh_log()
 
+    def open_keyboard_heatmap(self) -> None:
+        """Open (or re-raise) the live keyboard heatmap window."""
+        if self.keyboard_dialog is None:
+            from .key_heatmap_ui import KeyboardHeatmapDialog
+
+            self.keyboard_dialog = KeyboardHeatmapDialog(self.collector, parent=self)
+            self.keyboard_dialog.finished.connect(lambda result: setattr(self, "keyboard_dialog", None))
+        self.keyboard_dialog.show()
+        self.keyboard_dialog.raise_()
+        self.keyboard_dialog.activateWindow()
+
     def save_settings(self) -> None:
         """Persist + apply, keeping the dialog open (matches GitHub/Calendar)."""
         settings = activity_mod.ActivitySettings(
             enabled=self.enabled_box.isChecked(),
             mouse_enabled=self.mouse_box.isChecked(),
             keyboard_enabled=self.keyboard_box.isChecked(),
+            # The heatmap opt-in is toggled from its own window; carry it through
+            # so a Save here never silently turns it off.
+            key_heatmap_enabled=self.collector.settings.key_heatmap_enabled,
             retention_days=self.retention_spin.value(),
             prompted=True,
         )

--- a/mycat/activity_ui.py
+++ b/mycat/activity_ui.py
@@ -267,6 +267,14 @@ class ActivityDialog(QtWidgets.QDialog):
         self.keyboard_box = QtWidgets.QCheckBox("Keyboard")
         self.keyboard_box.setToolTip("Keystroke count in the diary (never which keys).")
         self.keyboard_box.setChecked(settings.keyboard_enabled)
+        # Opt-in per-key heatmap collection (off by default). Session-only,
+        # aggregate counts in memory — feeds the Keyboard heatmap window.
+        self.collect_box = QtWidgets.QCheckBox("Collect keys")
+        self.collect_box.setToolTip(
+            "Count key presses per key for the Keyboard heatmap. Aggregate counts only —\n"
+            "never the order, timing or text — kept in memory and gone on restart."
+        )
+        self.collect_box.setChecked(settings.key_heatmap_enabled)
         # Independent of the tracking tracks: whether hovering the cat shows the
         # live stats tooltip (driven by the FocusController).
         self.tooltip_box = QtWidgets.QCheckBox("Tooltip")
@@ -281,6 +289,7 @@ class ActivityDialog(QtWidgets.QDialog):
         toggles_row.addSpacing(16)
         toggles_row.addWidget(self.mouse_box)
         toggles_row.addWidget(self.keyboard_box)
+        toggles_row.addWidget(self.collect_box)
         toggles_row.addWidget(self.tooltip_box)
         toggles_row.addStretch(1)
         layout.addLayout(toggles_row)
@@ -391,7 +400,7 @@ class ActivityDialog(QtWidgets.QDialog):
         self.delete_button.clicked.connect(self.delete_all)
         button_row.addWidget(self.delete_button)
         button_row.addStretch(1)
-        self.keyboard_button = QtWidgets.QPushButton("Keyboard")
+        self.keyboard_button = QtWidgets.QPushButton("Keyboard heatmap")
         self.keyboard_button.setToolTip("Open a live keyboard heatmap of key presses this session.")
         self.keyboard_button.clicked.connect(self.open_keyboard_heatmap)
         button_row.addWidget(self.keyboard_button)
@@ -776,9 +785,7 @@ class ActivityDialog(QtWidgets.QDialog):
             enabled=self.enabled_box.isChecked(),
             mouse_enabled=self.mouse_box.isChecked(),
             keyboard_enabled=self.keyboard_box.isChecked(),
-            # The heatmap opt-in is toggled from its own window; carry it through
-            # so a Save here never silently turns it off.
-            key_heatmap_enabled=self.collector.settings.key_heatmap_enabled,
+            key_heatmap_enabled=self.collect_box.isChecked(),
             retention_days=self.retention_spin.value(),
             prompted=True,
         )

--- a/mycat/activity_ui.py
+++ b/mycat/activity_ui.py
@@ -269,9 +269,9 @@ class ActivityDialog(QtWidgets.QDialog):
         self.keyboard_box.setChecked(settings.keyboard_enabled)
         # Opt-in per-key heatmap collection (off by default). Session-only,
         # aggregate counts in memory — feeds the Keyboard heatmap window.
-        self.collect_box = QtWidgets.QCheckBox("Collect keys")
+        self.collect_box = QtWidgets.QCheckBox("Heatmap")
         self.collect_box.setToolTip(
-            "Count key presses per key for the Keyboard heatmap. Aggregate counts only —\n"
+            "Count key presses per key for the Heatmap window. Aggregate counts only —\n"
             "never the order, timing or text — kept in memory and gone on restart."
         )
         self.collect_box.setChecked(settings.key_heatmap_enabled)
@@ -400,8 +400,11 @@ class ActivityDialog(QtWidgets.QDialog):
         self.delete_button.clicked.connect(self.delete_all)
         button_row.addWidget(self.delete_button)
         button_row.addStretch(1)
-        self.keyboard_button = QtWidgets.QPushButton("Keyboard heatmap")
+        self.keyboard_button = QtWidgets.QPushButton("Heatmap")
         self.keyboard_button.setToolTip("Open a live keyboard heatmap of key presses this session.")
+        # Only usable once the Heatmap toggle is on — nothing is collected otherwise.
+        self.keyboard_button.setEnabled(self.collect_box.isChecked())
+        self.collect_box.toggled.connect(self.keyboard_button.setEnabled)
         self.keyboard_button.clicked.connect(self.open_keyboard_heatmap)
         button_row.addWidget(self.keyboard_button)
         self.save_button = QtWidgets.QPushButton("Save")

--- a/mycat/key_heatmap.py
+++ b/mycat/key_heatmap.py
@@ -1,0 +1,136 @@
+"""Pure layout + key-to-cell mapping for the optional keyboard heatmap.
+
+No Qt here — this module is imported both by the Qt dialog and by the X11
+record thread, so it must stay dependency-free. It knows two things:
+
+1. **Which diagram cell a keypress belongs to.** Counting is by *logical
+   character* on a Latin QWERTY board: `A`/`a`/Shift+`a` all land on the `a`
+   cell, `!` lands on `1`, and non-Latin input (e.g. a Cyrillic layout) maps
+   to nothing and is simply not shown. Only aggregate per-cell counts ever
+   exist, and only in memory — never the order, timing or text.
+2. **The board to draw.** `KEYBOARD_ROWS` is a Latin QWERTY with a function
+   row, modifiers and space; every key has a stable cell id, a label and a
+   width in key units.
+"""
+
+from __future__ import annotations
+
+# Shifted punctuation folds back onto its unshifted key so the heatmap counts
+# by physical letter, not by the shifted glyph.
+SHIFTED_TO_BASE = {
+    "!": "1", "@": "2", "#": "3", "$": "4", "%": "5", "^": "6", "&": "7",
+    "*": "8", "(": "9", ")": "0", "_": "-", "+": "=", "{": "[", "}": "]",
+    "|": "\\", ":": ";", '"': "'", "<": ",", ">": ".", "?": "/", "~": "`",
+}
+
+# The unshifted glyphs that are their own cell on the board.
+BASE_KEYS = set("`1234567890-=qwertyuiop[]\\asdfghjkl;'zxcvbnm,./")
+
+# pynput's Key.<name> for the non-character keys we colour.
+SPECIAL_CELLS = {
+    "space": "space", "enter": "enter", "return": "enter",
+    "tab": "tab", "backspace": "backspace",
+}
+
+# X11 keysyms for those same non-character keys (space arrives as 0x20 and is
+# handled through the ASCII path, so it isn't listed here).
+SPECIAL_KEYSYMS = {
+    0xFF0D: "enter",       # XK_Return
+    0xFF8D: "enter",       # XK_KP_Enter
+    0xFF09: "tab",         # XK_Tab
+    0xFF08: "backspace",   # XK_BackSpace
+}
+
+
+def char_to_cell(ch: str | None) -> str | None:
+    """The board cell a produced character belongs to, or None if off-board."""
+    if not ch or len(ch) != 1:
+        return None
+    if ch == " ":
+        return "space"
+    lower = ch.lower()
+    if "a" <= lower <= "z":
+        return lower
+    if ch in SHIFTED_TO_BASE:
+        return SHIFTED_TO_BASE[ch]
+    if ch in BASE_KEYS:
+        return ch
+    return None
+
+
+def cell_for_pynput_key(key) -> str | None:
+    """Map a pynput key (Windows/macOS) to a board cell, or None."""
+    ch = getattr(key, "char", None)
+    if ch:
+        return char_to_cell(ch)
+    name = getattr(key, "name", None)
+    if name:
+        return SPECIAL_CELLS.get(name.lower())
+    return None
+
+
+def cell_for_keysym(keysym: int) -> str | None:
+    """Map an X11 keysym to a board cell, or None (non-Latin layouts fall here)."""
+    if 0x20 <= keysym <= 0x7E:
+        return char_to_cell(chr(keysym))
+    return SPECIAL_KEYSYMS.get(keysym)
+
+
+def heat_rgb(fraction: float) -> tuple[int, int, int]:
+    """Cold→hot colour for a 0..1 fraction: blue → cyan → green → yellow → red.
+
+    A hue sweep from 240° (blue, rarely pressed) down to 0° (red, most
+    pressed) — the familiar thermal ramp Olya asked for ("синий → красный").
+    """
+    fraction = 0.0 if fraction < 0 else 1.0 if fraction > 1 else fraction
+    hue = 240.0 * (1.0 - fraction)     # 240=blue … 0=red
+    saturation = 1.0
+    value = 0.92
+    sector = hue / 60.0
+    i = int(sector) % 6
+    f = sector - int(sector)
+    p = value * (1.0 - saturation)
+    q = value * (1.0 - saturation * f)
+    t = value * (1.0 - saturation * (1.0 - f))
+    r, g, b = (
+        (value, t, p), (q, value, p), (p, value, t),
+        (p, q, value), (t, p, value), (value, p, q),
+    )[i]
+    return round(r * 255), round(g * 255), round(b * 255)
+
+
+# Each row: (cell_id, label, width in key units). Cell ids that key resolution
+# never produces (modifiers, function keys) simply stay grey.
+KEYBOARD_ROWS = [
+    [
+        ("esc", "Esc", 1.0), ("f1", "F1", 1.0), ("f2", "F2", 1.0), ("f3", "F3", 1.0),
+        ("f4", "F4", 1.0), ("f5", "F5", 1.0), ("f6", "F6", 1.0), ("f7", "F7", 1.0),
+        ("f8", "F8", 1.0), ("f9", "F9", 1.0), ("f10", "F10", 1.0), ("f11", "F11", 1.0),
+        ("f12", "F12", 1.0),
+    ],
+    [
+        ("`", "`", 1.0), ("1", "1", 1.0), ("2", "2", 1.0), ("3", "3", 1.0), ("4", "4", 1.0),
+        ("5", "5", 1.0), ("6", "6", 1.0), ("7", "7", 1.0), ("8", "8", 1.0), ("9", "9", 1.0),
+        ("0", "0", 1.0), ("-", "-", 1.0), ("=", "=", 1.0), ("backspace", "⌫", 2.0),
+    ],
+    [
+        ("tab", "Tab", 1.5), ("q", "Q", 1.0), ("w", "W", 1.0), ("e", "E", 1.0), ("r", "R", 1.0),
+        ("t", "T", 1.0), ("y", "Y", 1.0), ("u", "U", 1.0), ("i", "I", 1.0), ("o", "O", 1.0),
+        ("p", "P", 1.0), ("[", "[", 1.0), ("]", "]", 1.0), ("\\", "\\", 1.5),
+    ],
+    [
+        ("caps", "Caps", 1.75), ("a", "A", 1.0), ("s", "S", 1.0), ("d", "D", 1.0), ("f", "F", 1.0),
+        ("g", "G", 1.0), ("h", "H", 1.0), ("j", "J", 1.0), ("k", "K", 1.0), ("l", "L", 1.0),
+        (";", ";", 1.0), ("'", "'", 1.0), ("enter", "⏎", 2.25),
+    ],
+    [
+        ("lshift", "Shift", 2.25), ("z", "Z", 1.0), ("x", "X", 1.0), ("c", "C", 1.0), ("v", "V", 1.0),
+        ("b", "B", 1.0), ("n", "N", 1.0), ("m", "M", 1.0), (",", ",", 1.0), (".", ".", 1.0),
+        ("/", "/", 1.0), ("rshift", "Shift", 2.75),
+    ],
+    [
+        ("lctrl", "Ctrl", 1.5), ("lsuper", "Super", 1.25), ("lalt", "Alt", 1.25),
+        ("space", "Space", 6.5), ("ralt", "Alt", 1.25), ("rsuper", "Super", 1.25),
+        ("rctrl", "Ctrl", 1.5),
+    ],
+]

--- a/mycat/key_heatmap_ui.py
+++ b/mycat/key_heatmap_ui.py
@@ -177,9 +177,9 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
                 "permission), so nothing can be collected."
             )
         elif not self.collector.settings.key_heatmap_enabled:
-            self.note.setText("Collection is off — tick “Collect keys” in the Activity window and Save.")
+            self.note.setText("Collection is off — tick “Heatmap” in the Activity window and Save.")
         else:
-            self.note.setText("Counting this session — press keys and the map fills in.")
+            self.note.setText("")
 
     def refresh(self) -> None:
         self.update_note()

--- a/mycat/key_heatmap_ui.py
+++ b/mycat/key_heatmap_ui.py
@@ -9,14 +9,11 @@ lives right here on the board.
 
 from __future__ import annotations
 
-import logging
-
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import activity as activity_mod
 from . import key_heatmap
-
-logger = logging.getLogger(__name__)
+from .ui_theme import LIGHT_QSS
 
 GREY = QtGui.QColor(210, 210, 210)
 GREY_BORDER = QtGui.QColor(170, 170, 170)
@@ -91,12 +88,12 @@ class KeyboardBoard(QtWidgets.QWidget):
 
 
 class HeatLegend(QtWidgets.QWidget):
-    """The colour scale under the board: blue = 1 press, red = the peak count."""
+    """Single-row colour scale: `1` (min) — gradient — peak (max), all inline."""
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.peak = 0
-        self.setFixedHeight(42)
+        self.setFixedHeight(24)
 
     def set_peak(self, peak: int) -> None:
         self.peak = peak
@@ -105,8 +102,25 @@ class HeatLegend(QtWidgets.QWidget):
     def paintEvent(self, event) -> None:
         painter = QtGui.QPainter(self)
         painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
-        margin = 8.0
-        bar = QtCore.QRectF(margin, 4.0, self.width() - 2 * margin, 14.0)
+        min_text = "1"
+        max_text = f"{self.peak:,}" if self.peak > 0 else "—"
+        metrics = painter.fontMetrics()
+        min_w = metrics.horizontalAdvance(min_text)
+        max_w = metrics.horizontalAdvance(max_text)
+        h = float(self.height())
+
+        painter.setPen(QtGui.QColor(110, 110, 110))
+        left_cells = QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter
+        right_cells = QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter
+        painter.drawText(QtCore.QRectF(0.0, 0.0, min_w, h), left_cells, min_text)
+        painter.drawText(QtCore.QRectF(self.width() - max_w, 0.0, max_w, h), right_cells, max_text)
+
+        pad = 8.0
+        bar_h = 12.0
+        bar = QtCore.QRectF(
+            min_w + pad, (h - bar_h) / 2.0,
+            max(1.0, self.width() - min_w - max_w - 2 * pad), bar_h,
+        )
         gradient = QtGui.QLinearGradient(bar.left(), 0.0, bar.right(), 0.0)
         for step in range(11):
             r, g, b = key_heatmap.heat_rgb(step / 10.0)
@@ -114,12 +128,6 @@ class HeatLegend(QtWidgets.QWidget):
         painter.setPen(QtGui.QPen(QtGui.QColor(150, 150, 150), 1.0))
         painter.setBrush(QtGui.QBrush(gradient))
         painter.drawRoundedRect(bar, 3.0, 3.0)
-
-        painter.setPen(QtGui.QColor(110, 110, 110))
-        labels = QtCore.QRectF(margin, bar.bottom() + 2.0, self.width() - 2 * margin, 16.0)
-        painter.drawText(labels, QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter, "1")
-        peak_label = f"{self.peak:,}" if self.peak > 0 else "—"
-        painter.drawText(labels, QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter, peak_label)
         painter.end()
 
 
@@ -131,7 +139,9 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
         self.collector = collector
         self.setWindowTitle("Keyboard heatmap")
         self.setModal(False)
+        self.setMinimumWidth(700)
         self.resize(720, 400)
+        self.setStyleSheet(LIGHT_QSS)
 
         layout = QtWidgets.QVBoxLayout(self)
 

--- a/mycat/key_heatmap_ui.py
+++ b/mycat/key_heatmap_ui.py
@@ -118,11 +118,6 @@ class HeatLegend(QtWidgets.QWidget):
         painter.setPen(QtGui.QColor(110, 110, 110))
         labels = QtCore.QRectF(margin, bar.bottom() + 2.0, self.width() - 2 * margin, 16.0)
         painter.drawText(labels, QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter, "1")
-        painter.drawText(
-            labels,
-            QtCore.Qt.AlignmentFlag.AlignHCenter | QtCore.Qt.AlignmentFlag.AlignVCenter,
-            "presses per key",
-        )
         peak_label = f"{self.peak:,}" if self.peak > 0 else "—"
         painter.drawText(labels, QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter, peak_label)
         painter.end()

--- a/mycat/key_heatmap_ui.py
+++ b/mycat/key_heatmap_ui.py
@@ -1,0 +1,156 @@
+"""The on-screen keyboard heatmap window (opened by the Activity dialog).
+
+Draws a Latin QWERTY board and colours each key by how often it was pressed
+this session — cold blue for rarely, hot red for most. The counts are the
+collector's in-memory per-cell tally: session-only, never written to disk, and
+gone on restart. Collecting them is a separate opt-in (off by default) that
+lives right here on the board.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from . import activity as activity_mod
+from . import key_heatmap
+
+logger = logging.getLogger(__name__)
+
+GREY = QtGui.QColor(210, 210, 210)
+GREY_BORDER = QtGui.QColor(170, 170, 170)
+
+
+class KeyboardBoard(QtWidgets.QWidget):
+    """Paints KEYBOARD_ROWS, each key filled by its heat fraction."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.counts: dict[str, int] = {}
+        self.peak = 0
+        self.row_units = max(sum(w for _, _, w in row) for row in key_heatmap.KEYBOARD_ROWS)
+        self.setMinimumSize(660, 250)
+
+    def set_data(self, counts: dict[str, int]) -> None:
+        self.counts = counts
+        self.peak = max(counts.values()) if counts else 0
+        self.update()
+
+    def paintEvent(self, event) -> None:
+        painter = QtGui.QPainter(self)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+        gap = 4.0
+        unit = (self.width() - gap) / self.row_units
+        key_h = (self.height() - gap) / len(key_heatmap.KEYBOARD_ROWS)
+        font = painter.font()
+        font.setPointSizeF(max(7.0, min(unit, key_h) * 0.34))
+        painter.setFont(font)
+
+        y = gap / 2.0
+        for row in key_heatmap.KEYBOARD_ROWS:
+            x = gap / 2.0
+            for cell_id, label, width in row:
+                w = unit * width - gap
+                h = key_h - gap
+                rect = QtCore.QRectF(x, y, w, h)
+                count = self.counts.get(cell_id, 0)
+                if count > 0 and self.peak > 0:
+                    r, g, b = key_heatmap.heat_rgb(count / self.peak)
+                    fill = QtGui.QColor(r, g, b)
+                    border = fill.darker(130)
+                    text_color = QtGui.QColor(20, 20, 20)
+                else:
+                    fill, border, text_color = GREY, GREY_BORDER, QtGui.QColor(90, 90, 90)
+                painter.setBrush(fill)
+                painter.setPen(QtGui.QPen(border, 1.0))
+                painter.drawRoundedRect(rect, 4.0, 4.0)
+                painter.setPen(text_color)
+                if count > 0:
+                    # Split the key: label in the top, the count below it, so the
+                    # two never overlap on a 1-unit key.
+                    label_rect = QtCore.QRectF(rect.x(), rect.y(), rect.width(), h * 0.60)
+                    painter.drawText(label_rect, QtCore.Qt.AlignmentFlag.AlignCenter, label)
+                    small = QtGui.QFont(font)
+                    small.setPointSizeF(max(6.0, font.pointSizeF() * 0.72))
+                    painter.setFont(small)
+                    count_rect = QtCore.QRectF(rect.x(), rect.y() + h * 0.56, rect.width(), h * 0.40)
+                    painter.drawText(count_rect, QtCore.Qt.AlignmentFlag.AlignCenter, f"{count:,}")
+                    painter.setFont(font)
+                else:
+                    painter.drawText(rect, QtCore.Qt.AlignmentFlag.AlignCenter, label)
+                x += unit * width
+            y += key_h
+        painter.end()
+
+
+class KeyboardHeatmapDialog(QtWidgets.QDialog):
+    """A live keyboard heatmap for the current session."""
+
+    def __init__(self, collector, parent=None) -> None:
+        super().__init__(parent)
+        self.collector = collector
+        self.setWindowTitle("Keyboard heatmap")
+        self.setModal(False)
+        self.resize(720, 320)
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.collect_box = QtWidgets.QCheckBox("Collect key heatmap (this session)")
+        self.collect_box.setToolTip(
+            "Count key presses per key while this is ticked. Aggregate counts only —\n"
+            "never the order, timing or text — kept in memory and gone on restart."
+        )
+        self.collect_box.setChecked(bool(collector.settings.key_heatmap_enabled))
+        self.collect_box.toggled.connect(self.on_toggle)
+        layout.addWidget(self.collect_box)
+
+        self.note = QtWidgets.QLabel("")
+        self.note.setWordWrap(True)
+        self.note.setStyleSheet("color: #888888;")
+        layout.addWidget(self.note)
+
+        self.board = KeyboardBoard(self)
+        layout.addWidget(self.board, 1)
+
+        button_row = QtWidgets.QHBoxLayout()
+        button_row.addStretch(1)
+        self.close_button = QtWidgets.QPushButton("Close")
+        self.close_button.clicked.connect(self.reject)
+        button_row.addWidget(self.close_button)
+        layout.addLayout(button_row)
+
+        self.timer = QtCore.QTimer(self)
+        self.timer.setInterval(500)
+        self.timer.timeout.connect(self.refresh)
+        self.timer.start()
+
+        self.update_note()
+        self.refresh()
+
+    def on_toggle(self, checked: bool) -> None:
+        settings = replace(self.collector.settings, key_heatmap_enabled=checked)
+        activity_mod.save_activity_settings(settings)
+        self.collector.apply_settings(settings)
+        logger.info("Key heatmap collection %s", "on" if checked else "off")
+        self.update_note()
+        self.refresh()
+
+    def update_note(self) -> None:
+        if not activity_mod.counts_available():
+            self.note.setText(
+                "Key counting isn't available here (needs X11, or macOS Input Monitoring "
+                "permission), so nothing can be collected."
+            )
+        elif not self.collector.settings.key_heatmap_enabled:
+            self.note.setText("Collection is off — tick the box to build a heatmap for this session.")
+        else:
+            self.note.setText("Counting this session · blue = rarely pressed → red = most pressed.")
+
+    def refresh(self) -> None:
+        self.board.set_data(self.collector.snapshot_key_cells())
+
+    def closeEvent(self, event) -> None:
+        self.timer.stop()
+        super().closeEvent(event)

--- a/mycat/key_heatmap_ui.py
+++ b/mycat/key_heatmap_ui.py
@@ -10,7 +10,6 @@ lives right here on the board.
 from __future__ import annotations
 
 import logging
-from dataclasses import replace
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
@@ -38,6 +37,12 @@ class KeyboardBoard(QtWidgets.QWidget):
         self.peak = max(counts.values()) if counts else 0
         self.update()
 
+    def fraction(self, count: int) -> float:
+        """Position on the 1→max scale: 1 press = 0.0 (blue), the peak = 1.0 (red)."""
+        if self.peak <= 1:
+            return 0.0
+        return (count - 1) / (self.peak - 1)
+
     def paintEvent(self, event) -> None:
         painter = QtGui.QPainter(self)
         painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
@@ -57,7 +62,7 @@ class KeyboardBoard(QtWidgets.QWidget):
                 rect = QtCore.QRectF(x, y, w, h)
                 count = self.counts.get(cell_id, 0)
                 if count > 0 and self.peak > 0:
-                    r, g, b = key_heatmap.heat_rgb(count / self.peak)
+                    r, g, b = key_heatmap.heat_rgb(self.fraction(count))
                     fill = QtGui.QColor(r, g, b)
                     border = fill.darker(130)
                     text_color = QtGui.QColor(20, 20, 20)
@@ -85,6 +90,44 @@ class KeyboardBoard(QtWidgets.QWidget):
         painter.end()
 
 
+class HeatLegend(QtWidgets.QWidget):
+    """The colour scale under the board: blue = 1 press, red = the peak count."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.peak = 0
+        self.setFixedHeight(42)
+
+    def set_peak(self, peak: int) -> None:
+        self.peak = peak
+        self.update()
+
+    def paintEvent(self, event) -> None:
+        painter = QtGui.QPainter(self)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+        margin = 8.0
+        bar = QtCore.QRectF(margin, 4.0, self.width() - 2 * margin, 14.0)
+        gradient = QtGui.QLinearGradient(bar.left(), 0.0, bar.right(), 0.0)
+        for step in range(11):
+            r, g, b = key_heatmap.heat_rgb(step / 10.0)
+            gradient.setColorAt(step / 10.0, QtGui.QColor(r, g, b))
+        painter.setPen(QtGui.QPen(QtGui.QColor(150, 150, 150), 1.0))
+        painter.setBrush(QtGui.QBrush(gradient))
+        painter.drawRoundedRect(bar, 3.0, 3.0)
+
+        painter.setPen(QtGui.QColor(110, 110, 110))
+        labels = QtCore.QRectF(margin, bar.bottom() + 2.0, self.width() - 2 * margin, 16.0)
+        painter.drawText(labels, QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter, "1")
+        painter.drawText(
+            labels,
+            QtCore.Qt.AlignmentFlag.AlignHCenter | QtCore.Qt.AlignmentFlag.AlignVCenter,
+            "presses per key",
+        )
+        peak_label = f"{self.peak:,}" if self.peak > 0 else "—"
+        painter.drawText(labels, QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter, peak_label)
+        painter.end()
+
+
 class KeyboardHeatmapDialog(QtWidgets.QDialog):
     """A live keyboard heatmap for the current session."""
 
@@ -97,15 +140,6 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
 
         layout = QtWidgets.QVBoxLayout(self)
 
-        self.collect_box = QtWidgets.QCheckBox("Collect key heatmap (this session)")
-        self.collect_box.setToolTip(
-            "Count key presses per key while this is ticked. Aggregate counts only —\n"
-            "never the order, timing or text — kept in memory and gone on restart."
-        )
-        self.collect_box.setChecked(bool(collector.settings.key_heatmap_enabled))
-        self.collect_box.toggled.connect(self.on_toggle)
-        layout.addWidget(self.collect_box)
-
         self.note = QtWidgets.QLabel("")
         self.note.setWordWrap(True)
         self.note.setStyleSheet("color: #888888;")
@@ -113,9 +147,13 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
 
         self.board = KeyboardBoard(self)
         layout.addWidget(self.board, 1)
-        # The board fills the vertical stretch, so keep a clear gap before the
-        # buttons — otherwise Close rides up against the bottom-row keys.
-        layout.addSpacing(12)
+        layout.addSpacing(8)
+        # The colour scale for the board, at the bottom.
+        self.legend = HeatLegend(self)
+        layout.addWidget(self.legend)
+        # Keep a clear gap before the buttons — otherwise Close rides up against
+        # the legend/board.
+        layout.addSpacing(8)
 
         button_row = QtWidgets.QHBoxLayout()
         button_row.addStretch(1)
@@ -132,14 +170,6 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
         self.update_note()
         self.refresh()
 
-    def on_toggle(self, checked: bool) -> None:
-        settings = replace(self.collector.settings, key_heatmap_enabled=checked)
-        activity_mod.save_activity_settings(settings)
-        self.collector.apply_settings(settings)
-        logger.info("Key heatmap collection %s", "on" if checked else "off")
-        self.update_note()
-        self.refresh()
-
     def update_note(self) -> None:
         if not activity_mod.counts_available():
             self.note.setText(
@@ -147,12 +177,14 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
                 "permission), so nothing can be collected."
             )
         elif not self.collector.settings.key_heatmap_enabled:
-            self.note.setText("Collection is off — tick the box to build a heatmap for this session.")
+            self.note.setText("Collection is off — tick “Collect keys” in the Activity window and Save.")
         else:
-            self.note.setText("Counting this session · blue = rarely pressed → red = most pressed.")
+            self.note.setText("Counting this session — press keys and the map fills in.")
 
     def refresh(self) -> None:
+        self.update_note()
         self.board.set_data(self.collector.snapshot_key_cells())
+        self.legend.set_peak(self.board.peak)
 
     def closeEvent(self, event) -> None:
         self.timer.stop()

--- a/mycat/key_heatmap_ui.py
+++ b/mycat/key_heatmap_ui.py
@@ -93,7 +93,7 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
         self.collector = collector
         self.setWindowTitle("Keyboard heatmap")
         self.setModal(False)
-        self.resize(720, 320)
+        self.resize(720, 400)
 
         layout = QtWidgets.QVBoxLayout(self)
 
@@ -113,6 +113,9 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
 
         self.board = KeyboardBoard(self)
         layout.addWidget(self.board, 1)
+        # The board fills the vertical stretch, so keep a clear gap before the
+        # buttons — otherwise Close rides up against the bottom-row keys.
+        layout.addSpacing(12)
 
         button_row = QtWidgets.QHBoxLayout()
         button_row.addStretch(1)

--- a/mycat/xinput_linux.py
+++ b/mycat/xinput_linux.py
@@ -2,8 +2,11 @@
 
 This is the Linux counting backend so `pip install mycat` works out of the box:
 pynput would need the `evdev` C extension (no wheels, needs a compiler), while
-`python-xlib` is pure Python with wheels. Like the pynput path, only integers
-survive — the key identity is dropped inside the callback and never stored.
+`python-xlib` is pure Python with wheels. By default only integers survive — the
+key identity is dropped inside the callback and never stored. When the caller
+turns on `resolve_chars` (the opt-in keyboard heatmap), each keycode is mapped
+to its Latin-QWERTY cell for an in-memory tally; still no order, timing or text,
+and nothing on disk.
 
 Unavailable (returns False from `start()`) off X11 (e.g. Wayland) or if the X
 server lacks the RECORD extension; the diary then keeps only the cursor path.
@@ -14,6 +17,8 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import Callable
+
+from . import key_heatmap
 
 logger = logging.getLogger(__name__)
 
@@ -36,17 +41,21 @@ def available() -> bool:
 class InputCounter:
     """Count key presses and mouse-button presses globally via X RECORD.
 
-    `on_key` / `on_click` are called (no arguments) once per event; keep them
-    cheap and thread-safe — they run on the record thread.
+    `on_click` is called with no arguments; `on_key` is called with the Latin
+    QWERTY cell id for the keypress (or None) when `resolve_chars` is on, else
+    with None. Keep both cheap and thread-safe — they run on the record thread.
     """
 
     def __init__(
         self,
-        on_key: Callable[[], None] | None = None,
+        on_key: Callable[[str | None], None] | None = None,
         on_click: Callable[[], None] | None = None,
     ) -> None:
         self.on_key = on_key
         self.on_click = on_click
+        # When True, resolve each keycode to its heatmap cell (honouring the
+        # active layout group); when False, the key identity is never looked up.
+        self.resolve_chars = False
         self.thread: threading.Thread | None = None
         self.control_display = None
         self.record_display = None
@@ -117,7 +126,8 @@ class InputCounter:
                 )
                 if event.type == X.KeyPress:
                     if self.on_key is not None:
-                        self.on_key()
+                        cell = self.resolve_cell(event.detail, event.state) if self.resolve_chars else None
+                        self.on_key(cell)
                 elif event.type == X.ButtonPress:
                     if self.on_click is not None:
                         self.on_click()
@@ -131,6 +141,25 @@ class InputCounter:
                 self.record_display.record_free_context(self.context)
             except Exception:
                 pass
+
+    def resolve_cell(self, keycode: int, state: int) -> str | None:
+        """Keycode + modifier state → heatmap cell for the active layout group.
+
+        Uses `control_display` (a separate connection from the record loop) so
+        the keymap lookup doesn't disturb the record stream. Cyrillic and other
+        non-Latin keysyms map to nothing and are dropped."""
+        display = self.control_display
+        if display is None:
+            return None
+        try:
+            group = (state >> 13) & 0x3          # XKB group (active layout) bits
+            shift = 1 if (state & 0x1) else 0     # ShiftMask
+            keysym = display.keycode_to_keysym(keycode, group * 2 + shift)
+            if not keysym:
+                keysym = display.keycode_to_keysym(keycode, 0)
+        except Exception:
+            return None
+        return key_heatmap.cell_for_keysym(keysym)
 
     def stop(self) -> None:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.21"
+version = "0.1.22"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_key_heatmap.py
+++ b/tests/test_key_heatmap.py
@@ -1,0 +1,110 @@
+"""The keyboard heatmap: cell mapping, cold→hot colour, and the session tally."""
+
+import tempfile
+from pathlib import Path
+
+from mycat import activity_store, key_heatmap
+from mycat.activity import ActivityCollector, ActivitySettings
+
+
+class FakeKeyCode:
+    """Stand-in for a pynput printable key."""
+
+    def __init__(self, char):
+        self.char = char
+
+
+class FakeKey:
+    """Stand-in for a pynput special key (space, enter, …)."""
+
+    def __init__(self, name):
+        self.char = None
+        self.name = name
+
+
+def test_char_to_cell_folds_case_and_shift():
+    assert key_heatmap.char_to_cell("A") == "a"
+    assert key_heatmap.char_to_cell("a") == "a"
+    assert key_heatmap.char_to_cell("!") == "1"      # shifted digit → base
+    assert key_heatmap.char_to_cell("?") == "/"
+    assert key_heatmap.char_to_cell(" ") == "space"
+    assert key_heatmap.char_to_cell("5") == "5"
+
+
+def test_char_to_cell_drops_non_latin():
+    assert key_heatmap.char_to_cell("ф") is None     # Cyrillic layout → off-board
+    assert key_heatmap.char_to_cell("") is None
+    assert key_heatmap.char_to_cell(None) is None
+
+
+def test_cell_for_pynput_key():
+    assert key_heatmap.cell_for_pynput_key(FakeKeyCode("Z")) == "z"
+    assert key_heatmap.cell_for_pynput_key(FakeKeyCode("@")) == "2"
+    assert key_heatmap.cell_for_pynput_key(FakeKey("space")) == "space"
+    assert key_heatmap.cell_for_pynput_key(FakeKey("enter")) == "enter"
+    assert key_heatmap.cell_for_pynput_key(FakeKey("f1")) is None
+    assert key_heatmap.cell_for_pynput_key(FakeKeyCode("ж")) is None
+
+
+def test_cell_for_keysym():
+    assert key_heatmap.cell_for_keysym(0x41) == "a"      # 'A'
+    assert key_heatmap.cell_for_keysym(0x20) == "space"
+    assert key_heatmap.cell_for_keysym(0xFF0D) == "enter"
+    assert key_heatmap.cell_for_keysym(0xFF08) == "backspace"
+    assert key_heatmap.cell_for_keysym(0x6C1) is None    # Cyrillic keysym
+
+
+def test_heat_rgb_runs_cold_to_hot():
+    r0, g0, b0 = key_heatmap.heat_rgb(0.0)
+    r1, g1, b1 = key_heatmap.heat_rgb(1.0)
+    assert b0 > 200 and r0 < 40      # 0 → blue
+    assert r1 > 200 and b1 < 40      # 1 → red
+    # clamps out of range
+    assert key_heatmap.heat_rgb(-1.0) == key_heatmap.heat_rgb(0.0)
+    assert key_heatmap.heat_rgb(2.0) == key_heatmap.heat_rgb(1.0)
+
+
+def test_board_cell_ids_are_unique():
+    ids = [cell for row in key_heatmap.KEYBOARD_ROWS for (cell, _label, _w) in row]
+    assert len(ids) == len(set(ids))
+
+
+def make_collector(**settings):
+    tmp = Path(tempfile.mkdtemp()) / "activity.db"
+    store = activity_store.ActivityStore(db_path=tmp)
+    collector = ActivityCollector(
+        store=store, settings=ActivitySettings(**settings), start_timers=False
+    )
+    return collector
+
+
+def test_collector_tally_counts_per_cell():
+    collector = make_collector(key_heatmap_enabled=True)
+    for ch in "hello WORLD!!":
+        cell = "space" if ch == " " else key_heatmap.cell_for_pynput_key(FakeKeyCode(ch))
+        collector.record_key_cell(cell)
+    snap = collector.snapshot_key_cells()
+    assert snap["l"] == 3          # hello (2) + WORLD (1)
+    assert snap["o"] == 2
+    assert snap["1"] == 2          # two '!' fold onto '1'
+    assert snap["space"] == 1
+    collector.stop()
+
+
+def test_snapshot_is_a_copy():
+    collector = make_collector(key_heatmap_enabled=True)
+    collector.record_key_cell("a")
+    snap = collector.snapshot_key_cells()
+    snap["a"] = 999
+    assert collector.snapshot_key_cells()["a"] == 1
+    collector.stop()
+
+
+def test_heatmap_only_does_not_start_disk_diary():
+    collector = make_collector(
+        mouse_enabled=False, keyboard_enabled=False, key_heatmap_enabled=True
+    )
+    # start_timers=False means no poll_timer at all; the point is that enabling
+    # only the heatmap never tried to create/run the disk sampler.
+    assert not hasattr(collector, "poll_timer")
+    collector.stop()


### PR DESCRIPTION
## Summary

Adds an **opt-in keyboard heatmap** to the Activity tab and bumps the version to **0.1.22**.

- A new **Keyboard** button next to *Save* opens an on-screen **Latin QWERTY** board that colours each key **cold-blue (rarely pressed) → hot-red (most pressed)** for the current session.
- Collecting the counts is a **separate opt-in inside the heatmap window, off by default**. The diary keyboard count track is unchanged.
- **Privacy:** only aggregate **per-key counts**, kept **in memory** — never the order, timing or text, and never written to disk (they reset on restart). Counting is by *logical character* folded onto the Latin board, so a **Cyrillic layout maps to nothing** and isn't shown.
- The Activity toggle row is relabelled to **`Enable: Tracking / Mouse / Keyboard / Tooltip`**.
- New files: `mycat/key_heatmap.py` (pure mapping/layout/colour), `mycat/key_heatmap_ui.py` (the live dialog). Wiring in `activity.py`, `xinput_linux.py`, `activity_ui.py`. Docstrings/tooltips that promised "never which keys" updated to reflect the opt-in.

## Test plan

- [x] `ruff check .` clean
- [x] Full suite green — 217 existing + 9 new (`tests/test_key_heatmap.py`)
- [x] Activity dialog shows `Enable: Tracking / Mouse / Keyboard / Tooltip` and a `Keyboard` button next to `Save` (rendered)
- [x] Heatmap board colours keys blue→red; label/count don't overlap (rendered)
- [x] Cyrillic input maps to nothing on the Latin board (unit-tested)
- [x] Counts live in memory only, heatmap-only mode never starts the disk diary (unit-tested)
- [ ] Manual on X11: tick the opt-in, type, watch keys heat up; confirm counts reset on restart and `activity.db` gains no per-key data
