### PR TITLE
Release 0.1.23: heatmap input-stall fix + unified update dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.1.23] - 2026-07-19
+
+### Changed
+- **The update dialog is one consistent set of buttons: Releases · Update · Close.** *Releases* always opens the releases page; *Update* downloads the new build and restarts, and is enabled only when a self-update is actually possible (Windows/macOS with a newer release) — greyed out on pip/git/deb/AppImage installs and whenever there's nothing to update. Replaces the old mix of an "Open releases" box and a separate Yes/No prompt (branch `fix/heatmap-perf-and-update-buttons`).
+
+### Fixed
+- **The Keyboard heatmap window no longer stalls typing.** While collecting, its 500 ms refresh reopened a full X connection every tick on the python-xlib path, blocking the event loop whenever keys were flowing — so typing froze and the cursor stuttered. Availability is now read once when the window opens, and the board repaints only when the tally changes (branch `fix/heatmap-perf-and-update-buttons`).
+
 ## [0.1.22] - 2026-07-19
 
 ### Added

--- a/mycat/key_heatmap_ui.py
+++ b/mycat/key_heatmap_ui.py
@@ -137,6 +137,11 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
     def __init__(self, collector, parent=None) -> None:
         super().__init__(parent)
         self.collector = collector
+        # Computed once — calling counts_available() opens (and closes) a fresh X
+        # connection on the no-pynput path, which would stall the event loop if
+        # done on the refresh timer. It can't change while the window is open.
+        self.counting_available = activity_mod.counts_available()
+        self.last_counts: dict[str, int] | None = None
         self.setWindowTitle("Keyboard heatmap")
         self.setModal(False)
         self.setMinimumWidth(700)
@@ -176,20 +181,27 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
         self.refresh()
 
     def update_note(self) -> None:
-        if not activity_mod.counts_available():
-            self.note.setText(
+        if not self.counting_available:
+            text = (
                 "Key counting isn't available here (needs X11, or macOS Input Monitoring "
                 "permission), so nothing can be collected."
             )
         elif not self.collector.settings.key_heatmap_enabled:
-            self.note.setText("Collection is off — tick “Heatmap” in the Activity window and Save.")
+            text = "Collection is off — tick “Heatmap” in the Activity window and Save."
         else:
-            self.note.setText("")
+            text = ""
+        if text != self.note.text():
+            self.note.setText(text)
 
     def refresh(self) -> None:
         self.update_note()
-        self.board.set_data(self.collector.snapshot_key_cells())
-        self.legend.set_peak(self.board.peak)
+        counts = self.collector.snapshot_key_cells()
+        # Only repaint when the tally actually changed — an idle open window then
+        # does no drawing work.
+        if counts != self.last_counts:
+            self.last_counts = counts
+            self.board.set_data(counts)
+            self.legend.set_peak(self.board.peak)
 
     def closeEvent(self, event) -> None:
         self.timer.stop()

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -1394,53 +1394,72 @@ class PixelCatWindow(QtWidgets.QWidget):
 
         threading.Thread(target=check, name="mycat-update-check", daemon=True).start()
 
-    def open_releases_box(self, title: str, text: str, informative: str) -> None:
-        """A message box with an 'Open releases' button linking to GitHub."""
+    def update_box(self, title: str, text: str, informative: str, kind: str, can_update: bool) -> None:
+        """The update dialog — always three buttons: Releases · Update · Close.
+
+        Releases always opens the GitHub releases page. Update downloads the new
+        build and restarts, and is enabled only when a self-update is actually
+        possible (Windows/macOS with a newer release); it is greyed out on
+        pip/git/deb/AppImage installs and whenever there's nothing to update."""
         box = QtWidgets.QMessageBox(self)
         box.setWindowTitle(title)
         box.setText(text)
         box.setInformativeText(informative)
         box.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
-        open_button = box.addButton("Open releases", QtWidgets.QMessageBox.ButtonRole.ActionRole)
+        releases_button = box.addButton("Releases", QtWidgets.QMessageBox.ButtonRole.ActionRole)
+        update_button = box.addButton("Update", QtWidgets.QMessageBox.ButtonRole.ActionRole)
+        update_button.setEnabled(can_update)
         box.addButton(QtWidgets.QMessageBox.StandardButton.Close)
         box.exec()
-        if box.clickedButton() is open_button:
+        clicked = box.clickedButton()
+        if clicked is releases_button:
             QtGui.QDesktopServices.openUrl(QtCore.QUrl(updater.RELEASES_PAGE))
+        elif clicked is update_button:
+            self.download_update(kind)
 
     def on_update_checked(self, kind: str, current: str, latest: str) -> None:
+        # One dialog everywhere (Releases · Update · Close). Update is live only
+        # in the last case: a reachable, newer release on a self-updating build.
         if not latest:
             # The check couldn't reach GitHub (offline, or the API rate-limited
-            # this IP). Don't claim we're up to date — say the check failed and
-            # point at the releases page so they can look for themselves.
-            self.open_releases_box(
+            # this IP). Don't claim we're up to date — say the check failed.
+            self.update_box(
                 "Update check",
                 "Couldn't check for updates right now.",
                 "GitHub may be unreachable or rate-limited — try again in a bit, "
                 "or open the releases page to check by hand.",
+                kind,
+                can_update=False,
             )
             return
         if update_check.parse_version(latest) <= update_check.parse_version(current):
-            # Up to date — reassure, and still offer the releases page.
-            self.open_releases_box(
-                "mycat", f"You're on the latest version ({current}). 🐱", "Everything's up to date."
+            # Up to date — nothing to update, so Update stays greyed out.
+            self.update_box(
+                "mycat",
+                f"You're on the latest version ({current}). 🐱",
+                "Everything's up to date.",
+                kind,
+                can_update=False,
             )
             return
         if not updater.can_self_update(kind):
-            # pip / deb / AppImage / source: just tell them, with how-to + a link.
-            self.open_releases_box(
+            # pip / git / deb / AppImage: tell them how, Update stays greyed out.
+            self.update_box(
                 "Update available",
                 f"mycat {latest} is available (you have {current}).",
                 f"Update with:\n\n    {updater.update_hint(kind)}",
+                kind,
+                can_update=False,
             )
             return
-        # Windows / macOS: download the new build and restart.
-        reply = QtWidgets.QMessageBox.question(
-            self,
-            "Update mycat",
-            f"Update to {latest}? mycat will download the new build and restart.",
+        # Windows / macOS with a newer release: Update is enabled.
+        self.update_box(
+            "Update available",
+            f"mycat {latest} is available (you have {current}).",
+            "Click Update to download the new build and restart.",
+            kind,
+            can_update=True,
         )
-        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
-            self.download_update(kind)
 
     def download_update(self, kind: str) -> None:
         signals = self.update_signals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.22"
+version = "0.1.23"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Release **0.1.23** — two fixes on top of 0.1.22.

- **Fixed:** the Keyboard heatmap window stalled typing (jerky cursor). Its 500 ms refresh reopened a full X connection each tick on the python-xlib path; availability is now read once and the board repaints only when the tally changes.
- **Changed:** the update dialog is unified into **Releases · Update · Close** — Releases always available, Update enabled only for a possible self-update (Windows/macOS + newer release), greyed out otherwise.
- Version bumped to 0.1.23 with a dated changelog.

## Test plan

- [x] `ruff check .` clean, full suite green (226)
- [x] Heatmap refresh makes 0 `counts_available()` calls; idle window doesn't repaint; a keypress does
- [x] Update dialog: Releases/Update/Close, Update greyed on pip/git, enabled on win/mac-with-update (rendered)
