### PR TITLE
Refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 ## [0.1.25] - Unreleased
 
 ### Fixed
+- **The update check now uses your GitHub token, so it isn't rate-limited.** It made anonymous GitHub calls (60 req/h per IP), so a shared IP could hit "rate-limited" even with a token configured. A shared `github_api.py` layer now attaches the `[github]` token (or `GITHUB_TOKEN`) to *every* GitHub request — the update check and the notifications poller both go through it (5000 req/h). The update dialog is shorter and always shows the current and latest version, then whether an update is needed.
 - **The autostart entry shows "myCat", not "mycat".** The XDG autostart `.desktop` wrote `Name=mycat` while the app-menu entry wrote `Name=myCat`, so the same app showed two different names.
 - **Switching char no longer half-updates the window on a bad char.** `_load_image` mutated the window's state and resized it inside the same `try` that decodes the GIF, so a decode failure left the window half-switched; it now decodes into locals first and commits only on success.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [0.1.25] - Unreleased
+## [0.1.25] - 2026-07-22
 
 ### Fixed
 - **The update check now uses your GitHub token, so it isn't rate-limited.** It made anonymous GitHub calls (60 req/h per IP), so a shared IP could hit "rate-limited" even with a token configured. A shared `github_api.py` layer now attaches the `[github]` token (or `GITHUB_TOKEN`) to *every* GitHub request — the update check and the notifications poller both go through it (5000 req/h). The update dialog is shorter and always shows the current and latest version, then whether an update is needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.1.25] - Unreleased
+
+### Fixed
+- **The autostart entry shows "myCat", not "mycat".** The XDG autostart `.desktop` wrote `Name=mycat` while the app-menu entry wrote `Name=myCat`, so the same app showed two different names.
+- **Switching char no longer half-updates the window on a bad char.** `_load_image` mutated the window's state and resized it inside the same `try` that decodes the GIF, so a decode failure left the window half-switched; it now decodes into locals first and commits only on success.
+
+### Changed
+- **Internal maintainability refactor (no behaviour change).** A single source of truth for the config path (`paths.py`) and shared config load/save plumbing (`config_store.py`) replace the per-feature copy-paste, and every single-underscore identifier across the codebase was renamed to a plain public name (house style). Also corrects stale contributor paths in `CLAUDE.md` (`chars/` and the "Chars" menu) and drops a dead `prompted` config field (branch `chore/maintainability-phase-0`).
+
 ## [0.1.24] - 2026-07-21
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# myCat — for contributors 🐱
+
+Hi — and thank you for being here. myCat is a tiny desktop pet, and its little
+characters (the "skins") are the whole point of it. This is a short, friendly
+guide for anyone who'd like to add one or help out.
+
+## 🎨 Make your own skin (step by step)
+
+Good news: a skin is tiny. Under the hood it's just **one animated GIF inside a
+`.zip`** — no JSON, no code, nothing to compile.
+
+### 1. How a skin works
+
+- The **ZIP's filename is the name shown in the menu** — `redcat.zip` appears as
+  **redcat**.
+- Inside the ZIP there's a single animated **`.gif`**.
+- The GIF's **first frame is the resting pose** myCat shows while idle (for about
+  5 seconds, or `--wait` seconds). Then the GIF plays through once and settles
+  back on that first frame.
+- Keep it within **300×500 px** — anything larger is scaled down automatically
+  (the aspect ratio is preserved).
+- Use a **transparent background**, so the cat sits on your desktop instead of
+  inside a box.
+
+### 2. Draw your frames
+
+Draw your character as a few frames of animation — PNGs with a transparent
+background work best. Frame 1 is the calm idle pose; the rest are the little
+animation that plays now and then (a blink, a stretch, a wave… up to you).
+
+### 3. Build the animated GIF
+
+Any tool that exports an animated GIF works — GIMP, Aseprite, [ezgif.com](https://ezgif.com),
+or ImageMagick from the terminal:
+
+```bash
+# From separate frames (frame1 = the idle pose):
+convert -delay 12 -loop 0 frame1.png frame2.png frame3.png redcat.gif
+
+# …or from a 2-frame sprite sheet (left half = idle, right half = action):
+convert sheet.png -crop 50%x100% +repage -set delay '200,100' -loop 0 redcat.gif
+```
+
+`-delay` is in hundredths of a second per frame; `-loop 0` is fine — myCat
+handles the "play once, then rest" behaviour itself.
+
+### 4. Package it as a ZIP
+
+The zip's name becomes the menu name, so name it nicely:
+
+```bash
+zip redcat.zip redcat.gif
+```
+
+### 5. Try it right away
+
+- **Launch with it:** `mycat --image /path/to/redcat.zip`
+- **Install it for keeps:** drop `redcat.zip` into your personal chars folder and
+  it shows up in the right-click **Chars** menu instantly — no restart:
+  - **Linux:** `~/.local/share/mycat/chars/` (or `$XDG_DATA_HOME/mycat/chars/`)
+  - **macOS:** `~/Library/Application Support/mycat/chars/`
+  - **Windows:** `%LOCALAPPDATA%\mycat\chars\`
+
+### 6. Share it with everyone (optional)
+
+Want it bundled with myCat for everyone? Put `redcat.zip` into `mycat/chars/`
+and open a pull request. ⚠️ Please only share art **you drew yourself** — see
+**Artwork & licensing** below.
+
+### If something looks off
+
+- **A black box around the cat** → the GIF needs a transparent background. (On
+  Linux/X11 a compositor helps; without one, myCat clips the window to the cat's
+  outline.)
+- **It doesn't move** → make sure it's a real multi-frame animated GIF, not a
+  single still image.
+- **It's huge** → that's fine, it gets scaled down to fit 300×500.
+
+### ✅ Quick recap
+
+1. Draw your frames — **first frame = idle pose**, transparent background, ≤300×500.
+2. Export them as one **animated GIF**.
+3. `zip myname.zip myname.gif` — the **zip name is the menu name**.
+4. Test it: `mycat --image myname.zip`, or drop the zip in your chars folder.
+5. To contribute it: put it in `mycat/chars/` and open a PR — **only your own art.**
+
+## 🐞 Hit a problem? Open an Issue
+
+If something doesn't work, or you have an idea, please open an [Issue](../../issues).
+Tell me what happened and how you ran it (your OS, the command) so I can reproduce
+it.
+
+## 🔀 Opening a pull request
+
+When you open a PR, please add a short note about **what it does and why** — even a
+sentence or two. It lets me understand and review it quickly. 🙏
+
+## 💛 About artwork & licensing
+
+I'm genuinely happy every single time someone shares an animation — thank you. I'll
+be honest with you: I can't draw, and that's my biggest limitation here.
+
+Because of licensing and repository size, **I can only accept artwork that you drew
+yourself.** If a character wasn't made by you personally, I won't be able to merge
+it — not because it isn't lovely, but because I can't take on art I don't have the
+rights to. I hope you understand. 🙏
+
+## 🌱 A little dream
+
+One day I'd love to build a small site — a place to upload and download characters
+and share them freely, without crowding the repo. If that idea excites you, I'd be
+glad for the company.
+
+Thank you, really. 🐾

--- a/mycat/activity.py
+++ b/mycat/activity.py
@@ -88,7 +88,6 @@ class ActivitySettings:
     # session-only — the counts are never written to disk.
     key_heatmap_enabled: bool = False
     retention_days: int = DEFAULT_RETENTION_DAYS
-    prompted: bool = False  # kept for config compatibility (prompt removed)
 
 
 def pynput_available() -> bool:
@@ -128,7 +127,6 @@ def load_activity_settings(cfg_file: Path = CFG_FILE) -> ActivitySettings:
         settings.keyboard_enabled = section.getboolean("keyboard_enabled", fallback=True)
         settings.key_heatmap_enabled = section.getboolean("key_heatmap_enabled", fallback=False)
         settings.retention_days = section.getint("retention_days", fallback=DEFAULT_RETENTION_DAYS)
-        settings.prompted = section.getboolean("prompted", fallback=False)
     except Exception as exc:  # noqa: BLE001 - never let a bad config crash the app
         logger.error("Failed to load [activity] settings: %s", exc)
     return settings
@@ -148,7 +146,6 @@ def save_activity_settings(settings: ActivitySettings, cfg_file: Path = CFG_FILE
         section["keyboard_enabled"] = "true" if settings.keyboard_enabled else "false"
         section["key_heatmap_enabled"] = "true" if settings.key_heatmap_enabled else "false"
         section["retention_days"] = str(settings.retention_days)
-        section["prompted"] = "true" if settings.prompted else "false"
         with open(cfg_file, "w") as fh:
             config.write(fh)
         secret_store.secure_file(cfg_file)

--- a/mycat/activity.py
+++ b/mycat/activity.py
@@ -30,7 +30,6 @@ The two COUNT tracks switch independently (``mouse_enabled`` = click counts,
 the diary is on — the cat's eyes track the cursor anyway — so it has no toggle.
 """
 
-import configparser
 import logging
 import threading
 from dataclasses import dataclass
@@ -40,12 +39,12 @@ from pathlib import Path
 from PySide6 import QtCore, QtGui
 
 if __package__:
-    from . import activity_store, key_heatmap, paths, secret_store
+    from . import activity_store, config_store, key_heatmap, paths
 else:
     import importlib
 
     activity_store = importlib.import_module("mycat.activity_store")
-    secret_store = importlib.import_module("mycat.secret_store")
+    config_store = importlib.import_module("mycat.config_store")
     key_heatmap = importlib.import_module("mycat.key_heatmap")
     paths = importlib.import_module("mycat.paths")
 
@@ -115,43 +114,33 @@ def counts_available() -> bool:
 
 def load_activity_settings(cfg_file: Path = CFG_FILE) -> ActivitySettings:
     settings = ActivitySettings()
-    if not cfg_file.exists():
+    config = config_store.read_config(cfg_file)
+    if config is None or "activity" not in config:
         return settings
     try:
-        config = configparser.ConfigParser()
-        config.read(cfg_file)
-        if "activity" not in config:
-            return settings
         section = config["activity"]
         settings.enabled = section.getboolean("enabled", fallback=True)
         settings.mouse_enabled = section.getboolean("mouse_enabled", fallback=True)
         settings.keyboard_enabled = section.getboolean("keyboard_enabled", fallback=True)
         settings.key_heatmap_enabled = section.getboolean("key_heatmap_enabled", fallback=False)
         settings.retention_days = section.getint("retention_days", fallback=DEFAULT_RETENTION_DAYS)
-    except Exception as exc:  # noqa: BLE001 - never let a bad config crash the app
+    except (ValueError, TypeError) as exc:  # a malformed value -> keep the defaults
         logger.error("Failed to load [activity] settings: %s", exc)
     return settings
 
 
 def save_activity_settings(settings: ActivitySettings, cfg_file: Path = CFG_FILE) -> None:
-    try:
-        cfg_file.parent.mkdir(parents=True, exist_ok=True)
-        config = configparser.ConfigParser()
-        if cfg_file.exists():
-            config.read(cfg_file)
-        if "activity" not in config:
-            config.add_section("activity")
-        section = config["activity"]
-        section["enabled"] = "true" if settings.enabled else "false"
-        section["mouse_enabled"] = "true" if settings.mouse_enabled else "false"
-        section["keyboard_enabled"] = "true" if settings.keyboard_enabled else "false"
-        section["key_heatmap_enabled"] = "true" if settings.key_heatmap_enabled else "false"
-        section["retention_days"] = str(settings.retention_days)
-        with open(cfg_file, "w") as fh:
-            config.write(fh)
-        secret_store.secure_file(cfg_file)
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Failed to save [activity] settings: %s", exc)
+    config_store.write_section(
+        "activity",
+        {
+            "enabled": config_store.bool_str(settings.enabled),
+            "mouse_enabled": config_store.bool_str(settings.mouse_enabled),
+            "keyboard_enabled": config_store.bool_str(settings.keyboard_enabled),
+            "key_heatmap_enabled": config_store.bool_str(settings.key_heatmap_enabled),
+            "retention_days": settings.retention_days,
+        },
+        cfg_file,
+    )
 
 
 # -- collector -------------------------------------------------------------------

--- a/mycat/activity.py
+++ b/mycat/activity.py
@@ -40,18 +40,19 @@ from pathlib import Path
 from PySide6 import QtCore, QtGui
 
 if __package__:
-    from . import activity_store, key_heatmap, secret_store
+    from . import activity_store, key_heatmap, paths, secret_store
 else:
     import importlib
 
     activity_store = importlib.import_module("mycat.activity_store")
     secret_store = importlib.import_module("mycat.secret_store")
     key_heatmap = importlib.import_module("mycat.key_heatmap")
+    paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
 
-CFG_DIR = Path.home() / ".config" / "mycat"
-CFG_FILE = CFG_DIR / "config.ini"
+CFG_DIR = paths.config_dir()
+CFG_FILE = paths.config_file()
 
 CURSOR_POLL_MS = 100  # 10 Hz — plenty for a distance integral
 # A minute counts as "active" from this much cursor travel (filters out the

--- a/mycat/activity_ui.py
+++ b/mycat/activity_ui.py
@@ -797,7 +797,6 @@ class ActivityDialog(QtWidgets.QDialog):
             keyboard_enabled=self.keyboard_box.isChecked(),
             key_heatmap_enabled=self.collect_box.isChecked(),
             retention_days=self.retention_spin.value(),
-            prompted=True,
         )
         activity_mod.save_activity_settings(settings)
         self.collector.apply_settings(settings)

--- a/mycat/ai_backends.py
+++ b/mycat/ai_backends.py
@@ -34,16 +34,14 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from pathlib import Path
 
 from PIL import Image, UnidentifiedImageError
 
-from . import ai_char
+from . import ai_char, paths
 from .ai_char import AICharError
 
-APP_NAME = "mycat"
-CFG_DIR = Path.home() / ".config" / APP_NAME
-CFG_FILE = CFG_DIR / "config.ini"
+CFG_DIR = paths.config_dir()
+CFG_FILE = paths.config_file()
 CFG_SECTION = "generation"
 
 BACKENDS = ("openai", "a1111", "comfyui")

--- a/mycat/ai_char.py
+++ b/mycat/ai_char.py
@@ -56,7 +56,7 @@ def slugify(name: str) -> str:
     return f"custom-{slug[:48]}"
 
 
-def _reference_png(path: Path) -> bytes:
+def reference_png(path: Path) -> bytes:
     try:
         with Image.open(path) as source:
             image = ImageOps.exif_transpose(source).convert("RGB")
@@ -71,7 +71,7 @@ def _reference_png(path: Path) -> bytes:
 def prepare_references(paths: list[Path]) -> list[tuple[str, bytes]]:
     if not 1 <= len(paths) <= MAX_REFERENCES:
         raise AICharError("Choose between 1 and 3 reference images.")
-    return [(f"reference-{index}.png", _reference_png(Path(path))) for index, path in enumerate(paths, 1)]
+    return [(f"reference-{index}.png", reference_png(Path(path))) for index, path in enumerate(paths, 1)]
 
 
 def build_prompt(additional_instructions: str = "") -> str:
@@ -89,7 +89,7 @@ def build_prompt(additional_instructions: str = "") -> str:
     )
 
 
-def _multipart(fields: dict[str, str], images: list[tuple[str, bytes]]) -> tuple[bytes, str]:
+def multipart(fields: dict[str, str], images: list[tuple[str, bytes]]) -> tuple[bytes, str]:
     boundary = f"mycat-{uuid.uuid4().hex}"
     body = io.BytesIO()
 
@@ -125,7 +125,7 @@ def request_image(
         raise AICharError("Enter an OpenAI API key or set OPENAI_API_KEY.")
     if quality not in {"low", "medium"}:
         raise AICharError("Unsupported image quality.")
-    body, content_type = _multipart(
+    body, content_type = multipart(
         {
             "model": model,
             "prompt": prompt if prompt is not None else build_prompt(additional_instructions),
@@ -170,7 +170,7 @@ def request_image(
     return result
 
 
-def _normalized_character_png(image_bytes: bytes) -> bytes:
+def normalized_character_png(image_bytes: bytes) -> bytes:
     with Image.open(io.BytesIO(image_bytes)) as source:
         image = source.convert("RGBA")
     alpha_box = image.getchannel("A").getbbox()
@@ -273,7 +273,7 @@ def install_character(display_name: str, image_bytes: bytes) -> tuple[str, Path]
         "max_height": 400,
         "blink": {"enabled": False},
     }
-    png = _normalized_character_png(image_bytes)
+    png = normalized_character_png(image_bytes)
     try:
         with zipfile.ZipFile(temporary, "w", compression=zipfile.ZIP_DEFLATED) as archive:
             archive.writestr("static.png", png)

--- a/mycat/autostart.py
+++ b/mycat/autostart.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-APP_ID = "mycat"
+APP_ID = "mycat"          # technical id: .desktop filename, Windows Run key value name
+APP_NAME = "myCat"        # display name shown to the user (Name= in the .desktop)
 WIN_RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
 
 
@@ -49,7 +50,7 @@ def linux_set(enabled: bool) -> None:
         path.write_text(
             "[Desktop Entry]\n"
             "Type=Application\n"
-            f"Name={APP_ID}\n"
+            f"Name={APP_NAME}\n"
             f"Exec={launch_command()}\n"
             "Terminal=false\n"
             "X-GNOME-Autostart-enabled=true\n"

--- a/mycat/calendar_ics.py
+++ b/mycat/calendar_ics.py
@@ -27,16 +27,17 @@ from pathlib import Path
 from PySide6 import QtCore
 
 if __package__:
-    from . import secret_store
+    from . import paths, secret_store
 else:
     import importlib
 
     secret_store = importlib.import_module("mycat.secret_store")
+    paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
 
-CFG_DIR = Path.home() / ".config" / "mycat"
-CFG_FILE = CFG_DIR / "config.ini"
+CFG_DIR = paths.config_dir()
+CFG_FILE = paths.config_file()
 
 DEFAULT_REMIND_MINUTES = 10
 DEFAULT_POLL_MINUTES = 10

--- a/mycat/calendar_ics.py
+++ b/mycat/calendar_ics.py
@@ -17,7 +17,6 @@ expansion is a swamp not worth hand-rolling). They are an optional extra:
 nothing else breaks.
 """
 
-import configparser
 import logging
 import urllib.request
 from dataclasses import dataclass
@@ -27,11 +26,11 @@ from pathlib import Path
 from PySide6 import QtCore
 
 if __package__:
-    from . import paths, secret_store
+    from . import config_store, paths
 else:
     import importlib
 
-    secret_store = importlib.import_module("mycat.secret_store")
+    config_store = importlib.import_module("mycat.config_store")
     paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
@@ -59,41 +58,31 @@ class CalendarSettings:
 
 def load_calendar_settings(cfg_file: Path = CFG_FILE) -> CalendarSettings:
     settings = CalendarSettings()
-    if not cfg_file.exists():
+    config = config_store.read_config(cfg_file)
+    if config is None or "calendar" not in config:
         return settings
     try:
-        config = configparser.ConfigParser()
-        config.read(cfg_file)
-        if "calendar" not in config:
-            return settings
         section = config["calendar"]
         settings.enabled = section.getboolean("enabled", fallback=False)
         settings.url = section.get("url", "")
         settings.remind_minutes = section.getint("remind_minutes", fallback=DEFAULT_REMIND_MINUTES)
         settings.poll_minutes = section.getint("poll_minutes", fallback=DEFAULT_POLL_MINUTES)
-    except Exception as exc:  # noqa: BLE001 - never let a bad config crash the app
+    except (ValueError, TypeError) as exc:  # a malformed value -> keep the defaults
         logger.error("Failed to load [calendar] settings: %s", exc)
     return settings
 
 
 def save_calendar_settings(settings: CalendarSettings, cfg_file: Path = CFG_FILE) -> None:
-    try:
-        cfg_file.parent.mkdir(parents=True, exist_ok=True)
-        config = configparser.ConfigParser()
-        if cfg_file.exists():
-            config.read(cfg_file)
-        if "calendar" not in config:
-            config.add_section("calendar")
-        section = config["calendar"]
-        section["enabled"] = "true" if settings.enabled else "false"
-        section["url"] = settings.url
-        section["remind_minutes"] = str(settings.remind_minutes)
-        section["poll_minutes"] = str(settings.poll_minutes)
-        with open(cfg_file, "w") as fh:
-            config.write(fh)
-        secret_store.secure_file(cfg_file)
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Failed to save [calendar] settings: %s", exc)
+    config_store.write_section(
+        "calendar",
+        {
+            "enabled": config_store.bool_str(settings.enabled),
+            "url": settings.url,
+            "remind_minutes": settings.remind_minutes,
+            "poll_minutes": settings.poll_minutes,
+        },
+        cfg_file,
+    )
 
 
 # -- pure helpers (unit-tested without Qt or network) ---------------------------

--- a/mycat/config_store.py
+++ b/mycat/config_store.py
@@ -59,3 +59,18 @@ def write_section(name: str, values: dict, cfg_file: Path) -> None:
         secret_store.secure_file(cfg_file)
     except (OSError, configparser.Error) as exc:
         logger.error("Failed to save [%s] to %s: %s", name, cfg_file, exc)
+
+
+def remove_section(name: str, cfg_file: Path) -> None:
+    """Drop the whole ``[name]`` section from ``cfg_file`` (no-op if absent)."""
+    try:
+        if not cfg_file.exists():
+            return
+        config = configparser.ConfigParser()
+        config.read(cfg_file)
+        if config.remove_section(name):
+            with open(cfg_file, "w") as fh:
+                config.write(fh)
+            secret_store.secure_file(cfg_file)
+    except (OSError, configparser.Error) as exc:
+        logger.error("Failed to clear [%s] in %s: %s", name, cfg_file, exc)

--- a/mycat/config_store.py
+++ b/mycat/config_store.py
@@ -1,0 +1,61 @@
+"""Shared read/write plumbing for the ``~/.config/mycat/config.ini`` sections.
+
+Every feature owns its own dataclass and decides which fields map to which keys
+(including any legacy-key fallbacks); this module does the identical
+``ConfigParser`` dance once instead of once per feature:
+
+- :func:`read_config` — parse the file (or ``None`` if absent/unreadable),
+- :func:`write_section` — merge one section back without touching the others,
+  create the file, and secure it,
+- :func:`bool_str` — serialize a bool the way the config has always stored it.
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+from pathlib import Path
+
+from . import secret_store
+
+logger = logging.getLogger(__name__)
+
+
+def bool_str(value: bool) -> str:
+    """``True``/``False`` -> the ``"true"``/``"false"`` the config stores."""
+    return "true" if value else "false"
+
+
+def read_config(cfg_file: Path) -> configparser.ConfigParser | None:
+    """Parse ``cfg_file``, or ``None`` if it is absent or cannot be read."""
+    if not cfg_file.exists():
+        return None
+    config = configparser.ConfigParser()
+    try:
+        config.read(cfg_file)
+    except (configparser.Error, OSError) as exc:
+        logger.error("Failed to read %s: %s", cfg_file, exc)
+        return None
+    return config
+
+
+def write_section(name: str, values: dict, cfg_file: Path) -> None:
+    """Merge ``values`` into the ``[name]`` section of ``cfg_file``.
+
+    Creates the file and the section as needed and leaves every other section
+    untouched, then secures the file. Persistence is best-effort: failures are
+    logged, never raised.
+    """
+    try:
+        cfg_file.parent.mkdir(parents=True, exist_ok=True)
+        config = configparser.ConfigParser()
+        if cfg_file.exists():
+            config.read(cfg_file)
+        if name not in config:
+            config.add_section(name)
+        config[name].update({key: str(value) for key, value in values.items()})
+        with open(cfg_file, "w") as fh:
+            config.write(fh)
+        secret_store.secure_file(cfg_file)
+    except (OSError, configparser.Error) as exc:
+        logger.error("Failed to save [%s] to %s: %s", name, cfg_file, exc)

--- a/mycat/digest.py
+++ b/mycat/digest.py
@@ -10,7 +10,6 @@ session. The last delivered date is remembered in the config so a restart
 never re-delivers the same paper.
 """
 
-import configparser
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -19,11 +18,12 @@ from PySide6 import QtCore, QtGui
 
 if __package__:
     from . import activity as activity_mod
-    from . import paths
+    from . import config_store, paths
 else:
     import importlib
 
     activity_mod = importlib.import_module("mycat.activity")
+    config_store = importlib.import_module("mycat.config_store")
     paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
@@ -38,29 +38,14 @@ TICK_SECONDS = 60
 
 
 def load_digest_date(cfg_file: Path = CFG_FILE) -> str:
-    if not cfg_file.exists():
+    config = config_store.read_config(cfg_file)
+    if config is None:
         return ""
-    try:
-        config = configparser.ConfigParser()
-        config.read(cfg_file)
-        return config.get("activity", "digest_date", fallback="")
-    except Exception:  # noqa: BLE001
-        return ""
+    return config.get("activity", "digest_date", fallback="")
 
 
 def save_digest_date(day_iso: str, cfg_file: Path = CFG_FILE) -> None:
-    try:
-        cfg_file.parent.mkdir(parents=True, exist_ok=True)
-        config = configparser.ConfigParser()
-        if cfg_file.exists():
-            config.read(cfg_file)
-        if "activity" not in config:
-            config.add_section("activity")
-        config["activity"]["digest_date"] = day_iso
-        with open(cfg_file, "w") as fh:
-            config.write(fh)
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Failed to save digest date: %s", exc)
+    config_store.write_section("activity", {"digest_date": day_iso}, cfg_file)
 
 
 def compose_digest(summary: dict) -> str:

--- a/mycat/digest.py
+++ b/mycat/digest.py
@@ -19,15 +19,17 @@ from PySide6 import QtCore, QtGui
 
 if __package__:
     from . import activity as activity_mod
+    from . import paths
 else:
     import importlib
 
     activity_mod = importlib.import_module("mycat.activity")
+    paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
 
-CFG_DIR = Path.home() / ".config" / "mycat"
-CFG_FILE = CFG_DIR / "config.ini"
+CFG_DIR = paths.config_dir()
+CFG_FILE = paths.config_file()
 
 # Before this local hour a "new day" hasn't really started — a 01:00 session
 # is yesterday's late evening, and getting yesterday's paper then feels off.

--- a/mycat/focus.py
+++ b/mycat/focus.py
@@ -16,7 +16,6 @@ is always shown. The 🍅 / 🍌 accounting lives in :mod:`mycat.activity` (runs
 graded by length); this class only drives the live tooltip and the rest banner.
 """
 
-import configparser
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -26,13 +25,13 @@ from PySide6 import QtCore
 
 if __package__:
     from . import activity as activity_mod
-    from . import activity_store, paths, secret_store
+    from . import activity_store, config_store, paths
 else:
     import importlib
 
     activity_mod = importlib.import_module("mycat.activity")
     activity_store = importlib.import_module("mycat.activity_store")
-    secret_store = importlib.import_module("mycat.secret_store")
+    config_store = importlib.import_module("mycat.config_store")
     paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
@@ -74,37 +73,28 @@ class FocusSettings:
 def load_focus_settings(cfg_file: Path = CFG_FILE) -> FocusSettings:
     """Read the ``[focus]`` section; every field falls back to the default."""
     settings = FocusSettings()
-    if not cfg_file.exists():
+    config = config_store.read_config(cfg_file)
+    if config is None or "focus" not in config:
         return settings
     try:
-        config = configparser.ConfigParser()
-        config.read(cfg_file)
-        if "focus" not in config:
-            return settings
         section = config["focus"]
         settings.focus_minutes = section.getint("focus_minutes", fallback=settings.focus_minutes)
         settings.tooltip_enabled = section.getboolean("tooltip_enabled", fallback=settings.tooltip_enabled)
-    except Exception as exc:  # noqa: BLE001 - never let a bad config crash the app
+    except (ValueError, TypeError) as exc:  # a malformed value -> keep the defaults
         logger.error("Failed to load focus settings: %s", exc)
     return settings
 
 
 def save_focus_settings(settings: FocusSettings, cfg_file: Path = CFG_FILE) -> None:
-    """Persist the ``[focus]`` section (Pomodoro goal + tooltip), creating the file if needed."""
-    try:
-        cfg_file.parent.mkdir(parents=True, exist_ok=True)
-        config = configparser.ConfigParser()
-        if cfg_file.exists():
-            config.read(cfg_file)
-        if "focus" not in config:
-            config.add_section("focus")
-        config["focus"]["focus_minutes"] = str(settings.focus_minutes)
-        config["focus"]["tooltip_enabled"] = "true" if settings.tooltip_enabled else "false"
-        with open(cfg_file, "w") as fh:
-            config.write(fh)
-        secret_store.secure_file(cfg_file)
-    except Exception as exc:  # noqa: BLE001 - never let a bad config crash the app
-        logger.error("Failed to save focus settings: %s", exc)
+    """Persist the ``[focus]`` section (Pomodoro goal + tooltip)."""
+    config_store.write_section(
+        "focus",
+        {
+            "focus_minutes": settings.focus_minutes,
+            "tooltip_enabled": config_store.bool_str(settings.tooltip_enabled),
+        },
+        cfg_file,
+    )
 
 
 class FocusController(QtCore.QObject):

--- a/mycat/focus.py
+++ b/mycat/focus.py
@@ -26,19 +26,20 @@ from PySide6 import QtCore
 
 if __package__:
     from . import activity as activity_mod
-    from . import activity_store, secret_store
+    from . import activity_store, paths, secret_store
 else:
     import importlib
 
     activity_mod = importlib.import_module("mycat.activity")
     activity_store = importlib.import_module("mycat.activity_store")
     secret_store = importlib.import_module("mycat.secret_store")
+    paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
 
 # Same config file the rest of the app uses (see main.py / reminder.py).
-CFG_DIR = Path.home() / ".config" / "mycat"
-CFG_FILE = CFG_DIR / "config.ini"
+CFG_DIR = paths.config_dir()
+CFG_FILE = paths.config_file()
 
 
 def cursor_km_estimate(mouse_px: int) -> float:

--- a/mycat/github_api.py
+++ b/mycat/github_api.py
@@ -1,0 +1,54 @@
+"""Shared GitHub REST helper — the one place the auth token is attached.
+
+If a token is configured — the ``[github]`` section's ``token`` (the same one the
+notifications feature uses), or the ``GITHUB_TOKEN`` env var — every GitHub
+request goes out authenticated, lifting the anonymous 60 req/h per-IP cap to
+5000 req/h. Both the notifications poller and the update check build their
+requests here, so a token set once is used for every GitHub call.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import urllib.request
+
+from . import config_store, paths
+
+logger = logging.getLogger(__name__)
+
+ACCEPT = "application/vnd.github+json"
+API_VERSION = "2022-11-28"
+USER_AGENT = "mycat-desktop-pet"
+DEFAULT_TOKEN_ENV = "GITHUB_TOKEN"
+
+
+def resolve_token(config_token: str = "", token_env: str = DEFAULT_TOKEN_ENV) -> str:
+    """A literal config token wins; otherwise fall back to the env var."""
+    return config_token or os.getenv(token_env, "")
+
+
+def github_token() -> str:
+    """The token to authenticate GitHub calls, read from the ``[github]`` config
+    (or ``GITHUB_TOKEN``) — for callers without a loaded settings object."""
+    config = config_store.read_config(paths.config_file())
+    if config is None or "github" not in config:
+        return resolve_token()
+    section = config["github"]
+    return resolve_token(section.get("token", ""), section.get("token_env", DEFAULT_TOKEN_ENV))
+
+
+def build_request(url: str, *, token: str = "", etag: str = "", last_modified: str = "") -> urllib.request.Request:
+    """A GitHub API request with the standard headers, plus the ``Authorization``
+    header when a token is given (so it counts against the 5000/h authed limit)."""
+    request = urllib.request.Request(url)
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", ACCEPT)
+    request.add_header("X-GitHub-Api-Version", API_VERSION)
+    request.add_header("User-Agent", USER_AGENT)
+    if etag:
+        request.add_header("If-None-Match", etag)
+    if last_modified:
+        request.add_header("If-Modified-Since", last_modified)
+    return request

--- a/mycat/github_notify.py
+++ b/mycat/github_notify.py
@@ -40,10 +40,11 @@ from pathlib import Path
 from PySide6 import QtCore
 
 if __package__:
-    from . import paths, secret_store
+    from . import config_store, paths, secret_store
 else:
     import importlib
 
+    config_store = importlib.import_module("mycat.config_store")
     secret_store = importlib.import_module("mycat.secret_store")
     paths = importlib.import_module("mycat.paths")
 
@@ -148,13 +149,10 @@ class GitHubSettings:
 
 def load_github_settings(cfg_file: Path = CFG_FILE) -> GitHubSettings:
     settings = GitHubSettings()
-    if not cfg_file.exists():
+    config = config_store.read_config(cfg_file)
+    if config is None or "github" not in config:
         return settings
     try:
-        config = configparser.ConfigParser()
-        config.read(cfg_file)
-        if "github" not in config:
-            return settings
         section = config["github"]
         settings.enabled = section.getboolean("enabled", fallback=False)
         settings.token = section.get("token", "")
@@ -168,7 +166,7 @@ def load_github_settings(cfg_file: Path = CFG_FILE) -> GitHubSettings:
         raw = section.get("categories", "") or section.get("reasons", ",".join(DEFAULT_CATEGORIES))
         categories = tuple(item.strip() for item in raw.split(",") if item.strip())
         settings.categories = categories or DEFAULT_CATEGORIES
-    except Exception as exc:  # noqa: BLE001 - never let a bad config crash the app
+    except (ValueError, TypeError) as exc:  # a malformed value -> keep the defaults
         logger.error("Failed to load [github] settings: %s", exc)
     return settings
 

--- a/mycat/github_notify.py
+++ b/mycat/github_notify.py
@@ -40,16 +40,17 @@ from pathlib import Path
 from PySide6 import QtCore
 
 if __package__:
-    from . import secret_store
+    from . import paths, secret_store
 else:
     import importlib
 
     secret_store = importlib.import_module("mycat.secret_store")
+    paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
 
-CFG_DIR = Path.home() / ".config" / "mycat"
-CFG_FILE = CFG_DIR / "config.ini"
+CFG_DIR = paths.config_dir()
+CFG_FILE = paths.config_file()
 
 API_URL = "https://api.github.com/notifications"
 USER_URL = "https://api.github.com/user"

--- a/mycat/github_notify.py
+++ b/mycat/github_notify.py
@@ -40,11 +40,12 @@ from pathlib import Path
 from PySide6 import QtCore
 
 if __package__:
-    from . import config_store, paths, secret_store
+    from . import config_store, github_api, paths, secret_store
 else:
     import importlib
 
     config_store = importlib.import_module("mycat.config_store")
+    github_api = importlib.import_module("mycat.github_api")
     secret_store = importlib.import_module("mycat.secret_store")
     paths = importlib.import_module("mycat.paths")
 
@@ -140,11 +141,7 @@ class GitHubSettings:
     token_verified: bool = False  # a UI gate: the inbox checkboxes unlock on a good Test
 
     def resolve_token(self) -> str:
-        if self.token:
-            return self.token
-        import os
-
-        return os.getenv(self.token_env, "")
+        return github_api.resolve_token(self.token, self.token_env)
 
 
 def load_github_settings(cfg_file: Path = CFG_FILE) -> GitHubSettings:
@@ -461,17 +458,7 @@ class FollowerTracker:
 
 
 def github_request(url: str, token: str = "", etag: str = "", last_modified: str = ""):
-    request = urllib.request.Request(url)
-    if token:
-        request.add_header("Authorization", f"Bearer {token}")
-    request.add_header("Accept", "application/vnd.github+json")
-    request.add_header("X-GitHub-Api-Version", "2022-11-28")
-    request.add_header("User-Agent", "mycat-desktop-pet")
-    if etag:
-        request.add_header("If-None-Match", etag)
-    if last_modified:
-        request.add_header("If-Modified-Since", last_modified)
-    return request
+    return github_api.build_request(url, token=token, etag=etag, last_modified=last_modified)
 
 
 def rate_limit_reset(headers) -> int:

--- a/mycat/llm_prompt.py
+++ b/mycat/llm_prompt.py
@@ -20,7 +20,6 @@ CFG_DIR = paths.config_dir()
 CFG_FILE = paths.config_file()
 HISTORY_FILE = CFG_DIR / "history.txt"
 PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent / "PROMPT.j2"
-_LEGACY_PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent / "PROMT.j2"
 HISTORY_MAX_BYTES = 1_000_000
 
 DEFAULT_PROMPT_TEMPLATE = """You are a cute, affectionate talking cat belonging to a girl.
@@ -29,8 +28,8 @@ Recent conversation (latest {{history_count}} messages):
 {{history}}
 Stay warm, playful, and loving when you reply."""
 
-_ENV_LOADED = False
-_PROMPT_TEMPLATE_CACHE: str | None = None
+ENV_LOADED = False
+PROMPT_TEMPLATE_CACHE: str | None = None
 
 HISTORY_HEADER_RE = re.compile(r"^\[(?P<timestamp>.+?)\]\s+(?P<label>REQUEST|RESPONSE):$")
 
@@ -49,10 +48,10 @@ class LLMSettings:
 
 def load_env_file() -> None:
     """Populate environment variables from .env-style files once per process."""
-    global _ENV_LOADED
-    if _ENV_LOADED:
+    global ENV_LOADED
+    if ENV_LOADED:
         return
-    _ENV_LOADED = True
+    ENV_LOADED = True
 
     def apply_env(path: Path) -> None:
         try:
@@ -192,17 +191,17 @@ def ensure_history_file() -> Path:
         CFG_DIR.mkdir(parents=True, exist_ok=True)
         if not HISTORY_FILE.exists():
             HISTORY_FILE.touch()
-        _restrict_permissions(HISTORY_FILE)
+        restrict_permissions(HISTORY_FILE)
         return HISTORY_FILE
     except OSError as exc:
         logger.warning("Falling back to temp history file: %s", exc)
         fallback = Path(tempfile.gettempdir()) / "mycat_history.txt"
         fallback.touch(exist_ok=True)
-        _restrict_permissions(fallback)
+        restrict_permissions(fallback)
         return fallback
 
 
-def _restrict_permissions(path: Path) -> None:
+def restrict_permissions(path: Path) -> None:
     """Best-effort chmod 600 for files that may hold private chat content."""
     try:
         os.chmod(path, 0o600)
@@ -223,7 +222,7 @@ def rotate_history_if_needed(path: Path, max_bytes: int = HISTORY_MAX_BYTES) -> 
             logger.debug("Unable to remove old history backup %s: %s", backup, exc)
         path.replace(backup)
         path.touch()
-        _restrict_permissions(path)
+        restrict_permissions(path)
         logger.info("Rotated history file to %s", backup)
     except OSError as exc:
         logger.warning("Unable to rotate history file %s: %s", path, exc)
@@ -296,7 +295,7 @@ def get_history_tail(history_path: Path, limit: int) -> list[str]:
     return out
 
 
-_PLACEHOLDER_RE = re.compile(r"\{\{\s*(date|history|history_count)\s*\}\}")
+PLACEHOLDER_RE = re.compile(r"\{\{\s*(date|history|history_count)\s*\}\}")
 
 
 def render_prompt(history_lines: list[str], history_limit: int) -> str:
@@ -305,7 +304,7 @@ def render_prompt(history_lines: list[str], history_limit: int) -> str:
     Supports both `{{key}}` and `{{ key }}` placeholder forms so the file may
     use Jinja-style spacing without depending on Jinja2 itself.
     """
-    template = _load_prompt_template()
+    template = load_prompt_template()
     history_text = "\n".join(history_lines) if history_lines else "No history available."
     now = datetime.now().strftime("%Y-%m-%d %H:%M")
     values = {
@@ -313,24 +312,22 @@ def render_prompt(history_lines: list[str], history_limit: int) -> str:
         "history": history_text,
         "history_count": str(history_limit),
     }
-    return _PLACEHOLDER_RE.sub(lambda m: values[m.group(1)], template)
+    return PLACEHOLDER_RE.sub(lambda m: values[m.group(1)], template)
 
 
-def _load_prompt_template() -> str:
-    global _PROMPT_TEMPLATE_CACHE
-    if _PROMPT_TEMPLATE_CACHE is not None:
-        return _PROMPT_TEMPLATE_CACHE
-    for candidate in (PROMPT_TEMPLATE_PATH, _LEGACY_PROMPT_TEMPLATE_PATH):
-        if not candidate.exists():
-            continue
+def load_prompt_template() -> str:
+    global PROMPT_TEMPLATE_CACHE
+    if PROMPT_TEMPLATE_CACHE is not None:
+        return PROMPT_TEMPLATE_CACHE
+    if PROMPT_TEMPLATE_PATH.exists():
         try:
-            _PROMPT_TEMPLATE_CACHE = candidate.read_text(encoding="utf-8")
-            logger.debug("Loaded prompt template from %s", candidate)
-            return _PROMPT_TEMPLATE_CACHE
+            PROMPT_TEMPLATE_CACHE = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
+            logger.debug("Loaded prompt template from %s", PROMPT_TEMPLATE_PATH)
+            return PROMPT_TEMPLATE_CACHE
         except OSError as exc:
-            logger.warning("Unable to read %s: %s", candidate, exc)
-    _PROMPT_TEMPLATE_CACHE = DEFAULT_PROMPT_TEMPLATE
-    return _PROMPT_TEMPLATE_CACHE
+            logger.warning("Unable to read %s: %s", PROMPT_TEMPLATE_PATH, exc)
+    PROMPT_TEMPLATE_CACHE = DEFAULT_PROMPT_TEMPLATE
+    return PROMPT_TEMPLATE_CACHE
 
 
 __all__ = [

--- a/mycat/llm_prompt.py
+++ b/mycat/llm_prompt.py
@@ -11,13 +11,13 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-from . import secret_store
+from . import paths, secret_store
 
 logger = logging.getLogger(__name__)
 
-APP_NAME = "mycat"
-CFG_DIR = Path.home() / ".config" / APP_NAME
-CFG_FILE = CFG_DIR / "config.ini"
+APP_NAME = "mycat"  # kept for backward-compat: exported in __all__
+CFG_DIR = paths.config_dir()
+CFG_FILE = paths.config_file()
 HISTORY_FILE = CFG_DIR / "history.txt"
 PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent / "PROMPT.j2"
 _LEGACY_PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent / "PROMT.j2"

--- a/mycat/llm_settings_ui.py
+++ b/mycat/llm_settings_ui.py
@@ -164,7 +164,7 @@ class LLMSettingsDialog(QtWidgets.QDialog):
     # -- state --------------------------------------------------------------
 
     def controller(self):
-        return getattr(self.host_window, "_llm_controller", None)
+        return getattr(self.host_window, "llm_controller", None)
 
     def current_enabled(self) -> bool:
         controller = self.controller()

--- a/mycat/llm_ui.py
+++ b/mycat/llm_ui.py
@@ -19,15 +19,15 @@ logger = logging.getLogger(__name__)
 
 
 def attach_chat(window: QtWidgets.QWidget, context: LLMContext, enabled: bool = True) -> None:
-    controller = _LLMController(window, context, enabled=enabled)
-    setattr(window, "_llm_controller", controller)
-    setattr(window, "_toggle_llm_chat", controller.toggle_chat)
-    setattr(window, "_toggle_llm_enabled", controller.toggle_enabled)
-    setattr(window, "_is_llm_enabled", controller.is_enabled)
+    controller = LLMController(window, context, enabled=enabled)
+    setattr(window, "llm_controller", controller)
+    setattr(window, "toggle_llm_chat", controller.toggle_chat)
+    setattr(window, "toggle_llm_enabled", controller.toggle_enabled)
+    setattr(window, "is_llm_enabled", controller.is_enabled)
     logger.debug("Chat controller attached to window %s", window)
 
 
-class _LLMController(QtCore.QObject):
+class LLMController(QtCore.QObject):
     """Owns the chat dialog lifecycle and keeps it anchored to the cat window."""
 
     def __init__(self, window: QtWidgets.QWidget, context: LLMContext, enabled: bool = True) -> None:
@@ -39,7 +39,7 @@ class _LLMController(QtCore.QObject):
         self.history_file = llm_prompt.ensure_history_file()
 
         window.installEventFilter(self)
-        window.destroyed.connect(self._on_window_destroyed)
+        window.destroyed.connect(self.on_window_destroyed)
         logger.debug("LLM controller initialised with history file %s", self.history_file)
 
     def eventFilter(self, watched: QtCore.QObject, event: QtCore.QEvent) -> bool:
@@ -47,10 +47,11 @@ class _LLMController(QtCore.QObject):
             QtCore.QEvent.Type.Move,
             QtCore.QEvent.Type.Resize,
         ):
-            self._position_dialog()
+            self.position_dialog()
         return super().eventFilter(watched, event)
 
-    def _toggle_chat(self) -> None:
+    def toggle_chat(self) -> None:
+        """Public hook for opening chat from host UI."""
         if not self.enabled:
             logger.debug("LLM chat is disabled, ignoring toggle")
             return
@@ -61,7 +62,7 @@ class _LLMController(QtCore.QObject):
                 return
             logger.debug("Showing existing chat dialog")
             self.chat_dialog.show()
-            self._position_dialog()
+            self.position_dialog()
             self.chat_dialog.raise_()
             self.chat_dialog.activateWindow()
             return
@@ -69,13 +70,9 @@ class _LLMController(QtCore.QObject):
         logger.debug("Creating new chat dialog")
         dialog = ChatDialog(self)
         dialog.show()
-        dialog.destroyed.connect(self._on_chat_destroyed)
+        dialog.destroyed.connect(self.on_chat_destroyed)
         self.chat_dialog = dialog
-        self._position_dialog()
-
-    def toggle_chat(self) -> None:
-        """Public hook for opening chat from host UI."""
-        self._toggle_chat()
+        self.position_dialog()
 
     def is_enabled(self) -> bool:
         return self.enabled
@@ -90,7 +87,7 @@ class _LLMController(QtCore.QObject):
         logger.info("LLM chat %s", "enabled" if self.enabled else "disabled")
         return self.enabled
 
-    def _position_dialog(self) -> None:
+    def position_dialog(self) -> None:
         if not self.chat_dialog:
             return
         screen_rect = QtGui.QGuiApplication.primaryScreen().availableGeometry()
@@ -110,35 +107,35 @@ class _LLMController(QtCore.QObject):
         if x + dialog_width > screen_rect.width():
             x = screen_rect.width() - dialog_width - 10
 
-        dialog._suspend_anchor = True  # type: ignore[attr-defined]
+        dialog.suspend_anchor = True  # type: ignore[attr-defined]
         dialog.move(x, y)
-        dialog._suspend_anchor = False  # type: ignore[attr-defined]
+        dialog.suspend_anchor = False  # type: ignore[attr-defined]
 
-    def _on_chat_destroyed(self, *_args) -> None:
+    def on_chat_destroyed(self, *_args) -> None:
         logger.debug("Chat dialog destroyed")
         self.chat_dialog = None
 
-    def _on_window_destroyed(self, *_args) -> None:
+    def on_window_destroyed(self, *_args) -> None:
         self.chat_dialog = None
 
 
 class ChatDialog(QtWidgets.QDialog):
     """Frameless chat dialog with message history and async LLM requests."""
 
-    def __init__(self, controller: _LLMController):
+    def __init__(self, controller: LLMController):
         super().__init__(controller.window)
         self.controller = controller
         self.backend = controller.context.backend
         self.settings = controller.context.settings
         self.history_file = controller.history_file
         self.message_count = 0
-        self._waiting_for_response = False
-        self._thread_pool = QtCore.QThreadPool.globalInstance()
-        self._pending_worker: _LLMWorker | None = None
-        self._pending_request_started: float | None = None
-        self._pending_request_text: str | None = None
-        self._suspend_anchor = False
-        self._messages: list[tuple[str, str, str]] = []
+        self.waiting_for_response = False
+        self.thread_pool = QtCore.QThreadPool.globalInstance()
+        self.pending_worker: LLMWorker | None = None
+        self.pending_request_started: float | None = None
+        self.pending_request_text: str | None = None
+        self.suspend_anchor = False
+        self.messages: list[tuple[str, str, str]] = []
 
         self.setWindowFlags(
             QtCore.Qt.WindowType.Window
@@ -151,10 +148,10 @@ class ChatDialog(QtWidgets.QDialog):
         self.setSizeGripEnabled(True)
         self.setModal(False)
 
-        self._build_ui()
-        self._load_history()
+        self.build_ui()
+        self.load_history()
 
-    def _build_ui(self) -> None:
+    def build_ui(self) -> None:
         main_layout = QtWidgets.QVBoxLayout(self)
         main_layout.setContentsMargins(4, 4, 4, 4)
         main_layout.setSpacing(2)
@@ -175,7 +172,7 @@ class ChatDialog(QtWidgets.QDialog):
         self.messages_layout.setAlignment(QtCore.Qt.AlignmentFlag.AlignBottom)
         self.scroll_area.setWidget(self.messages_widget)
         self.scroll_area.verticalScrollBar().rangeChanged.connect(
-            lambda *_: QtCore.QTimer.singleShot(0, self._scroll_to_bottom)
+            lambda *_: QtCore.QTimer.singleShot(0, self.scroll_to_bottom)
         )
 
         input_layout = QtWidgets.QHBoxLayout()
@@ -226,23 +223,23 @@ class ChatDialog(QtWidgets.QDialog):
         self.send_button.setStyleSheet(button_style)
         self.send_button.setDefault(True)
         self.send_button.setAutoDefault(True)
-        self.send_button.clicked.connect(self._send_message)
+        self.send_button.clicked.connect(self.send_message)
         input_layout.addWidget(self.send_button)
 
         main_layout.addLayout(input_layout)
-        self.input_field.returnPressed.connect(self._send_message)
-        self._typing_indicator: TypingIndicator | None = None
+        self.input_field.returnPressed.connect(self.send_message)
+        self.typing_indicator: TypingIndicator | None = None
 
-    def _load_history(self) -> None:
+    def load_history(self) -> None:
         entries = llm_prompt.parse_history_file(self.history_file)
-        self._messages = entries
+        self.messages = entries
         self.message_count = len(entries)
         logger.debug("Loaded %d history entries", self.message_count)
-        self._render_messages()
+        self.render_messages()
 
-    def _show_welcome_message(self) -> None:
-        self._messages = []
-        self._clear_message_widgets()
+    def show_welcome_message(self) -> None:
+        self.messages = []
+        self.clear_message_widgets()
         label = QtWidgets.QLabel("Write something...")
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         label.setStyleSheet("color: #888; font-style: italic; margin-top: 40px;")
@@ -258,64 +255,64 @@ class ChatDialog(QtWidgets.QDialog):
 
     def resizeEvent(self, event: QtGui.QResizeEvent) -> None:
         super().resizeEvent(event)
-        if not getattr(self, "_suspend_anchor", False):
-            self.controller._position_dialog()
+        if not getattr(self, "suspend_anchor", False):
+            self.controller.position_dialog()
 
     def moveEvent(self, event: QtGui.QMoveEvent) -> None:
         super().moveEvent(event)
-        if not getattr(self, "_suspend_anchor", False):
-            self.controller._position_dialog()
+        if not getattr(self, "suspend_anchor", False):
+            self.controller.position_dialog()
 
-    def _send_message(self) -> None:
+    def send_message(self) -> None:
         text = self.input_field.text().strip()
-        if not text or self._waiting_for_response:
+        if not text or self.waiting_for_response:
             return
         logger.info("Request: %s", text)
-        self._append_message("user", text)
-        QtCore.QTimer.singleShot(0, self._scroll_to_bottom)
+        self.append_message("user", text)
+        QtCore.QTimer.singleShot(0, self.scroll_to_bottom)
         self.input_field.clear()
-        self._set_input_enabled(False)
-        self._waiting_for_response = True
-        self._request_ai_response(text)
-        self._show_typing_indicator()
-        self._schedule_scroll()
+        self.set_input_enabled(False)
+        self.waiting_for_response = True
+        self.request_ai_response(text)
+        self.show_typing_indicator()
+        self.schedule_scroll()
 
-    def _request_ai_response(self, text: str) -> None:
+    def request_ai_response(self, text: str) -> None:
         history_lines = llm_prompt.get_history_tail(self.history_file, self.settings.history_messages)
         system_prompt = llm_prompt.render_prompt(history_lines, self.settings.history_messages)
-        self._pending_request_started = time.monotonic()
-        self._pending_request_text = text
-        worker = _LLMWorker(self.backend, text, system_prompt)
-        worker.signals.result.connect(self._on_ai_success)
-        worker.signals.error.connect(self._on_ai_error)
-        worker.signals.finished.connect(self._on_ai_finished)
-        self._thread_pool.start(worker)
-        self._pending_worker = worker
+        self.pending_request_started = time.monotonic()
+        self.pending_request_text = text
+        worker = LLMWorker(self.backend, text, system_prompt)
+        worker.signals.result.connect(self.on_ai_success)
+        worker.signals.error.connect(self.on_ai_error)
+        worker.signals.finished.connect(self.on_ai_finished)
+        self.thread_pool.start(worker)
+        self.pending_worker = worker
 
-    def _on_ai_success(self, answer: str) -> None:
-        self._append_message("cat", answer)
-        self._schedule_scroll()
-        self._log_request_summary(answer, success=True)
+    def on_ai_success(self, answer: str) -> None:
+        self.append_message("cat", answer)
+        self.schedule_scroll()
+        self.log_request_summary(answer, success=True)
 
-    def _on_ai_error(self, message: str) -> None:
+    def on_ai_error(self, message: str) -> None:
         logger.error("LLM backend error: %s", message)
-        self._append_message("cat", f"Error: {message}")
-        self._schedule_scroll()
-        self._log_request_summary(message, success=False)
+        self.append_message("cat", f"Error: {message}")
+        self.schedule_scroll()
+        self.log_request_summary(message, success=False)
 
-    def _on_ai_finished(self) -> None:
-        self._pending_worker = None
-        self._waiting_for_response = False
-        self._set_input_enabled(True)
-        self._pending_request_started = None
-        self._pending_request_text = None
-        self._hide_typing_indicator()
+    def on_ai_finished(self) -> None:
+        self.pending_worker = None
+        self.waiting_for_response = False
+        self.set_input_enabled(True)
+        self.pending_request_started = None
+        self.pending_request_text = None
+        self.hide_typing_indicator()
 
-    def _set_input_enabled(self, enabled: bool) -> None:
+    def set_input_enabled(self, enabled: bool) -> None:
         self.input_field.setEnabled(enabled)
         self.send_button.setEnabled(enabled)
 
-    def _append_message(
+    def append_message(
         self,
         role: str,
         text: str,
@@ -324,59 +321,59 @@ class ChatDialog(QtWidgets.QDialog):
     ) -> None:
         timestamp = timestamp or datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         if self.message_count == 0:
-            self._messages = []
-        self._messages.append((role, text, timestamp))
-        self.message_count = len(self._messages)
-        self._render_messages()
+            self.messages = []
+        self.messages.append((role, text, timestamp))
+        self.message_count = len(self.messages)
+        self.render_messages()
         if persist:
             llm_prompt.append_history_entry(self.history_file, role, text, timestamp)
 
-    def _render_messages(self) -> None:
-        if not self._messages:
-            self._show_welcome_message()
+    def render_messages(self) -> None:
+        if not self.messages:
+            self.show_welcome_message()
             return
 
-        self._clear_message_widgets()
-        for role, text, _timestamp in self._messages:
+        self.clear_message_widgets()
+        for role, text, _timestamp in self.messages:
             bubble = MessageBubble(role, text)
             self.messages_layout.addWidget(bubble, alignment=bubble.alignment_flag)
-        self._schedule_scroll()
-        self._update_bubble_widths()
+        self.schedule_scroll()
+        self.update_bubble_widths()
 
-    def _clear_message_widgets(self) -> None:
+    def clear_message_widgets(self) -> None:
         while self.messages_layout.count():
             item = self.messages_layout.takeAt(0)
             widget = item.widget()
             if widget:
                 widget.deleteLater()
-        self._typing_indicator = None
+        self.typing_indicator = None
 
-    def _show_typing_indicator(self) -> None:
-        if getattr(self, "_typing_indicator", None):
+    def show_typing_indicator(self) -> None:
+        if getattr(self, "typing_indicator", None):
             return
         indicator = TypingIndicator()
         self.messages_layout.addWidget(indicator, alignment=QtCore.Qt.AlignmentFlag.AlignRight)
-        self._typing_indicator = indicator
-        self._schedule_scroll()
+        self.typing_indicator = indicator
+        self.schedule_scroll()
 
-    def _hide_typing_indicator(self) -> None:
-        indicator = getattr(self, "_typing_indicator", None)
+    def hide_typing_indicator(self) -> None:
+        indicator = getattr(self, "typing_indicator", None)
         if not indicator:
             return
         indicator.deleteLater()
-        self._typing_indicator = None
-        self._schedule_scroll()
+        self.typing_indicator = None
+        self.schedule_scroll()
 
-    def _scroll_to_bottom(self) -> None:
+    def scroll_to_bottom(self) -> None:
         scrollbar = self.scroll_area.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
-        self._update_bubble_widths()
+        self.update_bubble_widths()
 
-    def _schedule_scroll(self) -> None:
-        QtCore.QTimer.singleShot(0, self._scroll_to_bottom)
-        QtCore.QTimer.singleShot(60, self._scroll_to_bottom)
+    def schedule_scroll(self) -> None:
+        QtCore.QTimer.singleShot(0, self.scroll_to_bottom)
+        QtCore.QTimer.singleShot(60, self.scroll_to_bottom)
 
-    def _update_bubble_widths(self) -> None:
+    def update_bubble_widths(self) -> None:
         viewport = self.scroll_area.viewport()
         max_width = max(100, int(viewport.width() * 0.85))
         for index in range(self.messages_layout.count()):
@@ -386,10 +383,10 @@ class ChatDialog(QtWidgets.QDialog):
                 widget.set_max_width(max_width)
         self.messages_widget.setMinimumHeight(viewport.height())
 
-    def _log_request_summary(self, response: str, success: bool) -> None:
-        if self._pending_request_started is None or self._pending_request_text is None:
+    def log_request_summary(self, response: str, success: bool) -> None:
+        if self.pending_request_started is None or self.pending_request_text is None:
             return
-        duration = time.monotonic() - self._pending_request_started
+        duration = time.monotonic() - self.pending_request_started
         # One line. The request itself is already logged when it is sent.
         if success:
             # Readable text, newlines collapsed so it stays on one line.
@@ -399,21 +396,21 @@ class ChatDialog(QtWidgets.QDialog):
             logger.error("error: %s (%.2fs)", json.dumps(response, ensure_ascii=False), duration)
 
 
-class _LLMWorkerSignals(QtCore.QObject):
+class LLMWorkerSignals(QtCore.QObject):
     """Qt signals emitted by the background worker."""
     result = QtCore.Signal(str)
     error = QtCore.Signal(str)
     finished = QtCore.Signal()
 
 
-class _LLMWorker(QtCore.QRunnable):
+class LLMWorker(QtCore.QRunnable):
     """Runs LLM requests off the UI thread and streams results via signals."""
     def __init__(self, backend, user_text: str, system_prompt: str) -> None:
         super().__init__()
         self.backend = backend
         self.user_text = user_text
         self.system_prompt = system_prompt
-        self.signals = _LLMWorkerSignals()
+        self.signals = LLMWorkerSignals()
 
     def run(self) -> None:
         try:
@@ -473,28 +470,28 @@ class MessageBubble(QtWidgets.QWidget):
         inner.addWidget(body)
         layout.addWidget(self.frame)
 
-        self._body_label = body
-        self._opacity_timer = QtCore.QTimer(self)
-        self._opacity_timer.setSingleShot(True)
-        self._opacity_timer.timeout.connect(self._restore_opacity)
+        self.body_label = body
+        self.opacity_timer = QtCore.QTimer(self)
+        self.opacity_timer.setSingleShot(True)
+        self.opacity_timer.timeout.connect(self.restore_opacity)
 
     def mousePressEvent(self, event: QtGui.QMouseEvent) -> None:
         if event.button() == QtCore.Qt.MouseButton.LeftButton:
             QtWidgets.QApplication.clipboard().setText(self.raw_text)
-            self._body_label.setStyleSheet("font-size: 13px; color: rgba(28,28,28,0.4);")
-            self._opacity_timer.start(200)
+            self.body_label.setStyleSheet("font-size: 13px; color: rgba(28,28,28,0.4);")
+            self.opacity_timer.start(200)
         super().mousePressEvent(event)
 
-    def _restore_opacity(self) -> None:
-        self._body_label.setStyleSheet("font-size: 13px; color: #1c1c1c; background: transparent;")
+    def restore_opacity(self) -> None:
+        self.body_label.setStyleSheet("font-size: 13px; color: #1c1c1c; background: transparent;")
 
     def set_max_width(self, width: int) -> None:
         self.frame.setMaximumWidth(width)
         self.frame.setMinimumWidth(min(width, 200))
         max_body = max(50, width - 12)
         self.frame.setMinimumWidth(max_body)
-        self._body_label.setMaximumWidth(max_body - 12)
-        self._body_label.setMinimumWidth(max(60, max_body - 12))
+        self.body_label.setMaximumWidth(max_body - 12)
+        self.body_label.setMinimumWidth(max(60, max_body - 12))
 
 
 class TypingIndicator(QtWidgets.QWidget):
@@ -522,18 +519,18 @@ class TypingIndicator(QtWidgets.QWidget):
         inner.addWidget(self.label)
         layout.addWidget(frame)
 
-        self._phase = 0
-        self._timer = QtCore.QTimer(self)
-        self._timer.timeout.connect(self._advance)
-        self._timer.start(1000)
+        self.phase = 0
+        self.timer = QtCore.QTimer(self)
+        self.timer.timeout.connect(self.advance)
+        self.timer.start(1000)
 
-    def _advance(self) -> None:
-        if self._phase < 3:
+    def advance(self) -> None:
+        if self.phase < 3:
             opacity = 1.0
         else:
             opacity = 0.5
         self.label.setStyleSheet(f"font-size: 14px; color: rgba(28,28,28,{opacity});")
-        self._phase = (self._phase + 1) % 4
+        self.phase = (self.phase + 1) % 4
 
 
 __all__ = ["attach_chat"]

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -39,6 +39,7 @@ if __package__:
         focus,
         github_notify,
         llm,
+        paths,
         reminder,
         secret_store,
         update_check,
@@ -50,6 +51,7 @@ else:
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
     llm = importlib.import_module("mycat.llm")
+    paths = importlib.import_module("mycat.paths")
     char_catalog = importlib.import_module("mycat.char_catalog")
     reminder = importlib.import_module("mycat.reminder")
     secret_store = importlib.import_module("mycat.secret_store")
@@ -86,9 +88,9 @@ logging.basicConfig(**LOGGING)
 logger = logging.getLogger(__name__)
 logger.debug("LLM integration module path: %s", getattr(llm, "__file__", "builtin"))
 
-# Config paths
-CFG_DIR = Path.home() / ".config" / "mycat"
-CFG_FILE = CFG_DIR / "config.ini"
+# Config paths — single source of truth in paths.py (stays ~/.config/mycat).
+CFG_DIR = paths.config_dir()
+CFG_FILE = paths.config_file()
 
 # Per-user local-socket name: a second `mycat` launch uses it to raise the
 # running cat's window (so hiding it to a flaky tray is always recoverable).

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -37,6 +37,7 @@ if __package__:
         char_pack,
         digest,
         focus,
+        github_api,
         github_notify,
         llm,
         paths,
@@ -59,6 +60,7 @@ else:
     char_pack = importlib.import_module("mycat.char_pack")
     announcer = importlib.import_module("mycat.announcer")
     focus = importlib.import_module("mycat.focus")
+    github_api = importlib.import_module("mycat.github_api")
     github_notify = importlib.import_module("mycat.github_notify")
     calendar_ics = importlib.import_module("mycat.calendar_ics")
     activity = importlib.import_module("mycat.activity")
@@ -1375,7 +1377,7 @@ class PixelCatWindow(QtWidgets.QWidget):
             # let on_update_checked decide up-to-date vs. newer vs. check-failed —
             # so a rate-limited/offline check never poses as "you're up to date".
             try:
-                signals.checked.emit(update_check.latest_release_tag() or "")
+                signals.checked.emit(update_check.latest_release_tag(token=github_api.github_token()) or "")
             except Exception as exc:  # noqa: BLE001 - surfaced to the user
                 signals.failed.emit(str(exc))
 
@@ -1411,20 +1413,20 @@ class PixelCatWindow(QtWidgets.QWidget):
             # The check couldn't reach GitHub (offline, or the API rate-limited
             # this IP). Don't claim we're up to date — say the check failed.
             self.update_box(
-                "Update check",
-                "Couldn't check for updates right now.",
-                "GitHub may be unreachable or rate-limited — try again in a bit, "
-                "or open the releases page to check by hand.",
+                "myCat",
+                f"Current: {current}",
+                "Couldn't reach GitHub — try again in a bit.",
                 kind,
                 can_update=False,
             )
             return
+        versions = f"Current: {current}\nLatest: {latest}"
         if update_check.parse_version(latest) <= update_check.parse_version(current):
             # Up to date — nothing to update, so Update stays greyed out.
             self.update_box(
-                "mycat",
-                f"You're on the latest version ({current}). 🐱",
-                "Everything's up to date.",
+                "myCat",
+                versions,
+                "No update needed — you're on the latest version. 🐱",
                 kind,
                 can_update=False,
             )
@@ -1432,18 +1434,18 @@ class PixelCatWindow(QtWidgets.QWidget):
         if not updater.can_self_update(kind):
             # pip / git / deb / AppImage: tell them how, Update stays greyed out.
             self.update_box(
-                "Update available",
-                f"mycat {latest} is available (you have {current}).",
-                f"Update with:\n\n    {updater.update_hint(kind)}",
+                "myCat",
+                versions,
+                f"Update available. Update with:\n\n    {updater.update_hint(kind)}",
                 kind,
                 can_update=False,
             )
             return
         # Windows / macOS with a newer release: Update is enabled.
         self.update_box(
-            "Update available",
-            f"mycat {latest} is available (you have {current}).",
-            "Click Update to download the new build and restart.",
+            "myCat",
+            versions,
+            "Update available — click Update to download and restart.",
             kind,
             can_update=True,
         )

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -578,27 +578,27 @@ class PixelCatWindow(QtWidgets.QWidget):
 
         # Content setup branches by char type; the chrome below is shared.
         if self.char_pack is not None:
-            self._setup_pack_content()
+            self.setup_pack_content()
         else:
-            self._setup_gif_content(png_pixmap, gif_movie, gif_data)
+            self.setup_gif_content(png_pixmap, gif_movie, gif_data)
 
         # Dragging state
         self.dragging = False
         self.drag_start_pos = QtCore.QPoint()
 
         # Set window size to pixmap size (pack: bounding box over all frames).
-        self.resize(self._pack_content_size() if self.char_pack is not None else self.current_pixmap.size())
+        self.resize(self.pack_content_size() if self.char_pack is not None else self.current_pixmap.size())
 
         # Position window - defaults to bottom-right
-        self._load_position()
+        self.load_position()
 
         # Setup context menu
         self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
-        self.customContextMenuRequested.connect(self._show_context_menu)
+        self.customContextMenuRequested.connect(self.show_context_menu)
 
         # Schedule first animation pass (GIF chars only)
         if self.char_pack is None:
-            self._schedule_next_animation()
+            self.schedule_next_animation()
 
         # Save current image to INI on startup
         save_image_to_ini(self.file_name)
@@ -635,7 +635,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         # after 05:00 — another small reason the cat is running at dawn.
         self.morning_digest = digest.MorningDigest(self.focus_controller.store, announcer=self.announcer)
 
-    def _setup_gif_content(self, png_pixmap, gif_movie, gif_data) -> None:
+    def setup_gif_content(self, png_pixmap, gif_movie, gif_data) -> None:
         """Legacy single-GIF char: static first frame + play-once animation."""
         self.png_pixmap = png_pixmap
         self.gif_movie = gif_movie
@@ -656,7 +656,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.gif_movie.setCacheMode(QtGui.QMovie.CacheMode.CacheAll)
         self.gif_movie.setSpeed(100)
         self.animation_timer = QtCore.QTimer(self)
-        self.animation_timer.timeout.connect(self._on_animation_frame)
+        self.animation_timer.timeout.connect(self.on_animation_frame)
         self.current_frame = 0
         gif_size = self.gif_movie.scaledSize()
         logger.info(
@@ -664,14 +664,14 @@ class PixelCatWindow(QtWidgets.QWidget):
             f"{gif_size.width()}x{gif_size.height()} (first_frame, {self.wait_time:.1f}s static)"
         )
 
-    def _all_pack_clips(self):
+    def all_pack_clips(self):
         """Every Anim in the pack (for hardening / preprocessing)."""
         pack = self.char_pack
         clips = list(pack.anims) + list(pack.idle_anims) + list(pack.click_anims) + list(pack.hungry_anims)
         clips += [a for a in (pack.sleep_in, pack.sleep_out, pack.yawn) if a is not None]
         return clips
 
-    def _pack_content_size(self) -> QtCore.QSize:
+    def pack_content_size(self) -> QtCore.QSize:
         """Bounding box over the static and every frame, so the window fits the
         largest pose. Frames are box-fit independently and a body GIF may be taller
         than the still; the window must hold it or it would be clipped. Each frame
@@ -681,12 +681,12 @@ class PixelCatWindow(QtWidgets.QWidget):
         for still in (pack.blink, pack.sleep):
             if still is not None:
                 width, height = max(width, still.width()), max(height, still.height())
-        for anim in self._all_pack_clips():
+        for anim in self.all_pack_clips():
             for frame in anim.frames:
                 width, height = max(width, frame.width()), max(height, frame.height())
         return QtCore.QSize(width, height)
 
-    def _setup_pack_content(self) -> None:
+    def setup_pack_content(self) -> None:
         """Interactive char pack: drives the state machine (awake/blink/click/idle/yawn/sleep/hungry)."""
         pack = self.char_pack
         # No compositor → snap body-frame edges to binary alpha (crisp, no fringe).
@@ -696,7 +696,7 @@ class PixelCatWindow(QtWidgets.QWidget):
             for still in ("blink", "sleep"):
                 if getattr(pack, still) is not None:
                     setattr(pack, still, harden_pixmap(getattr(pack, still)))
-            for anim in self._all_pack_clips():
+            for anim in self.all_pack_clips():
                 anim.frames = [harden_pixmap(frame) for frame in anim.frames]
         self.png_pixmap = pack.static
         self.gif_movie = None
@@ -708,8 +708,8 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.gif_duration, self.frame_delays = 0.0, []
         self.eye_clock = QtCore.QElapsedTimer()
         self.eye_clock.start()
-        self._test_now = None                 # tests inject time here
-        now = self._pack_now()
+        self.test_now = None                 # tests inject time here
+        now = self.pack_now()
 
         # --- state-machine state ---
         self.base_state = "awake"             # "awake" | "sleeping"
@@ -722,14 +722,14 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.next_idle = now + random.uniform(*pack.idle_random_every)
         self.next_hungry = now + random.uniform(*pack.hungry_every)
         self.anim_next = [now + random.uniform(*anim.every) for anim in pack.anims]
-        self._battery_pct = None
-        self._battery_checked = -1e9
-        self._pack_mode = "open"
-        self._last_cursor = QtGui.QCursor.pos()
-        self._mask_cache: dict = {}
+        self.battery_pct = None
+        self.battery_checked = -1e9
+        self.pack_mode = "open"
+        self.last_cursor = QtGui.QCursor.pos()
+        self.mask_cache: dict = {}
 
         self.pack_timer = QtCore.QTimer(self)
-        self.pack_timer.timeout.connect(self._pack_tick)
+        self.pack_timer.timeout.connect(self.pack_tick)
         self.pack_timer.start(33)             # ~30 fps; only repaints when something changed
         logger.info(
             f"Loaded interactive char '{pack.name}' ({pack.static.width()}x{pack.static.height()}; "
@@ -739,29 +739,29 @@ class PixelCatWindow(QtWidgets.QWidget):
             f"hungry={len(pack.hungry_anims)} anims={len(pack.anims)})"
         )
 
-    def _pack_now(self) -> float:
-        if getattr(self, "_test_now", None) is not None:
-            return self._test_now
+    def pack_now(self) -> float:
+        if getattr(self, "test_now", None) is not None:
+            return self.test_now
         return self.eye_clock.elapsed() / 1000.0
 
-    def _pack_tick(self) -> None:
+    def pack_tick(self) -> None:
         """Advance the state machine; repaint only when the frame or gaze changes."""
-        now = self._pack_now()
+        now = self.pack_now()
         cursor = QtGui.QCursor.pos()
-        moved = cursor != self._last_cursor
+        moved = cursor != self.last_cursor
         if moved:
-            self._last_cursor = cursor
+            self.last_cursor = cursor
             self.last_cursor_move = now
             self.yawned = False
         previous = self.current_pixmap
-        self._pack_mode = self._update_pack_frame()
+        self.pack_mode = self.update_pack_frame()
         changed = self.current_pixmap is not previous
-        if moved and self._pack_mode == "open" and self.char_pack.eyes is not None:
+        if moved and self.pack_mode == "open" and self.char_pack.eyes is not None:
             changed = True
         if changed:
             self.update()
 
-    def _clip_frame(self, anim, age_ms: float):
+    def clip_frame(self, anim, age_ms: float):
         accumulated = 0
         for frame, delay in zip(anim.frames, anim.delays):
             accumulated += delay
@@ -769,12 +769,12 @@ class PixelCatWindow(QtWidgets.QWidget):
                 return frame
         return anim.frames[-1]
 
-    def _start_clip(self, anim, next_state: str, now: float) -> None:
+    def start_clip(self, anim, next_state: str, now: float) -> None:
         self.active_clip = (anim, now, next_state)
         if anim.frames:
             self.current_pixmap = anim.frames[0]
 
-    def _wake(self, now: float) -> bool:
+    def wake(self, now: float) -> bool:
         """If asleep (or falling asleep), wake via sleep_out (or instantly). True if woke."""
         going_to_sleep = self.active_clip is not None and self.active_clip[2] == "sleeping"
         if self.base_state != "sleeping" and not going_to_sleep:
@@ -783,40 +783,40 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.last_cursor_move = now
         self.yawned = False
         if self.char_pack.sleep_out is not None:
-            self._start_clip(self.char_pack.sleep_out, "awake", now)
+            self.start_clip(self.char_pack.sleep_out, "awake", now)
         else:
             self.active_clip = None
             self.base_state = "awake"
         return True
 
-    def _battery_low(self) -> bool:
-        now = self._pack_now()
-        if now - self._battery_checked > 10.0:
-            self._battery_checked = now
-            self._battery_pct = read_battery_percent()
-        return self._battery_pct is not None and self._battery_pct <= self.char_pack.hungry_below
+    def battery_low(self) -> bool:
+        now = self.pack_now()
+        if now - self.battery_checked > 10.0:
+            self.battery_checked = now
+            self.battery_pct = read_battery_percent()
+        return self.battery_pct is not None and self.battery_pct <= self.char_pack.hungry_below
 
-    def _on_pack_click(self) -> None:
+    def on_pack_click(self) -> None:
         """Click reaction: wake if asleep, else play a clickN anim or squint."""
         if self.char_pack is None:
             return
-        now = self._pack_now()
+        now = self.pack_now()
         self.last_interaction = now
         self.yawned = False
-        if self._wake(now):
+        if self.wake(now):
             self.update()
             return
         pack = self.char_pack
         if pack.click_anims:
-            self._start_clip(random.choice(pack.click_anims), "awake", now)
+            self.start_clip(random.choice(pack.click_anims), "awake", now)
         elif pack.blink is not None:
             self.squint_until = now + pack.click_squint
         self.update()
 
-    def _update_pack_frame(self) -> str:
+    def update_pack_frame(self) -> str:
         """State machine: hungry > sleep > yawn > reaction > blink > awake. Sets current_pixmap."""
         pack = self.char_pack
-        now = self._pack_now()
+        now = self.pack_now()
 
         # An active one-shot clip (transition or reaction) plays to completion.
         if self.active_clip is not None:
@@ -827,7 +827,7 @@ class PixelCatWindow(QtWidgets.QWidget):
                 if next_state:
                     self.base_state = next_state
             else:
-                self.current_pixmap = self._clip_frame(anim, age_ms)
+                self.current_pixmap = self.clip_frame(anim, age_ms)
                 return "anim"
 
         # Held sleeping pose (wake is driven by interaction, not here).
@@ -839,14 +839,14 @@ class PixelCatWindow(QtWidgets.QWidget):
         cursor_still = now - self.last_cursor_move
 
         # hungry (low battery)
-        if pack.hungry_anims and now >= self.next_hungry and self._battery_low():
-            self._start_clip(random.choice(pack.hungry_anims), "awake", now)
+        if pack.hungry_anims and now >= self.next_hungry and self.battery_low():
+            self.start_clip(random.choice(pack.hungry_anims), "awake", now)
             self.next_hungry = now + random.uniform(*pack.hungry_every)
             return "anim"
         # sleep
         if (pack.sleep is not None or pack.sleep_in is not None) and idle_for > pack.sleep_after:
             if pack.sleep_in is not None:
-                self._start_clip(pack.sleep_in, "sleeping", now)
+                self.start_clip(pack.sleep_in, "sleeping", now)
                 return "anim"
             self.base_state = "sleeping"
             self.current_pixmap = pack.sleep or pack.static
@@ -854,17 +854,17 @@ class PixelCatWindow(QtWidgets.QWidget):
         # yawn (precursor to sleep)
         if pack.yawn is not None and not self.yawned and cursor_still > pack.yawn_after:
             self.yawned = True
-            self._start_clip(pack.yawn, "awake", now)
+            self.start_clip(pack.yawn, "awake", now)
             return "anim"
         # idle-random pool
         if pack.idle_anims and now >= self.next_idle:
-            self._start_clip(random.choice(pack.idle_anims), "awake", now)
+            self.start_clip(random.choice(pack.idle_anims), "awake", now)
             self.next_idle = now + random.uniform(*pack.idle_random_every)
             return "anim"
         # periodic config animations
         for index, anim in enumerate(pack.anims):
             if now >= self.anim_next[index]:
-                self._start_clip(anim, "awake", now)
+                self.start_clip(anim, "awake", now)
                 self.anim_next[index] = now + sum(anim.delays) / 1000.0 + random.uniform(*anim.every)
                 return "anim"
         # blink
@@ -923,7 +923,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         nose_y = max(eyes.left.y(), eyes.right.y()) + eyes.travel_radius * 2
         return self.mapToGlobal(QtCore.QPoint(round(x + nose_x), round(y + nose_y)))
 
-    def _draw_pupils(self, painter, x: int, y: int) -> None:
+    def draw_pupils(self, painter, x: int, y: int) -> None:
         """Draw the L/R pupil sprites at the computed gaze offsets."""
         pack = self.char_pack
         if not pack.eyes or pack.eye_left is None or pack.eye_right is None:
@@ -937,7 +937,7 @@ class PixelCatWindow(QtWidgets.QWidget):
             py = y + center.y() + oy - sprite.height() / 2.0
             painter.drawPixmap(QtCore.QPointF(px, py), sprite)
 
-    def _load_position(self) -> None:
+    def load_position(self) -> None:
         """Load window position from config; default to the bottom-right corner."""
         rect = usable_screen_rect()
         window_width = self.width()
@@ -947,7 +947,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         default_x, default_y = self.bottom_right_position(window_width, window_height)
         x = config.get("x", default_x)
         y = config.get("y", default_y)
-        x, y = self._clamp_to_screens(x, y, window_width, window_height)
+        x, y = self.clamp_to_screens(x, y, window_width, window_height)
         self.move(x, y)
 
     def bottom_right_position(self, width: int, height: int) -> tuple[int, int]:
@@ -957,7 +957,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         y = rect.y() + rect.height() - height - DEFAULT_POSITION_OFFSET_Y
         return x, y
 
-    def _clamp_to_screens(self, x: int, y: int, width: int, height: int) -> tuple[int, int]:
+    def clamp_to_screens(self, x: int, y: int, width: int, height: int) -> tuple[int, int]:
         """Keep the window visible; robust to Qt reporting empty screen geometry."""
         rect = usable_screen_rect()
         if rect.width() <= 0 or rect.height() <= 0:
@@ -981,13 +981,13 @@ class PixelCatWindow(QtWidgets.QWidget):
         )
         return fallback_x, fallback_y
     
-    def _save_position(self) -> None:
+    def save_position(self) -> None:
         """Save current window position to config."""
         pos = self.pos()
         config = {"x": pos.x(), "y": pos.y()}
         save_config(config)
 
-    def _reset_position(self) -> None:
+    def reset_position(self) -> None:
         """Snap the cat to the bottom-right corner, an equal inset from each edge.
 
         Measured from the true screen corner (full geometry, not the
@@ -1000,20 +1000,20 @@ class PixelCatWindow(QtWidgets.QWidget):
         x = rect.x() + rect.width() - self.width() - margin
         y = rect.y() + rect.height() - self.height() - margin
         self.move(x, y)
-        self._save_position()
+        self.save_position()
 
-    def _load_image(self, image_name: str) -> None:
+    def load_image(self, image_name: str) -> None:
         """Switch chars — a new interactive pack or a legacy single-GIF."""
         zip_path = char_catalog.find_char(image_name)
         if zip_path is None:
             logger.error(f"ZIP file not found for char: {image_name}")
             return
         if char_pack.is_new_pack(zip_path):
-            self._switch_to_pack(image_name, zip_path)
+            self.switch_to_pack(image_name, zip_path)
             return
         # Decode the new char into locals first — a failure here must not leave
         # the window half-switched. Only once everything is built do we commit
-        # to self.* and resize the window (mirrors _switch_to_pack).
+        # to self.* and resize the window (mirrors switch_to_pack).
         try:
             with char_pack.CharSource(zip_path) as source:
                 gif_files = sorted(n for n in source.names() if n.lower().endswith(".gif"))
@@ -1062,7 +1062,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         # Decoded cleanly — commit the switch. The Qt calls below don't raise, so
         # the old char stays fully intact if anything above failed.
         if self.char_pack is not None:
-            self._teardown_pack_mode()
+            self.teardown_pack_mode()
         self.png_pixmap = new_pixmap
         self.gif_movie = new_movie
         self.gif_data = gif_data
@@ -1075,7 +1075,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.current_pixmap = self.png_pixmap
         self.state = 'png'
         self.animation_timer.stop()
-        self._schedule_next_animation()
+        self.schedule_next_animation()
 
         # Keep the bottom-right corner fixed across the resize.
         old_size = self.size()
@@ -1087,11 +1087,11 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.move(bottom_right_x - new_size.width(), bottom_right_y - new_size.height())
 
         save_image_to_ini(image_name)
-        self._save_position()
+        self.save_position()
         logger.info("Switched to %s.zip %dx%d", image_name, self.png_pixmap.width(), self.png_pixmap.height())
         self.update()
 
-    def _teardown_pack_mode(self) -> None:
+    def teardown_pack_mode(self) -> None:
         """Leave interactive-pack mode so the legacy GIF path can take over."""
         if getattr(self, "pack_timer", None) is not None:
             self.pack_timer.stop()
@@ -1099,10 +1099,10 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.char_pack = None
         if getattr(self, "animation_timer", None) is None:
             self.animation_timer = QtCore.QTimer(self)
-            self.animation_timer.timeout.connect(self._on_animation_frame)
+            self.animation_timer.timeout.connect(self.on_animation_frame)
         self.current_frame = 0
 
-    def _switch_to_pack(self, image_name: str, zip_path) -> None:
+    def switch_to_pack(self, image_name: str, zip_path) -> None:
         """Switch to a new interactive char pack, preserving the bottom-right corner."""
         try:
             pack = char_pack.load_pack(zip_path)
@@ -1120,17 +1120,17 @@ class PixelCatWindow(QtWidgets.QWidget):
 
         self.char_pack = pack
         self.file_name = image_name
-        self._setup_pack_content()
+        self.setup_pack_content()
 
-        new_size = self._pack_content_size()
+        new_size = self.pack_content_size()
         self.resize(new_size)
         self.move(bottom_right_x - new_size.width(), bottom_right_y - new_size.height())
         save_image_to_ini(image_name)
-        self._save_position()
+        self.save_position()
         self.update()
         logger.info(f"Switched to interactive char {image_name}")
 
-    def _show_context_menu(self, pos: QtCore.QPoint) -> None:
+    def show_context_menu(self, pos: QtCore.QPoint) -> None:
         """Show context menu at the given position."""
         menu = QtWidgets.QMenu(self)
 
@@ -1154,7 +1154,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         calendar_action.triggered.connect(self.open_calendar_settings)
 
         reminder_action = menu.addAction("Reminder…")
-        reminder_action.triggered.connect(self._open_reminder)
+        reminder_action.triggered.connect(self.open_reminder)
 
         github_action = menu.addAction("GitHub…")
         github_action.triggered.connect(self.open_github_settings)
@@ -1165,7 +1165,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         # Shop temporarily hidden from the menu (work in progress). The dialog
         # and its handler stay in the codebase; re-enable by uncommenting:
         # shop_action = menu.addAction("Open Shop…")
-        # shop_action.triggered.connect(self._open_shop)
+        # shop_action.triggered.connect(self.open_shop)
 
         # Focus is fully automatic now (earned from activity) — no menu action.
         menu.addSeparator()
@@ -1190,11 +1190,11 @@ class PixelCatWindow(QtWidgets.QWidget):
                 if img_name == self.file_name:
                     action.setCheckable(True)
                     action.setChecked(True)
-                action.triggered.connect(lambda checked, name=img_name: self._load_image(name))
+                action.triggered.connect(lambda checked, name=img_name: self.load_image(name))
             menu.addSeparator()
 
         reset_action = menu.addAction("Reset")
-        reset_action.triggered.connect(self._reset_position)
+        reset_action.triggered.connect(self.reset_position)
 
         update_action = menu.addAction("Update…")
         update_action.triggered.connect(self.open_update)
@@ -1227,7 +1227,7 @@ class PixelCatWindow(QtWidgets.QWidget):
 
                 AICharDialog = importlib.import_module("mycat.ai_char_ui").AICharDialog
             dialog = AICharDialog(self)
-            dialog.character_created.connect(self._load_image)
+            dialog.character_created.connect(self.load_image)
             dialog.exec()
         except Exception as exc:  # noqa: BLE001 - keep the desktop companion alive
             logger.exception("Failed to open AI character generator")
@@ -1250,7 +1250,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         if was_active:
             fallback = "cat" if char_catalog.find_char("cat") else next(iter(self.available_images), "")
             if fallback:
-                self._load_image(fallback)
+                self.load_image(fallback)
 
     def open_llm_settings(self) -> None:
         """Open the LLM vendor settings dialog (vendor, model, test, save)."""
@@ -1323,9 +1323,9 @@ class PixelCatWindow(QtWidgets.QWidget):
         dialog.show()
         dialog.raise_()
 
-    def _open_shop(self) -> None:
+    def open_shop(self) -> None:
         """Lazily import and show the shop dialog."""
-        existing = getattr(self, "_shop_dialog", None)
+        existing = getattr(self, "shop_dialog", None)
         if existing is not None:
             try:
                 existing.show()
@@ -1333,7 +1333,7 @@ class PixelCatWindow(QtWidgets.QWidget):
                 existing.activateWindow()
                 return
             except RuntimeError:
-                self._shop_dialog = None  # Qt object was deleted
+                self.shop_dialog = None  # Qt object was deleted
 
         try:
             if __package__:
@@ -1347,15 +1347,15 @@ class PixelCatWindow(QtWidgets.QWidget):
 
         dialog = ShopDialog(self, config_path=CFG_FILE)
         dialog.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose, True)
-        dialog.destroyed.connect(lambda _=None: setattr(self, "_shop_dialog", None))
-        dialog.char_installed.connect(self._on_char_installed)
-        dialog.char_uninstalled.connect(self._on_char_uninstalled)
-        self._shop_dialog = dialog
+        dialog.destroyed.connect(lambda _=None: setattr(self, "shop_dialog", None))
+        dialog.char_installed.connect(self.on_char_installed)
+        dialog.char_uninstalled.connect(self.on_char_uninstalled)
+        self.shop_dialog = dialog
         dialog.show()
         dialog.raise_()
         dialog.activateWindow()
 
-    def _open_reminder(self) -> None:
+    def open_reminder(self) -> None:
         """Open the reminder settings dialog."""
         controller = getattr(self, "reminder_controller", None)
         if controller is not None:
@@ -1501,20 +1501,20 @@ class PixelCatWindow(QtWidgets.QWidget):
         logger.warning("Update failed: %s", message)
         QtWidgets.QMessageBox.warning(self, "Update failed", f"Couldn't update: {message}")
 
-    def _on_char_installed(self, _char_id: str) -> None:
+    def on_char_installed(self, _char_id: str) -> None:
         self.available_images = char_catalog.scan_all()
 
-    def _on_char_uninstalled(self, char_id: str) -> None:
+    def on_char_uninstalled(self, char_id: str) -> None:
         self.available_images = char_catalog.scan_all()
         if self.file_name == char_id and self.available_images:
-            self._load_image(self.available_images[0])
+            self.load_image(self.available_images[0])
     
-    def _schedule_next_animation(self) -> None:
+    def schedule_next_animation(self) -> None:
         """Schedule the next PNG -> GIF transition with a single-shot timer."""
         delay_ms = max(0, int(self.wait_time * 1000))
-        QtCore.QTimer.singleShot(delay_ms, self._start_animation)
+        QtCore.QTimer.singleShot(delay_ms, self.start_animation)
 
-    def _start_animation(self) -> None:
+    def start_animation(self) -> None:
         """Switch from static PNG to one-shot GIF playback."""
         if self.state != 'png':
             return
@@ -1546,7 +1546,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         else:
             self.animation_timer.start(100)
 
-    def _on_animation_frame(self) -> None:
+    def on_animation_frame(self) -> None:
         """Manually advance to next frame at controlled speed."""
         frame_count = self.gif_movie.frameCount()
 
@@ -1554,7 +1554,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         if self.current_frame >= frame_count:
             self.animation_timer.stop()
             logger.debug(f"Animation complete for {self.file_name} ({frame_count} frames)")
-            QtCore.QTimer.singleShot(50, self._complete_switch_to_png)
+            QtCore.QTimer.singleShot(50, self.complete_switch_to_png)
             return
 
         # Jump to current frame and display it
@@ -1573,7 +1573,7 @@ class PixelCatWindow(QtWidgets.QWidget):
             self.animation_timer.stop()
             self.animation_timer.start(delay)
 
-    def _complete_switch_to_png(self) -> None:
+    def complete_switch_to_png(self) -> None:
         """Complete the switch from GIF to PNG state."""
         if self.state == 'gif':
             # Switch to PNG state
@@ -1590,11 +1590,11 @@ class PixelCatWindow(QtWidgets.QWidget):
                 f"{self.png_pixmap.width()}x{self.png_pixmap.height()} (first_frame, {self.wait_time:.1f}s static)"
             )
             self.update()
-            self._schedule_next_animation()
+            self.schedule_next_animation()
 
     def paintEvent(self, event: QtGui.QPaintEvent) -> None:
         """Paint the current pixmap (+ tracking pupils for interactive chars)."""
-        mode = getattr(self, "_pack_mode", None) if self.char_pack is not None else None
+        mode = getattr(self, "pack_mode", None) if self.char_pack is not None else None
 
         # Centre the pixmap in the widget.
         widget_rect = self.rect()
@@ -1614,7 +1614,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
         painter.drawPixmap(x, y, self.current_pixmap)
         if mode == "open":
-            self._draw_pupils(painter, x, y)
+            self.draw_pupils(painter, x, y)
         painter.end()
 
     def refresh_shape_mask(self, x: int, y: int) -> None:
@@ -1631,7 +1631,7 @@ class PixelCatWindow(QtWidgets.QWidget):
 
         # Reuse the silhouette region per frame — building QRegion from a big
         # bitmap each paint is what made multi-frame chars lag.
-        cache = getattr(self, "_mask_cache", None)
+        cache = getattr(self, "mask_cache", None)
         region = cache.get(pixmap.cacheKey()) if cache is not None else None
         if region is None:
             bitmap = pixmap.mask()
@@ -1663,16 +1663,16 @@ class PixelCatWindow(QtWidgets.QWidget):
     def mousePressEvent(self, event: QtGui.QMouseEvent) -> None:
         """Handle mouse press for dragging (+ click reaction / wake on interactive chars)."""
         if event.button() == QtCore.Qt.MouseButton.LeftButton:
-            self._on_pack_click()
+            self.on_pack_click()
             self.dragging = True
             self.drag_start_pos = event.globalPosition().toPoint() - self.frameGeometry().topLeft()
 
     def mouseMoveEvent(self, event: QtGui.QMouseEvent) -> None:
         """Handle mouse move for dragging (+ counts as interaction: resets idle, wakes)."""
         if self.char_pack is not None:
-            now = self._pack_now()
+            now = self.pack_now()
             self.last_interaction = now
-            self._wake(now)
+            self.wake(now)
         if self.dragging and event.buttons() == QtCore.Qt.MouseButton.LeftButton:
             new_pos = event.globalPosition().toPoint() - self.drag_start_pos
             self.move(new_pos)
@@ -1681,7 +1681,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         """Handle mouse release to stop dragging and save position."""
         if event.button() == QtCore.Qt.MouseButton.LeftButton and self.dragging:
             self.dragging = False
-            self._save_position()
+            self.save_position()
 
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
@@ -2097,13 +2097,13 @@ def setup_tray(app, window):
     # Same order as the context menu: LLM, Calendar, Reminder, GitHub, Activity.
     menu.addAction("LLM…", window.open_llm_settings)
     menu.addAction("Calendar…", window.open_calendar_settings)
-    menu.addAction("Reminder…", window._open_reminder)
+    menu.addAction("Reminder…", window.open_reminder)
     menu.addAction("GitHub…", window.open_github_settings)
     menu.addAction("Activity…", window.open_activity_dialog)
 
     # Focus is fully automatic now (earned from activity) — no tray toggle.
 
-    menu.addAction("Reset", window._reset_position)
+    menu.addAction("Reset", window.reset_position)
     menu.addAction("Update…", window.open_update)
     if autostart.is_supported():
         menu.addSeparator()

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -1136,11 +1136,11 @@ class PixelCatWindow(QtWidgets.QWidget):
 
         # "Chat" appears only once Ollama is configured (a controller exists),
         # and is greyed out while the LLM is disabled.
-        toggle_chat = getattr(self, "_toggle_llm_chat", None)
+        toggle_chat = getattr(self, "toggle_llm_chat", None)
         if callable(toggle_chat):
             chat_action = menu.addAction("Chat")
             chat_action.triggered.connect(toggle_chat)
-            llm_is_enabled = getattr(self, "_is_llm_enabled", None)
+            llm_is_enabled = getattr(self, "is_llm_enabled", None)
             if callable(llm_is_enabled):
                 chat_action.setEnabled(bool(llm_is_enabled()))
             menu.addSeparator()
@@ -2091,7 +2091,7 @@ def setup_tray(app, window):
             show_window()
 
     menu = QtWidgets.QMenu(window)
-    toggle_chat = getattr(window, "_toggle_llm_chat", None)
+    toggle_chat = getattr(window, "toggle_llm_chat", None)
     if callable(toggle_chat):
         menu.addAction("Chat", toggle_chat)
     # Same order as the context menu: LLM, Calendar, Reminder, GitHub, Activity.

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -1009,100 +1009,85 @@ class PixelCatWindow(QtWidgets.QWidget):
         if char_pack.is_new_pack(zip_path):
             self._switch_to_pack(image_name, zip_path)
             return
-        if self.char_pack is not None:
-            self._teardown_pack_mode()
+        # Decode the new char into locals first — a failure here must not leave
+        # the window half-switched. Only once everything is built do we commit
+        # to self.* and resize the window (mirrors _switch_to_pack).
         try:
-            # Read the first GIF from the char (folder or zip, in memory).
             with char_pack.CharSource(zip_path) as source:
                 gif_files = sorted(n for n in source.names() if n.lower().endswith(".gif"))
                 if not gif_files:
-                    logger.error(f"No GIF found in char: {image_name}")
+                    logger.error("No GIF found in char: %s", image_name)
                     return
                 gif_data = source.read(gif_files[0])
-                logger.info(f"Extracted {gif_files[0]} from {Path(zip_path).name}")
-            
-            # Build the new movie from the GIF bytes in memory (no temp files).
+                logger.info("Extracted %s from %s", gif_files[0], Path(zip_path).name)
+
             new_movie = movie_from_gif_bytes(gif_data)
             new_movie.jumpToFrame(0)
             first_frame = new_movie.currentPixmap()
             if first_frame.isNull():
-                logger.error(f"Failed to extract first frame from {image_name}.zip")
+                logger.error("Failed to extract first frame from %s.zip", image_name)
                 return
 
-            # Scale if needed
-            original_size = first_frame.size()
+            source_size = first_frame.size()
             new_pixmap = scale_pixmap_if_needed(first_frame, IMAGE_WIDTH_MAX, IMAGE_HEIGHT_MAX)
-            if original_size != new_pixmap.size():
-                logger.info(
-                    f"Resized {image_name}.zip: "
-                    f"{original_size.width()}x{original_size.height()} -> "
-                    f"{new_pixmap.width()}x{new_pixmap.height()}"
-                )
             if new_pixmap.isNull():
-                logger.error(f"Failed to render first frame from {image_name}.zip")
+                logger.error("Failed to render first frame from %s.zip", image_name)
                 return
+            if source_size != new_pixmap.size():
+                logger.info(
+                    "Resized %s.zip: %dx%d -> %dx%d",
+                    image_name,
+                    source_size.width(), source_size.height(),
+                    new_pixmap.width(), new_pixmap.height(),
+                )
 
-            # Configure movie
             new_movie.setScaledSize(new_pixmap.size())
             new_movie.setSpeed(100)
             new_movie.jumpToFrame(0)
+            movie_frame_size = new_movie.currentPixmap().size()
+            gif_duration, frame_delays = get_gif_duration(new_movie, gif_data)
+        except Exception:  # noqa: BLE001 -- a bad char must never corrupt the current one
+            logger.exception("Error loading %s", image_name)
+            return
 
-            # Update current images
-            self.png_pixmap = new_pixmap
-            self.gif_movie = new_movie
-            self.gif_data = gif_data
-            self.file_name = image_name
+        if not frame_delays:
+            frame_count = new_movie.frameCount()
+            if frame_count > 0 and gif_duration > 0:
+                frame_delays = [int((gif_duration / frame_count) * 1000)] * frame_count
+            else:
+                frame_delays = [100]  # default 100ms per frame
 
-            # Update original size
-            new_movie.jumpToFrame(0)
-            self.original_size = new_movie.currentPixmap().size()
+        # Decoded cleanly — commit the switch. The Qt calls below don't raise, so
+        # the old char stays fully intact if anything above failed.
+        if self.char_pack is not None:
+            self._teardown_pack_mode()
+        self.png_pixmap = new_pixmap
+        self.gif_movie = new_movie
+        self.gif_data = gif_data
+        self.file_name = image_name
+        self.original_size = movie_frame_size
+        self.gif_duration = gif_duration
+        self.frame_delays = frame_delays
+        self.first_frame_pixmap = new_pixmap.copy()
 
-            # Calculate GIF duration and frame delays for new movie
-            self.gif_duration, self.frame_delays = get_gif_duration(new_movie, gif_data)
-            
-            # Fallback if no delays
-            if not self.frame_delays:
-                frame_count = new_movie.frameCount()
-                if frame_count > 0 and self.gif_duration > 0:
-                    self.frame_delays = [int((self.gif_duration / frame_count) * 1000)] * frame_count
-                else:
-                    self.frame_delays = [100]  # Default 100ms per frame
-            
-            # Save first frame (use the already scaled new_pixmap)
-            self.first_frame_pixmap = new_pixmap.copy()
-            
-            # Reset to PNG state
-            self.current_pixmap = self.png_pixmap
-            self.state = 'png'
-            self.animation_timer.stop()
-            self._schedule_next_animation()
+        self.current_pixmap = self.png_pixmap
+        self.state = 'png'
+        self.animation_timer.stop()
+        self._schedule_next_animation()
 
-            # Save bottom-right corner position before resize
-            old_size = self.size()
-            top_left = self.pos()
-            bottom_right_x = top_left.x() + old_size.width()
-            bottom_right_y = top_left.y() + old_size.height()
+        # Keep the bottom-right corner fixed across the resize.
+        old_size = self.size()
+        top_left = self.pos()
+        bottom_right_x = top_left.x() + old_size.width()
+        bottom_right_y = top_left.y() + old_size.height()
+        self.resize(self.png_pixmap.size())
+        new_size = self.png_pixmap.size()
+        self.move(bottom_right_x - new_size.width(), bottom_right_y - new_size.height())
 
-            # Resize window
-            self.resize(self.png_pixmap.size())
-
-            # Restore position to keep bottom-right corner in same place
-            new_size = self.png_pixmap.size()
-            new_x = bottom_right_x - new_size.width()
-            new_y = bottom_right_y - new_size.height()
-            self.move(new_x, new_y)
-
-            # Save to INI
-            save_image_to_ini(image_name)
-            
-            # Save new position
-            self._save_position()
-            
-            logger.info(f"Switched to {image_name}.zip {self.png_pixmap.width()}x{self.png_pixmap.height()}")
-            self.update()
-            
-        except Exception as e:
-            logger.error(f"Error loading {image_name}: {e}")
+        save_image_to_ini(image_name)
+        self._save_position()
+        logger.info("Switched to %s.zip %dx%d", image_name, self.png_pixmap.width(), self.png_pixmap.height())
+        self.update()
 
     def _teardown_pack_mode(self) -> None:
         """Leave interactive-pack mode so the legacy GIF path can take over."""

--- a/mycat/paths.py
+++ b/mycat/paths.py
@@ -1,0 +1,24 @@
+"""Single source of truth for mycat's config location.
+
+The config file has always lived in ``~/.config/mycat`` on every platform
+(``Path.home()`` resolves per-OS), and it stays there so existing installs keep
+their settings — no migration, no lost config on Windows/macOS. Data
+(``activity.db``) and chars use the per-OS conventional dirs instead; see
+``activity_store.user_data_dir`` / ``char_catalog.user_chars_dir``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+APP_NAME = "mycat"
+
+
+def config_dir() -> Path:
+    """Directory holding ``config.ini`` (and the LLM history) — ``~/.config/mycat``."""
+    return Path.home() / ".config" / APP_NAME
+
+
+def config_file() -> Path:
+    """Path to the shared ``config.ini``."""
+    return config_dir() / "config.ini"

--- a/mycat/reminder.py
+++ b/mycat/reminder.py
@@ -17,18 +17,17 @@ import configparser
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from pathlib import Path
 
 from PySide6 import QtCore
 
-from . import secret_store
+from . import paths, secret_store
 
 logger = logging.getLogger(__name__)
 
-# Same config file the rest of the app uses (see main.py). Derived locally to
-# avoid importing main and creating an import cycle.
-CFG_DIR = Path.home() / ".config" / "mycat"
-CFG_FILE = CFG_DIR / "config.ini"
+# The shared config file — paths.py is the single source (importing main here
+# would create an import cycle).
+CFG_DIR = paths.config_dir()
+CFG_FILE = paths.config_file()
 
 DIRECTION_LTR = "ltr"  # plane flies left -> right, banner trailing on the left
 DIRECTION_RTL = "rtl"  # plane flies right -> left, banner trailing on the right

--- a/mycat/reminder.py
+++ b/mycat/reminder.py
@@ -13,14 +13,13 @@ Only ``QtCore`` is imported here; the visual flyby and the settings dialog live
 in ``reminder_ui`` and are imported lazily so a headless run never needs widgets.
 """
 
-import configparser
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from PySide6 import QtCore
 
-from . import paths, secret_store
+from . import config_store, paths
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +65,7 @@ class Reminder:
         return DIRECTION_RTL if self.direction == DIRECTION_RTL else DIRECTION_LTR
 
 
-def _parse_dt(value: str) -> datetime | None:
+def parse_dt(value: str) -> datetime | None:
     try:
         return datetime.fromisoformat(value)
     except (ValueError, TypeError):
@@ -75,18 +74,15 @@ def _parse_dt(value: str) -> datetime | None:
 
 def load_reminder() -> Reminder | None:
     """Read the ``[reminder]`` section, or ``None`` if absent/unreadable."""
-    if not CFG_FILE.exists():
+    config = config_store.read_config(CFG_FILE)
+    if config is None or "reminder" not in config:
         return None
     try:
-        config = configparser.ConfigParser()
-        config.read(CFG_FILE)
-        if "reminder" not in config:
-            return None
         section = config["reminder"]
         return Reminder(
             text=section.get("text", DEFAULT_TEXT),
             direction=section.get("direction", DIRECTION_LTR),
-            fire_at=_parse_dt(section.get("fire_at", "")),
+            fire_at=parse_dt(section.get("fire_at", "")),
             repeat_daily=section.getboolean("repeat_daily", fallback=False),
             enabled=section.getboolean("enabled", fallback=True),
             speed=section.getfloat("speed", fallback=DEFAULT_SPEED),
@@ -96,52 +92,35 @@ def load_reminder() -> Reminder | None:
             mode=section.get("mode", "in"),
             in_minutes=section.getint("in_minutes", fallback=10),
         )
-    except Exception as exc:  # noqa: BLE001 - never let a bad config crash the app
+    except (ValueError, TypeError) as exc:  # a malformed value -> None
         logger.error("Failed to load reminder from config: %s", exc)
         return None
 
 
 def save_reminder(reminder: Reminder) -> None:
     """Persist ``reminder`` into ``[reminder]`` without touching other sections."""
-    try:
-        CFG_DIR.mkdir(parents=True, exist_ok=True)
-        config = configparser.ConfigParser()
-        if CFG_FILE.exists():
-            config.read(CFG_FILE)
-        if "reminder" not in config:
-            config.add_section("reminder")
-        section = config["reminder"]
-        section["text"] = reminder.text
-        section["direction"] = reminder.normalized_direction()
-        section["fire_at"] = reminder.fire_at.isoformat() if reminder.fire_at else ""
-        section["repeat_daily"] = "true" if reminder.repeat_daily else "false"
-        section["enabled"] = "true" if reminder.enabled else "false"
-        section["speed"] = str(reminder.speed)
-        section["plane_color"] = reminder.plane_color
-        section["plane_width"] = str(reminder.plane_width)
-        section["plane"] = reminder.plane
-        section["mode"] = reminder.mode
-        section["in_minutes"] = str(reminder.in_minutes)
-        with open(CFG_FILE, "w") as fh:
-            config.write(fh)
-        secret_store.secure_file(CFG_FILE)
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Failed to save reminder to config: %s", exc)
+    config_store.write_section(
+        "reminder",
+        {
+            "text": reminder.text,
+            "direction": reminder.normalized_direction(),
+            "fire_at": reminder.fire_at.isoformat() if reminder.fire_at else "",
+            "repeat_daily": config_store.bool_str(reminder.repeat_daily),
+            "enabled": config_store.bool_str(reminder.enabled),
+            "speed": reminder.speed,
+            "plane_color": reminder.plane_color,
+            "plane_width": reminder.plane_width,
+            "plane": reminder.plane,
+            "mode": reminder.mode,
+            "in_minutes": reminder.in_minutes,
+        },
+        CFG_FILE,
+    )
 
 
 def clear_reminder() -> None:
     """Disable the reminder (drop the whole ``[reminder]`` section)."""
-    try:
-        if not CFG_FILE.exists():
-            return
-        config = configparser.ConfigParser()
-        config.read(CFG_FILE)
-        if config.remove_section("reminder"):
-            with open(CFG_FILE, "w") as fh:
-                config.write(fh)
-            secret_store.secure_file(CFG_FILE)
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Failed to clear reminder in config: %s", exc)
+    config_store.remove_section("reminder", CFG_FILE)
 
 
 def next_future_occurrence(fire_at: datetime, now: datetime | None = None) -> datetime:
@@ -163,32 +142,28 @@ class ReminderController(QtCore.QObject):
 
     def __init__(self, window: QtCore.QObject) -> None:
         super().__init__(window)
-        self._window = window
-        self._reminder = load_reminder()
-        self._flyby = None  # keep a ref so the window isn't garbage-collected mid-flight
+        self.window = window
+        self.reminder = load_reminder()
+        self.flyby = None  # keep a ref so the window isn't garbage-collected mid-flight
         self.settings_dialog = None  # non-modal dialog ref (kept alive while open)
 
-        self._normalize_on_start()
+        self.normalize_on_start()
 
-        self._timer = QtCore.QTimer(self)
-        self._timer.setInterval(1000)
-        self._timer.timeout.connect(self._tick)
-        self._timer.start()
+        self.timer = QtCore.QTimer(self)
+        self.timer.setInterval(1000)
+        self.timer.timeout.connect(self.tick)
+        self.timer.start()
 
     # -- public API ---------------------------------------------------------
 
-    @property
-    def reminder(self) -> Reminder | None:
-        return self._reminder
-
     def set_reminder(self, reminder: Reminder) -> None:
-        self._reminder = reminder
+        self.reminder = reminder
         save_reminder(reminder)
         when = reminder.fire_at.isoformat() if reminder.fire_at else "—"
         logger.info("Reminder set: %r at %s (%s)", reminder.text, when, reminder.normalized_direction())
 
     def clear(self) -> None:
-        self._reminder = None
+        self.reminder = None
         clear_reminder()
         logger.info("Reminder cleared")
 
@@ -219,7 +194,7 @@ class ReminderController(QtCore.QObject):
             logger.exception("Failed to import reminder UI")
             return
 
-        dialog = ReminderDialog(self, self._reminder, parent=self._window)
+        dialog = ReminderDialog(self, self.reminder, parent=self.window)
         dialog.setModal(False)
         dialog.finished.connect(lambda result: setattr(self, "settings_dialog", None))
         self.settings_dialog = dialog
@@ -248,17 +223,17 @@ class ReminderController(QtCore.QObject):
             logger.exception("Failed to import flyby window")
             return
 
-        cat_pixmap = getattr(self._window, "first_frame_pixmap", None)
+        cat_pixmap = getattr(self.window, "first_frame_pixmap", None)
         flyby = FlybyWindow(cat_pixmap, reminder)
-        flyby.destroyed.connect(lambda _=None: setattr(self, "_flyby", None))
-        self._flyby = flyby
+        flyby.destroyed.connect(lambda _=None: setattr(self, "flyby", None))
+        self.flyby = flyby
         flyby.start()
 
     # -- internal -----------------------------------------------------------
 
-    def _normalize_on_start(self) -> None:
+    def normalize_on_start(self) -> None:
         """Avoid surprise flybys at launch for reminders whose time already passed."""
-        r = self._reminder
+        r = self.reminder
         if not r or not r.enabled or r.fire_at is None:
             return
         if r.fire_at > datetime.now():
@@ -271,15 +246,15 @@ class ReminderController(QtCore.QObject):
             r.enabled = False
             save_reminder(r)
 
-    def _tick(self) -> None:
-        r = self._reminder
+    def tick(self) -> None:
+        r = self.reminder
         if not r or not r.enabled or r.fire_at is None:
             return
         if datetime.now() >= r.fire_at:
-            self._fire()
+            self.fire()
 
-    def _fire(self) -> None:
-        r = self._reminder
+    def fire(self) -> None:
+        r = self.reminder
         if r is None:
             return
         logger.info("Firing reminder: %r", r.text)

--- a/mycat/reminder_ui.py
+++ b/mycat/reminder_ui.py
@@ -79,7 +79,7 @@ PLANE_COLORS = {
 }
 
 
-def _resolve_plane_color(name: str) -> QtGui.QColor:
+def resolve_plane_color(name: str) -> QtGui.QColor:
     """Map a colour name (or hex) to a QColor; fall back to white if unknown."""
     if name in PLANE_COLORS:
         return PLANE_COLORS[name]
@@ -89,7 +89,7 @@ def _resolve_plane_color(name: str) -> QtGui.QColor:
     return PLANE_COLORS["white"]
 
 
-def _tinted_pixmap(base: QtGui.QPixmap, tint: QtGui.QColor) -> QtGui.QPixmap:
+def tinted_pixmap(base: QtGui.QPixmap, tint: QtGui.QColor) -> QtGui.QPixmap:
     """Multiply-blend ``base`` by ``tint``, then restore the alpha mask.
 
     Qt's ``CompositionMode_Multiply`` is Porter-Duff "src over with multiply";
@@ -114,7 +114,7 @@ def _tinted_pixmap(base: QtGui.QPixmap, tint: QtGui.QColor) -> QtGui.QPixmap:
 # The bundled PNG is already chroma-keyed (transparent background) and cropped
 # to the alpha bbox — no Pillow processing happens at runtime. CANOPY_FRACS
 # (cx, cy, rx, ry as fractions of the cropped sprite, in its right-facing
-# orientation) tells _draw_cat_face where to plant the cat head inside the
+# orientation) tells draw_cat_face where to plant the cat head inside the
 # fuselage. Multiply-blend recolouring (pink / white / blue / red) is applied
 # on top of the bundled sprite — that's the only thing the user can customize.
 ASSETS_DIR = Path(__file__).resolve().parent / "assets"
@@ -190,10 +190,10 @@ class FlybyWindow(QtWidgets.QWidget):
 
         # Drag state — clicking the plane pauses the flight and lets the user
         # park it; right-click brings up a resume/close menu.
-        self._dragging = False
-        self._drag_anchor = QtCore.QPointF()
-        self._drag_start_offset = QtCore.QPointF()
-        self._user_offset = QtCore.QPointF(0.0, 0.0)
+        self.dragging = False
+        self.drag_anchor = QtCore.QPointF()
+        self.drag_start_offset = QtCore.QPointF()
+        self.user_offset = QtCore.QPointF(0.0, 0.0)
 
         # Without an X11 compositor a translucent window renders its transparent
         # pixels black, so a bounding-box mask would put the plane in a black box.
@@ -218,16 +218,16 @@ class FlybyWindow(QtWidgets.QWidget):
         if self.link_url:
             self.setToolTip("Double-click to open • Drag to move • Right-click for options")
 
-        self._text = (reminder.text or reminder_mod.DEFAULT_TEXT).strip() or reminder_mod.DEFAULT_TEXT
-        self._ltr = reminder.normalized_direction() != DIRECTION_RTL
-        self._progress = 0.0
+        self.text = (reminder.text or reminder_mod.DEFAULT_TEXT).strip() or reminder_mod.DEFAULT_TEXT
+        self.ltr = reminder.normalized_direction() != DIRECTION_RTL
+        self.progress = 0.0
         # Set on start(); paintEvent reads monotonic time so the flag ripple and
         # propeller spin advance smoothly regardless of the position easing curve.
-        self._start_time = None
+        self.start_time = None
 
         # Plane colour — applied to the sprite via multiply-blend. Same shape,
         # four liveries, all chosen client-side.
-        self._plane_color = _resolve_plane_color(getattr(reminder, "plane_color", "white"))
+        self.plane_color = resolve_plane_color(getattr(reminder, "plane_color", "white"))
 
         # Chosen plane sprite (assets/planes/<name>.png, falling back to the
         # bundled plane.png). Tint baked in here so per-frame drawing is just a
@@ -238,27 +238,27 @@ class FlybyWindow(QtWidgets.QWidget):
         sprite = QtGui.QPixmap(str(sprite_path))
         if sprite.isNull():
             logger.warning("Plane sprite missing at %s — flyby will be flag-only", sprite_path)
-            self._plane_sprite = None
+            self.plane_sprite = None
         else:
-            self._plane_sprite = _tinted_pixmap(sprite, self._plane_color)
-        self._canopy_fracs = CANOPY_FRACS
+            self.plane_sprite = tinted_pixmap(sprite, self.plane_color)
+        self.canopy_fracs = CANOPY_FRACS
 
         # Plane size — width is user-configurable, height follows the sprite's
         # cropped aspect ratio so the plane never gets squashed. Without a
         # sprite, fall back to a sensible default ratio so the geometry math
         # still works.
-        self._plane_width = max(80, int(getattr(reminder, "plane_width", DEFAULT_PLANE_WIDTH)))
-        if self._plane_sprite is not None and self._plane_sprite.width() > 0:
-            aspect = self._plane_sprite.height() / self._plane_sprite.width()
+        self.plane_width = max(80, int(getattr(reminder, "plane_width", DEFAULT_PLANE_WIDTH)))
+        if self.plane_sprite is not None and self.plane_sprite.width() > 0:
+            aspect = self.plane_sprite.height() / self.plane_sprite.width()
         else:
             aspect = 0.55
-        self._plane_height = max(40, int(self._plane_width * aspect))
+        self.plane_height = max(40, int(self.plane_width * aspect))
 
         # Flag height tied to the plane height so they stay proportional
         # regardless of the user's chosen plane width.
-        self._flag_h = max(36, int(self._plane_height * 0.58))
+        self.flag_h = max(36, int(self.plane_height * 0.58))
         # Band tall enough for the plane + bob + flag with some breathing room.
-        self._band_h = max(self._plane_height, self._flag_h) + 40
+        self.band_h = max(self.plane_height, self.flag_h) + 40
 
         # Cat crop + scale picked so the visible cat is HEAD + SHOULDERS +
         # UPPER BODY (top 75% of the source) without getting wider than before.
@@ -266,8 +266,8 @@ class FlybyWindow(QtWidgets.QWidget):
         # still lands at the same width (~48 px at ph=82) but yields a 36%
         # taller sprite — chest/neck now fills the cockpit area under the face
         # instead of leaving empty fuselage there.
-        target_h = int(self._plane_height * 0.46)
-        self._cat_face_pixmap = crop_cat_head(cat_pixmap, target_h)
+        target_h = int(self.plane_height * 0.46)
+        self.cat_face_pixmap = crop_cat_head(cat_pixmap, target_h)
         # The closed-eyes frame (same crop/scale) — the cat blinks mid-flight when
         # the char provides one; otherwise the awake face is shown throughout.
         self.cat_blink_pixmap = crop_cat_head(blink_pixmap, target_h)
@@ -277,62 +277,62 @@ class FlybyWindow(QtWidgets.QWidget):
         # ``band_top`` (~10% from the top). The setMask() call in paintEvent
         # keeps the rest of the screen click-through.
         screen = QtWidgets.QApplication.primaryScreen().geometry()
-        self._screen_w = screen.width()
-        self._band_top = int(screen.height() * 0.10)
-        self.setGeometry(screen.x(), screen.y(), self._screen_w, screen.height())
+        self.screen_w = screen.width()
+        self.band_top = int(screen.height() * 0.10)
+        self.setGeometry(screen.x(), screen.y(), self.screen_w, screen.height())
 
-        self._banner_w = self._compute_flag_length()
+        self.banner_w = self.compute_flag_length()
 
         speed = max(0.25, float(getattr(reminder, "speed", 1.0)))
-        self._anim = QtCore.QVariantAnimation(self)
-        self._anim.setStartValue(0.0)
-        self._anim.setEndValue(1.0)
-        self._anim.setDuration(int(BASE_DURATION_MS / speed))
-        self._anim.setEasingCurve(QtCore.QEasingCurve.Type.InOutSine)
-        self._anim.valueChanged.connect(self._on_value)
+        self.anim = QtCore.QVariantAnimation(self)
+        self.anim.setStartValue(0.0)
+        self.anim.setEndValue(1.0)
+        self.anim.setDuration(int(BASE_DURATION_MS / speed))
+        self.anim.setEasingCurve(QtCore.QEasingCurve.Type.InOutSine)
+        self.anim.valueChanged.connect(self.on_value)
         # On finish we DON'T just close — if the user dragged the plane back,
         # it could still be on screen at progress=1.0 (the main animation
         # tracks a fixed travel distance, drag offsets aren't part of that).
-        # _after_anim_finished checks the actual on-screen position and either
+        # after_anim_finished checks the actual on-screen position and either
         # closes or starts an exit animation that pushes the plane the rest of
         # the way off the screen.
-        self._anim.finished.connect(self._after_anim_finished)
-        self._exit_anim = None  # set when an exit motion is in progress
+        self.anim.finished.connect(self.after_anim_finished)
+        self.exit_anim = None  # set when an exit motion is in progress
 
     # -- public -------------------------------------------------------------
 
     def start(self) -> None:
-        self._start_time = time.monotonic()
+        self.start_time = time.monotonic()
         self.show()
         self.raise_()
-        self._anim.start()
+        self.anim.start()
 
     # -- sizing -------------------------------------------------------------
 
-    def _banner_font(self) -> QtGui.QFont:
+    def banner_font(self) -> QtGui.QFont:
         font = QtGui.QFont()
         font.setBold(True)
         # 0.40 of the flag height: banner texts got longer (GitHub events,
         # digests), a smaller face keeps the flag from growing screen-wide.
-        font.setPixelSize(max(10, int(self._flag_h * 0.40)))
+        font.setPixelSize(max(10, int(self.flag_h * 0.40)))
         return font
 
-    def _compute_flag_length(self) -> int:
-        fm = QtGui.QFontMetrics(self._banner_font())
-        text_w = fm.horizontalAdvance(self._text)
-        max_w = int(self._screen_w * 0.6)
+    def compute_flag_length(self) -> int:
+        fm = QtGui.QFontMetrics(self.banner_font())
+        text_w = fm.horizontalAdvance(self.text)
+        max_w = int(self.screen_w * 0.6)
         # Min length scales with plane size so a tiny plane doesn't drag a
         # ridiculously long flag and vice versa.
-        min_w = max(160, int(self._plane_width * 1.0))
+        min_w = max(160, int(self.plane_width * 1.0))
         return max(min_w, min(text_w + 80, max_w))
 
-    def _group_width(self) -> int:
-        return self._banner_w + GAP + self._plane_width
+    def group_width(self) -> int:
+        return self.banner_w + GAP + self.plane_width
 
     # -- animation ----------------------------------------------------------
 
-    def _on_value(self, value) -> None:
-        self._progress = float(value)
+    def on_value(self, value) -> None:
+        self.progress = float(value)
         self.update()
 
     # -- painting -----------------------------------------------------------
@@ -349,32 +349,32 @@ class FlybyWindow(QtWidgets.QWidget):
         self.plane_blit = None
         self.cat_blit = None
 
-        t = 0.0 if self._start_time is None else max(0.0, time.monotonic() - self._start_time)
+        t = 0.0 if self.start_time is None else max(0.0, time.monotonic() - self.start_time)
         bob = math.sin(t * 1.9) * 2.5  # gentle vertical "alive" motion
 
-        pw, ph = self._plane_width, self._plane_height
-        gw = self._group_width()
-        travel = self._screen_w + gw
-        if self._ltr:
-            left = -gw + self._progress * travel
-            plane_x = left + self._banner_w + GAP
+        pw, ph = self.plane_width, self.plane_height
+        gw = self.group_width()
+        travel = self.screen_w + gw
+        if self.ltr:
+            left = -gw + self.progress * travel
+            plane_x = left + self.banner_w + GAP
             flag_attach_x = plane_x - 18  # flag attaches just behind the tail
             flag_dir = -1  # flag trails to the left
         else:
-            left = self._screen_w - self._progress * travel
+            left = self.screen_w - self.progress * travel
             plane_x = left
             flag_attach_x = plane_x + pw + 18
             flag_dir = +1  # flag trails to the right
 
         # Apply manual drag offset from the mouse handlers — the plane, flag,
         # rope and cat all move as one rigid group.
-        plane_x += self._user_offset.x()
-        flag_attach_x += self._user_offset.x()
-        plane_y = self._band_top + (self._band_h - ph - 18) + bob + self._user_offset.y()
+        plane_x += self.user_offset.x()
+        flag_attach_x += self.user_offset.x()
+        plane_y = self.band_top + (self.band_h - ph - 18) + bob + self.user_offset.y()
         plane_rect = QtCore.QRectF(plane_x, plane_y, pw, ph)
 
         # Rope: from plane belly (behind the wing) up to the flag.
-        rope_from_frac_x = 0.18 if self._ltr else 0.82
+        rope_from_frac_x = 0.18 if self.ltr else 0.82
         rope_from = QtCore.QPointF(
             plane_rect.x() + pw * rope_from_frac_x,
             plane_rect.y() + ph * 0.74,
@@ -385,18 +385,18 @@ class FlybyWindow(QtWidgets.QWidget):
         # sprite on top. The plane silhouette hides the cat's body so only the
         # head peeks above it. With the taller crop (head+shoulders+chest), the
         # peek now shows roughly the full head — not just the ear tips.
-        self._draw_flag(painter, flag_attach, flag_dir, self._banner_w, self._flag_h, self._text)
-        if self._plane_sprite is not None:
-            self._draw_rope(painter, rope_from, flag_attach)
+        self.draw_flag(painter, flag_attach, flag_dir, self.banner_w, self.flag_h, self.text)
+        if self.plane_sprite is not None:
+            self.draw_rope(painter, rope_from, flag_attach)
             if self.plane_name == "plane1":
-                self._draw_cat_face(painter, plane_rect, facing_right=self._ltr)
-            self._draw_plane(painter, plane_rect, facing_right=self._ltr)
+                self.draw_cat_face(painter, plane_rect, facing_right=self.ltr)
+            self.draw_plane(painter, plane_rect, facing_right=self.ltr)
 
         # Refresh the input mask so only the plane+flag bbox is interactive.
         # Areas outside this region are click-through to whatever is below.
-        self._update_input_mask(plane_rect, flag_attach, flag_dir)
+        self.update_input_mask(plane_rect, flag_attach, flag_dir)
 
-    def _update_input_mask(self, plane_rect, flag_attach, flag_dir) -> None:
+    def update_input_mask(self, plane_rect, flag_attach, flag_dir) -> None:
         # Without a compositor, clip to the drawn silhouette so transparent areas
         # are not painted black; with a compositor keep the cheap bounding box.
         if self.silhouette_mask:
@@ -405,12 +405,12 @@ class FlybyWindow(QtWidgets.QWidget):
                 self.setMask(region)
                 return
 
-        flag_x = flag_attach.x() - self._banner_w if flag_dir < 0 else flag_attach.x()
-        flag_rect = QtCore.QRectF(flag_x, flag_attach.y() - self._flag_h / 2, self._banner_w, self._flag_h)
-        if self._plane_sprite is not None:
+        flag_x = flag_attach.x() - self.banner_w if flag_dir < 0 else flag_attach.x()
+        flag_rect = QtCore.QRectF(flag_x, flag_attach.y() - self.flag_h / 2, self.banner_w, self.flag_h)
+        if self.plane_sprite is not None:
             # Cat head pokes a little above the plane top — include that area in
             # the mask so the click-region matches what's actually drawn on screen.
-            cat_top = plane_rect.y() - self._plane_height * 0.10
+            cat_top = plane_rect.y() - self.plane_height * 0.10
             union_rect = plane_rect.united(flag_rect)
             union_rect.setTop(min(union_rect.top(), cat_top))
         else:
@@ -450,16 +450,16 @@ class FlybyWindow(QtWidgets.QWidget):
         # keep a 2x2 on-screen anchor at the entry edge so repaints keep coming;
         # once any part of the plane is on screen the silhouette itself keeps the
         # cycle alive and no anchor (and no stray pixel) is added.
-        screen = QtCore.QRect(0, 0, self._screen_w, self.height())
+        screen = QtCore.QRect(0, 0, self.screen_w, self.height())
         if not region.boundingRect().intersects(screen):
-            anchor_x = 0 if self._ltr else max(0, self._screen_w - 2)
-            anchor_y = self._band_top + self._band_h // 2
+            anchor_x = 0 if self.ltr else max(0, self.screen_w - 2)
+            anchor_y = self.band_top + self.band_h // 2
             region += QtGui.QRegion(anchor_x, anchor_y, 2, 2)
         return region
 
     # -- flag (static rectangle, plane-coloured) ----------------------------
 
-    def _draw_flag(self, painter, attach, direction, length, height, text) -> None:
+    def draw_flag(self, painter, attach, direction, length, height, text) -> None:
         # Classic banner pennant: rectangular cloth on a pole at the attach
         # edge, with a V-notch (swallowtail) cut into the trailing edge. This
         # silhouette reads instantly as a "flag/banner" rather than a notification
@@ -504,8 +504,8 @@ class FlybyWindow(QtWidgets.QWidget):
             text_right = notch_x - 6
 
         # Cloth
-        painter.setBrush(self._plane_color)
-        painter.setPen(QtGui.QPen(self._plane_color.darker(150), 2))
+        painter.setBrush(self.plane_color)
+        painter.setPen(QtGui.QPen(self.plane_color.darker(150), 2))
         painter.drawPolygon(polygon)
         self.flag_shape = polygon
 
@@ -518,11 +518,11 @@ class FlybyWindow(QtWidgets.QWidget):
         self.flag_pole = pole_rect
 
         # Text — luminance-aware contrast so a white-livery flag stays readable.
-        c = self._plane_color
+        c = self.plane_color
         lum = (0.299 * c.red() + 0.587 * c.green() + 0.114 * c.blue()) / 255.0
         text_color = FLAG_TEXT_DARK if lum > 0.7 else FLAG_TEXT_LIGHT
 
-        font = self._banner_font()
+        font = self.banner_font()
         fm = QtGui.QFontMetrics(font)
         inner_w = max(20, int(text_right - text_left))
         while font.pixelSize() > 11 and fm.horizontalAdvance(text) > inner_w:
@@ -534,7 +534,7 @@ class FlybyWindow(QtWidgets.QWidget):
         painter.setPen(text_color)
         painter.drawText(text_rect, QtCore.Qt.AlignmentFlag.AlignCenter, elided)
 
-    def _draw_rope(self, painter, p_from, p_to) -> None:
+    def draw_rope(self, painter, p_from, p_to) -> None:
         mid = QtCore.QPointF((p_from.x() + p_to.x()) / 2, max(p_from.y(), p_to.y()) + 16)
         path = QtGui.QPainterPath(p_from)
         path.quadTo(mid, p_to)
@@ -547,13 +547,13 @@ class FlybyWindow(QtWidgets.QWidget):
 
     # -- plane --------------------------------------------------------------
 
-    def _draw_plane(self, painter, rect, facing_right) -> None:
+    def draw_plane(self, painter, rect, facing_right) -> None:
         """Render the PNG plane sprite (nearest-neighbour, aspect-preserved).
 
         ``FlybyWindow`` only flies when a sprite is loaded — paintEvent skips
-        the plane (and the cat face) entirely if ``_plane_sprite`` is ``None``.
+        the plane (and the cat face) entirely if ``plane_sprite`` is ``None``.
         """
-        sprite = self._plane_sprite
+        sprite = self.plane_sprite
         if sprite is None:
             return
         if not facing_right:
@@ -577,19 +577,19 @@ class FlybyWindow(QtWidgets.QWidget):
 
     # -- cat face inside the cockpit ---------------------------------------
 
-    def _draw_cat_face(self, painter, plane_rect, facing_right) -> None:
+    def draw_cat_face(self, painter, plane_rect, facing_right) -> None:
         """Stamp the cat head at the cockpit, sunk ``CAT_SINK_FRAC`` into the plane
         so only the top of the head pokes above the fuselage. The eyes blink on a
         cycle when a closed-eyes frame is available. No clip, no glass, no rim —
         the plane sprite is drawn AFTER this so it covers most of the cat."""
         # Blink: briefly swap to the closed-eyes frame on a slow cycle.
-        elapsed = 0.0 if self._start_time is None else max(0.0, time.monotonic() - self._start_time)
+        elapsed = 0.0 if self.start_time is None else max(0.0, time.monotonic() - self.start_time)
         blinking = self.cat_blink_pixmap is not None and (elapsed % BLINK_PERIOD_S) < BLINK_DUR_S
-        cat = self.cat_blink_pixmap if blinking else self._cat_face_pixmap
+        cat = self.cat_blink_pixmap if blinking else self.cat_face_pixmap
         if cat is None or cat.isNull():
             return
         x, y, w, h = plane_rect.x(), plane_rect.y(), plane_rect.width(), plane_rect.height()
-        cx_frac_r, cy_frac, canopy_rx, canopy_ry = self._canopy_fracs
+        cx_frac_r, cy_frac, canopy_rx, canopy_ry = self.canopy_fracs
         cx_frac = cx_frac_r if facing_right else (1.0 - cx_frac_r)
         canopy_cx = x + w * cx_frac
         canopy_cy = y + h * cy_frac + h * CAT_SINK_FRAC  # sink deeper into the plane
@@ -614,25 +614,25 @@ class FlybyWindow(QtWidgets.QWidget):
             # target to grab. The exit animation is fully stopped — mouseRelease
             # will rebuild it from the new dropped position if the plane is
             # still on screen.
-            if self._anim.state() == QtCore.QAbstractAnimation.State.Running:
-                self._anim.pause()
-            if self._exit_anim is not None:
-                self._exit_anim.stop()
-                self._exit_anim = None
-            self._dragging = True
-            self._drag_anchor = event.globalPosition()
-            self._drag_start_offset = QtCore.QPointF(self._user_offset)
+            if self.anim.state() == QtCore.QAbstractAnimation.State.Running:
+                self.anim.pause()
+            if self.exit_anim is not None:
+                self.exit_anim.stop()
+                self.exit_anim = None
+            self.dragging = True
+            self.drag_anchor = event.globalPosition()
+            self.drag_start_offset = QtCore.QPointF(self.user_offset)
             self.setCursor(QtCore.Qt.CursorShape.ClosedHandCursor)
             event.accept()
             return
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event: QtGui.QMouseEvent) -> None:
-        if self._dragging:
-            delta = event.globalPosition() - self._drag_anchor
-            self._user_offset = QtCore.QPointF(
-                self._drag_start_offset.x() + delta.x(),
-                self._drag_start_offset.y() + delta.y(),
+        if self.dragging:
+            delta = event.globalPosition() - self.drag_anchor
+            self.user_offset = QtCore.QPointF(
+                self.drag_start_offset.x() + delta.x(),
+                self.drag_start_offset.y() + delta.y(),
             )
             self.update()
             event.accept()
@@ -640,22 +640,22 @@ class FlybyWindow(QtWidgets.QWidget):
         super().mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:
-        if event.button() == QtCore.Qt.MouseButton.LeftButton and self._dragging:
-            self._dragging = False
+        if event.button() == QtCore.Qt.MouseButton.LeftButton and self.dragging:
+            self.dragging = False
             self.setCursor(QtCore.Qt.CursorShape.OpenHandCursor)
             # Continue the flight from the dropped position. The accumulated
-            # ``_user_offset`` is intentionally kept so the plane resumes from
+            # ``user_offset`` is intentionally kept so the plane resumes from
             # wherever the user parked it rather than snapping back.
-            if self._anim.state() == QtCore.QAbstractAnimation.State.Paused:
-                self._anim.setPaused(False)
-            elif self._anim.state() == QtCore.QAbstractAnimation.State.Stopped:
+            if self.anim.state() == QtCore.QAbstractAnimation.State.Paused:
+                self.anim.setPaused(False)
+            elif self.anim.state() == QtCore.QAbstractAnimation.State.Stopped:
                 # Main animation has already played out. Re-issue an exit
                 # animation from the new position (or close if the plane is
                 # already past every screen edge).
-                if self._is_plane_fully_offscreen():
+                if self.is_plane_fully_offscreen():
                     self.close()
                 else:
-                    self._begin_exit_animation()
+                    self.begin_exit_animation()
             event.accept()
             return
         super().mouseReleaseEvent(event)
@@ -663,19 +663,19 @@ class FlybyWindow(QtWidgets.QWidget):
     def contextMenuEvent(self, event: QtGui.QContextMenuEvent) -> None:
         Paused = QtCore.QAbstractAnimation.State.Paused
         Running = QtCore.QAbstractAnimation.State.Running
-        main_paused = self._anim.state() == Paused
-        main_running = self._anim.state() == Running
-        exit_paused = self._exit_anim is not None and self._exit_anim.state() == Paused
-        exit_running = self._exit_anim is not None and self._exit_anim.state() == Running
+        main_paused = self.anim.state() == Paused
+        main_running = self.anim.state() == Running
+        exit_paused = self.exit_anim is not None and self.exit_anim.state() == Paused
+        exit_running = self.exit_anim is not None and self.exit_anim.state() == Running
 
         menu = QtWidgets.QMenu(self)
         if self.link_url:
             menu.addAction("Open link", self.open_link)
             menu.addSeparator()
-        if main_paused or exit_paused or self._anim.state() == QtCore.QAbstractAnimation.State.Stopped:
-            menu.addAction("Resume flight", self._resume_flight)
+        if main_paused or exit_paused or self.anim.state() == QtCore.QAbstractAnimation.State.Stopped:
+            menu.addAction("Resume flight", self.resume_flight)
         elif main_running or exit_running:
-            menu.addAction("Pause flight", self._pause_flight)
+            menu.addAction("Pause flight", self.pause_flight)
         menu.addSeparator()
         menu.addAction("Close", self.close)
         menu.exec(event.globalPos())
@@ -694,84 +694,84 @@ class FlybyWindow(QtWidgets.QWidget):
             return
         super().mouseDoubleClickEvent(event)
 
-    def _pause_flight(self) -> None:
-        if self._anim.state() == QtCore.QAbstractAnimation.State.Running:
-            self._anim.pause()
-        if self._exit_anim is not None and self._exit_anim.state() == QtCore.QAbstractAnimation.State.Running:
-            self._exit_anim.pause()
+    def pause_flight(self) -> None:
+        if self.anim.state() == QtCore.QAbstractAnimation.State.Running:
+            self.anim.pause()
+        if self.exit_anim is not None and self.exit_anim.state() == QtCore.QAbstractAnimation.State.Running:
+            self.exit_anim.pause()
 
-    def _resume_flight(self) -> None:
+    def resume_flight(self) -> None:
         # Resume whichever animation was paused. Resuming the main animation
         # keeps the drag offset; resuming the exit animation continues the
         # linear push toward the screen edge. If the main animation already
         # finished and there's no exit animation, start one from the current
         # parked position (or close if the plane is already off-screen).
-        if self._anim.state() == QtCore.QAbstractAnimation.State.Paused:
-            self._anim.setPaused(False)
-        elif self._exit_anim is not None and self._exit_anim.state() == QtCore.QAbstractAnimation.State.Paused:
-            self._exit_anim.setPaused(False)
-        elif self._anim.state() == QtCore.QAbstractAnimation.State.Stopped:
-            if self._is_plane_fully_offscreen():
+        if self.anim.state() == QtCore.QAbstractAnimation.State.Paused:
+            self.anim.setPaused(False)
+        elif self.exit_anim is not None and self.exit_anim.state() == QtCore.QAbstractAnimation.State.Paused:
+            self.exit_anim.setPaused(False)
+        elif self.anim.state() == QtCore.QAbstractAnimation.State.Stopped:
+            if self.is_plane_fully_offscreen():
                 self.close()
             else:
-                self._begin_exit_animation()
+                self.begin_exit_animation()
 
     # -- exit-from-screen: keep moving the plane until it's fully off ------
 
-    def _after_anim_finished(self) -> None:
+    def after_anim_finished(self) -> None:
         """Main animation ran out — close only if the plane is actually gone."""
-        if self._is_plane_fully_offscreen():
+        if self.is_plane_fully_offscreen():
             self.close()
         else:
-            self._begin_exit_animation()
+            self.begin_exit_animation()
 
-    def _compute_current_plane_position(self) -> tuple[float, float]:
+    def compute_current_plane_position(self) -> tuple[float, float]:
         """Return the plane's current (x, y) in window coords, drag offset included."""
-        ph = self._plane_height
-        gw = self._group_width()
-        travel = self._screen_w + gw
-        if self._ltr:
-            plane_x = -gw + self._progress * travel + self._banner_w + GAP
+        ph = self.plane_height
+        gw = self.group_width()
+        travel = self.screen_w + gw
+        if self.ltr:
+            plane_x = -gw + self.progress * travel + self.banner_w + GAP
         else:
-            plane_x = self._screen_w - self._progress * travel
-        plane_x += self._user_offset.x()
-        plane_y = self._band_top + (self._band_h - ph - 18) + self._user_offset.y()
+            plane_x = self.screen_w - self.progress * travel
+        plane_x += self.user_offset.x()
+        plane_y = self.band_top + (self.band_h - ph - 18) + self.user_offset.y()
         return plane_x, plane_y
 
-    def _is_plane_fully_offscreen(self) -> bool:
-        plane_x, plane_y = self._compute_current_plane_position()
-        pw, ph = self._plane_width, self._plane_height
-        return plane_x + pw <= 0 or plane_x >= self._screen_w or plane_y + ph <= 0 or plane_y >= self.height()
+    def is_plane_fully_offscreen(self) -> bool:
+        plane_x, plane_y = self.compute_current_plane_position()
+        pw, ph = self.plane_width, self.plane_height
+        return plane_x + pw <= 0 or plane_x >= self.screen_w or plane_y + ph <= 0 or plane_y >= self.height()
 
-    def _begin_exit_animation(self) -> None:
+    def begin_exit_animation(self) -> None:
         """Linearly continue pushing the plane in the flight direction until it
         clears the screen. Used after the main animation has finished but the
         plane is still visible (e.g. because the user dragged it back)."""
-        if self._exit_anim is not None:
-            self._exit_anim.stop()
-        plane_x, _ = self._compute_current_plane_position()
-        pw = self._plane_width
-        if self._ltr:
+        if self.exit_anim is not None:
+            self.exit_anim.stop()
+        plane_x, _ = self.compute_current_plane_position()
+        pw = self.plane_width
+        if self.ltr:
             # How far the offset needs to move right so plane_x crosses the right edge
-            dx_needed = (self._screen_w + 20) - plane_x
+            dx_needed = (self.screen_w + 20) - plane_x
         else:
             dx_needed = -(plane_x + pw + 20)
-        target_offset_x = self._user_offset.x() + dx_needed
+        target_offset_x = self.user_offset.x() + dx_needed
         # Linear motion at "natural cruising speed" matching the main animation.
-        cruise_px_per_sec = (self._screen_w + self._group_width()) / (BASE_DURATION_MS / 1000.0)
+        cruise_px_per_sec = (self.screen_w + self.group_width()) / (BASE_DURATION_MS / 1000.0)
         duration_ms = max(150, int(abs(dx_needed) / max(1.0, cruise_px_per_sec) * 1000))
 
-        self._exit_anim = QtCore.QVariantAnimation(self)
-        self._exit_anim.setStartValue(float(self._user_offset.x()))
-        self._exit_anim.setEndValue(float(target_offset_x))
-        self._exit_anim.setDuration(duration_ms)
-        self._exit_anim.setEasingCurve(QtCore.QEasingCurve.Type.Linear)
-        self._exit_anim.valueChanged.connect(self._on_exit_value)
-        self._exit_anim.finished.connect(self.close)
-        self._exit_anim.start()
+        self.exit_anim = QtCore.QVariantAnimation(self)
+        self.exit_anim.setStartValue(float(self.user_offset.x()))
+        self.exit_anim.setEndValue(float(target_offset_x))
+        self.exit_anim.setDuration(duration_ms)
+        self.exit_anim.setEasingCurve(QtCore.QEasingCurve.Type.Linear)
+        self.exit_anim.valueChanged.connect(self.on_exit_value)
+        self.exit_anim.finished.connect(self.close)
+        self.exit_anim.start()
 
-    def _on_exit_value(self, value) -> None:
-        self._user_offset = QtCore.QPointF(float(value), self._user_offset.y())
+    def on_exit_value(self, value) -> None:
+        self.user_offset = QtCore.QPointF(float(value), self.user_offset.y())
         self.update()
 
 
@@ -780,7 +780,7 @@ class ReminderDialog(QtWidgets.QDialog):
 
     def __init__(self, controller, reminder, parent=None) -> None:
         super().__init__(parent)
-        self._controller = controller
+        self.controller = controller
         self.setWindowTitle("Reminder")
         self.setMinimumWidth(380)
         # Force a complete light theme on the whole dialog. Styling only the input
@@ -815,17 +815,17 @@ class ReminderDialog(QtWidgets.QDialog):
         form = QtWidgets.QFormLayout()
         form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
 
-        self._text_edit = QtWidgets.QLineEdit(existing.text)
-        self._text_edit.setPlaceholderText("What should the cat remind you about?")
-        self._text_edit.setMaxLength(120)
-        form.addRow("Message", self._text_edit)
+        self.text_edit = QtWidgets.QLineEdit(existing.text)
+        self.text_edit.setPlaceholderText("What should the cat remind you about?")
+        self.text_edit.setMaxLength(120)
+        form.addRow("Message", self.text_edit)
 
-        self._direction = QtWidgets.QComboBox()
-        self._direction.addItem("Left → Right", DIRECTION_LTR)
-        self._direction.addItem("Right → Left", DIRECTION_RTL)
-        idx = self._direction.findData(existing.normalized_direction())
-        self._direction.setCurrentIndex(max(0, idx))
-        form.addRow("Direction", self._direction)
+        self.direction = QtWidgets.QComboBox()
+        self.direction.addItem("Left → Right", DIRECTION_LTR)
+        self.direction.addItem("Right → Left", DIRECTION_RTL)
+        idx = self.direction.findData(existing.normalized_direction())
+        self.direction.setCurrentIndex(max(0, idx))
+        form.addRow("Direction", self.direction)
 
         self.plane_combo = QtWidgets.QComboBox()
         self.plane_combo.setIconSize(QtCore.QSize(48, 24))
@@ -848,21 +848,21 @@ class ReminderDialog(QtWidgets.QDialog):
         self.plane_combo.setCurrentIndex(max(0, idx))
         form.addRow("Plane", self.plane_combo)
 
-        self._color = QtWidgets.QComboBox()
+        self.color = QtWidgets.QComboBox()
         for name, qcolor in PLANE_COLORS.items():
             swatch = QtGui.QPixmap(20, 20)
             swatch.fill(qcolor)
-            self._color.addItem(QtGui.QIcon(swatch), name.capitalize(), name)
-        idx = self._color.findData(existing.plane_color)
-        self._color.setCurrentIndex(max(0, idx))
-        form.addRow("Plane color", self._color)
+            self.color.addItem(QtGui.QIcon(swatch), name.capitalize(), name)
+        idx = self.color.findData(existing.plane_color)
+        self.color.setCurrentIndex(max(0, idx))
+        form.addRow("Plane color", self.color)
 
-        self._plane_width_spin = QtWidgets.QSpinBox()
-        self._plane_width_spin.setRange(120, 500)
-        self._plane_width_spin.setSuffix(" px")
+        self.plane_width_spin = QtWidgets.QSpinBox()
+        self.plane_width_spin.setRange(120, 500)
+        self.plane_width_spin.setSuffix(" px")
         # Height follows the sprite's aspect ratio — only the width is user-set.
-        self._plane_width_spin.setValue(max(120, int(existing.plane_width)))
-        form.addRow("Plane width", self._plane_width_spin)
+        self.plane_width_spin.setValue(max(120, int(existing.plane_width)))
+        form.addRow("Plane width", self.plane_width_spin)
 
         layout.addLayout(form)
 
@@ -870,39 +870,39 @@ class ReminderDialog(QtWidgets.QDialog):
         timing_box = QtWidgets.QGroupBox("When")
         timing_layout = QtWidgets.QGridLayout(timing_box)
 
-        self._in_radio = QtWidgets.QRadioButton("In")
-        self._in_spin = QtWidgets.QSpinBox()
-        self._in_spin.setRange(0, 1440)
-        self._in_spin.setSuffix(" min")
+        self.in_radio = QtWidgets.QRadioButton("In")
+        self.in_spin = QtWidgets.QSpinBox()
+        self.in_spin.setRange(0, 1440)
+        self.in_spin.setSuffix(" min")
         # 0 = fire on the very next scheduler tick (within ~1s).
-        self._in_spin.setSpecialValueText("now")
-        self._in_spin.setValue(max(0, existing.in_minutes))
+        self.in_spin.setSpecialValueText("now")
+        self.in_spin.setValue(max(0, existing.in_minutes))
 
-        self._at_radio = QtWidgets.QRadioButton("At")
-        self._at_time = QtWidgets.QTimeEdit()
-        self._at_time.setDisplayFormat("HH:mm")
+        self.at_radio = QtWidgets.QRadioButton("At")
+        self.at_time = QtWidgets.QTimeEdit()
+        self.at_time.setDisplayFormat("HH:mm")
         if existing.mode == "at" and existing.fire_at is not None:
-            self._at_time.setTime(QtCore.QTime(existing.fire_at.hour, existing.fire_at.minute))
+            self.at_time.setTime(QtCore.QTime(existing.fire_at.hour, existing.fire_at.minute))
         else:
-            self._at_time.setTime(QtCore.QTime.currentTime().addSecs(600))
+            self.at_time.setTime(QtCore.QTime.currentTime().addSecs(600))
 
-        timing_layout.addWidget(self._in_radio, 0, 0)
-        timing_layout.addWidget(self._in_spin, 0, 1)
-        timing_layout.addWidget(self._at_radio, 1, 0)
-        timing_layout.addWidget(self._at_time, 1, 1)
+        timing_layout.addWidget(self.in_radio, 0, 0)
+        timing_layout.addWidget(self.in_spin, 0, 1)
+        timing_layout.addWidget(self.at_radio, 1, 0)
+        timing_layout.addWidget(self.at_time, 1, 1)
 
-        self._repeat = QtWidgets.QCheckBox("Repeat daily")
-        self._repeat.setChecked(existing.repeat_daily)
-        timing_layout.addWidget(self._repeat, 2, 0, 1, 2)
+        self.repeat = QtWidgets.QCheckBox("Repeat daily")
+        self.repeat.setChecked(existing.repeat_daily)
+        timing_layout.addWidget(self.repeat, 2, 0, 1, 2)
 
         layout.addWidget(timing_box)
 
         if existing.mode == "at":
-            self._at_radio.setChecked(True)
+            self.at_radio.setChecked(True)
         else:
-            self._in_radio.setChecked(True)
-        self._sync_timing_enabled()
-        self._in_radio.toggled.connect(self._sync_timing_enabled)
+            self.in_radio.setChecked(True)
+        self.sync_timing_enabled()
+        self.in_radio.toggled.connect(self.sync_timing_enabled)
 
         # Buttons: Test, Reset (left) · Save, Close (right) — same order as
         # every other mycat dialog.
@@ -912,10 +912,10 @@ class ReminderDialog(QtWidgets.QDialog):
         close_btn = QtWidgets.QPushButton("Close")
         save_btn = QtWidgets.QPushButton("Save")
         save_btn.setDefault(True)
-        test_btn.clicked.connect(self._on_test)
-        reset_btn.clicked.connect(self._on_clear)
+        test_btn.clicked.connect(self.on_test)
+        reset_btn.clicked.connect(self.on_clear)
         close_btn.clicked.connect(self.reject)
-        save_btn.clicked.connect(self._on_save)
+        save_btn.clicked.connect(self.on_save)
         buttons.addWidget(test_btn)
         buttons.addWidget(reset_btn)
         buttons.addStretch(1)
@@ -931,23 +931,23 @@ class ReminderDialog(QtWidgets.QDialog):
         # On reopen, the dialog must visibly reflect the live schedule (Olya:
         # "if I open it again it looks reset"). A 1-second countdown keeps the
         # status line honest about how much time is left until the flyby.
-        self._countdown = QtCore.QTimer(self)
-        self._countdown.setInterval(1000)
-        self._countdown.timeout.connect(self._refresh_pending)
-        self._refresh_pending()
+        self.countdown = QtCore.QTimer(self)
+        self.countdown.setInterval(1000)
+        self.countdown.timeout.connect(self.refresh_pending)
+        self.refresh_pending()
         if self.status_label.text():
-            self._countdown.start()
+            self.countdown.start()
 
-    def _refresh_pending(self) -> None:
+    def refresh_pending(self) -> None:
         """Show the pending reminder as a short 'Reminder in N min. (HH:MM)' line."""
-        reminder = self._controller.reminder
+        reminder = self.controller.reminder
         if reminder is None or not reminder.enabled or reminder.fire_at is None:
-            self._countdown.stop()
+            self.countdown.stop()
             self.status_label.clear()
             return
         remaining = int((reminder.fire_at - datetime.now()).total_seconds())
         if remaining <= 0:
-            self._countdown.stop()
+            self.countdown.stop()
             self.status_label.clear()
             return
         if remaining >= 60:
@@ -959,24 +959,24 @@ class ReminderDialog(QtWidgets.QDialog):
         self.status_label.setStyleSheet("color: #1c7c2f;")
         self.status_label.setText(f"Reminder in {left}. ({at}{daily})")
 
-    def _sync_timing_enabled(self) -> None:
-        in_mode = self._in_radio.isChecked()
-        self._in_spin.setEnabled(in_mode)
-        self._at_time.setEnabled(not in_mode)
+    def sync_timing_enabled(self) -> None:
+        in_mode = self.in_radio.isChecked()
+        self.in_spin.setEnabled(in_mode)
+        self.at_time.setEnabled(not in_mode)
         # Daily repeat only makes sense for a fixed time of day.
-        self._repeat.setEnabled(not in_mode)
+        self.repeat.setEnabled(not in_mode)
         if in_mode:
-            self._repeat.setChecked(False)
+            self.repeat.setChecked(False)
 
-    def _build_reminder(self) -> Reminder:
-        text = self._text_edit.text().strip() or reminder_mod.DEFAULT_TEXT
-        direction = self._direction.currentData()
-        plane_color = self._color.currentData() or "white"
-        plane_width = self._plane_width_spin.value()
+    def build_reminder(self) -> Reminder:
+        text = self.text_edit.text().strip() or reminder_mod.DEFAULT_TEXT
+        direction = self.direction.currentData()
+        plane_color = self.color.currentData() or "white"
+        plane_width = self.plane_width_spin.value()
         plane = self.plane_combo.currentData() or "plane1"
         now = datetime.now()
-        if self._in_radio.isChecked():
-            minutes = self._in_spin.value()
+        if self.in_radio.isChecked():
+            minutes = self.in_spin.value()
             fire_at = now + timedelta(minutes=minutes)
             return Reminder(
                 text=text,
@@ -990,7 +990,7 @@ class ReminderDialog(QtWidgets.QDialog):
                 mode="in",
                 in_minutes=minutes,
             )
-        qt_time = self._at_time.time()
+        qt_time = self.at_time.time()
         fire_at = now.replace(hour=qt_time.hour(), minute=qt_time.minute(), second=0, microsecond=0)
         if fire_at <= now:
             fire_at += timedelta(days=1)
@@ -998,52 +998,52 @@ class ReminderDialog(QtWidgets.QDialog):
             text=text,
             direction=direction,
             fire_at=fire_at,
-            repeat_daily=self._repeat.isChecked(),
+            repeat_daily=self.repeat.isChecked(),
             enabled=True,
             plane_color=plane_color,
             plane_width=plane_width,
             plane=plane,
             mode="at",
-            in_minutes=self._in_spin.value(),
+            in_minutes=self.in_spin.value(),
         )
 
-    def _on_test(self) -> None:
+    def on_test(self) -> None:
         # Force left->right when previewing? No — honour the chosen direction.
-        self._controller.test(self._build_reminder())
+        self.controller.test(self.build_reminder())
 
-    def _on_clear(self) -> None:
-        self._countdown.stop()
-        self._controller.clear()
+    def on_clear(self) -> None:
+        self.countdown.stop()
+        self.controller.clear()
         # Full reset: wipe the schedule AND restore the form to defaults,
         # including the message text ("Do you feed mycat?").
         defaults = Reminder()
-        self._text_edit.setText(defaults.text)
-        self._direction.setCurrentIndex(
-            max(0, self._direction.findData(defaults.normalized_direction()))
+        self.text_edit.setText(defaults.text)
+        self.direction.setCurrentIndex(
+            max(0, self.direction.findData(defaults.normalized_direction()))
         )
-        color_idx = self._color.findData(defaults.plane_color)
+        color_idx = self.color.findData(defaults.plane_color)
         if color_idx >= 0:
-            self._color.setCurrentIndex(color_idx)
+            self.color.setCurrentIndex(color_idx)
         plane_idx = self.plane_combo.findData(defaults.plane)
         if plane_idx >= 0:
             self.plane_combo.setCurrentIndex(plane_idx)
-        self._plane_width_spin.setValue(max(120, defaults.plane_width))
-        self._in_spin.setValue(max(0, defaults.in_minutes))
-        self._repeat.setChecked(defaults.repeat_daily)
-        self._in_radio.setChecked(True)
-        self._at_time.setTime(QtCore.QTime.currentTime().addSecs(600))
-        self._sync_timing_enabled()
+        self.plane_width_spin.setValue(max(120, defaults.plane_width))
+        self.in_spin.setValue(max(0, defaults.in_minutes))
+        self.repeat.setChecked(defaults.repeat_daily)
+        self.in_radio.setChecked(True)
+        self.at_time.setTime(QtCore.QTime.currentTime().addSecs(600))
+        self.sync_timing_enabled()
         self.status_label.setStyleSheet("color: #777777;")
         self.status_label.setText("Reminder cleared.")
 
-    def _on_save(self) -> None:
-        reminder = self._build_reminder()
-        self._controller.set_reminder(reminder)
+    def on_save(self) -> None:
+        reminder = self.build_reminder()
+        self.controller.set_reminder(reminder)
         # Show the short countdown straight away — it doubles as the "saved"
         # confirmation, so nothing swaps in a few seconds later.
-        self._refresh_pending()
+        self.refresh_pending()
         if self.status_label.text():
-            self._countdown.start()
+            self.countdown.start()
         else:
             self.status_label.setStyleSheet("color: #1c7c2f;")
             self.status_label.setText("Reminder set.")

--- a/mycat/shop_api.py
+++ b/mycat/shop_api.py
@@ -173,14 +173,14 @@ class ShopClient:
         except urllib.error.HTTPError as exc:
             if exc.code == 304:
                 logger.debug("Catalog 304 Not Modified — using cached copy")
-                return self._load_cached_catalog(cache_file)
-            cached = self._maybe_load_cached_catalog(cache_file)
+                return self.load_cached_catalog(cache_file)
+            cached = self.maybe_load_cached_catalog(cache_file)
             if cached is not None:
                 logger.warning("Catalog HTTP %s; falling back to cache: %s", exc.code, exc)
                 return cached
             raise ShopError(f"Server returned HTTP {exc.code}: {exc.reason}") from exc
         except urllib.error.URLError as exc:
-            cached = self._maybe_load_cached_catalog(cache_file)
+            cached = self.maybe_load_cached_catalog(cache_file)
             if cached is not None:
                 logger.warning("Catalog network error; falling back to cache: %s", exc.reason)
                 return cached
@@ -188,17 +188,17 @@ class ShopClient:
         except json.JSONDecodeError as exc:
             raise ShopError(f"Catalog response is not valid JSON: {exc}") from exc
 
-        return self._load_cached_catalog(cache_file)
+        return self.load_cached_catalog(cache_file)
 
-    def _maybe_load_cached_catalog(self, cache_file: Path) -> Catalog | None:
+    def maybe_load_cached_catalog(self, cache_file: Path) -> Catalog | None:
         if not cache_file.exists():
             return None
         try:
-            return self._load_cached_catalog(cache_file)
+            return self.load_cached_catalog(cache_file)
         except ShopError:
             return None
 
-    def _load_cached_catalog(self, cache_file: Path) -> Catalog:
+    def load_cached_catalog(self, cache_file: Path) -> Catalog:
         try:
             return Catalog.from_dict(json.loads(cache_file.read_text(encoding="utf-8")))
         except (OSError, json.JSONDecodeError) as exc:
@@ -255,7 +255,7 @@ class ShopClient:
         """
         dest_dir.mkdir(parents=True, exist_ok=True)
         final_path = dest_dir / f"{char.id}.zip"
-        url = self._resolve_download_url(char)
+        url = self.resolve_download_url(char)
 
         headers = {"User-Agent": "mycat-client", "Accept": "application/zip, */*"}
         if auth_token:
@@ -315,22 +315,22 @@ class ShopClient:
             logger.info("Downloaded %s (%d bytes) -> %s", char.id, downloaded, final_path)
             return final_path
         except urllib.error.HTTPError as exc:
-            self._cleanup(tmp, tmp_path)
+            self.cleanup(tmp, tmp_path)
             raise ShopError(f"HTTP {exc.code} downloading {char.id}: {exc.reason}") from exc
         except urllib.error.URLError as exc:
-            self._cleanup(tmp, tmp_path)
+            self.cleanup(tmp, tmp_path)
             raise ShopError(f"Network error downloading {char.id}: {exc.reason}") from exc
         except OSError as exc:
-            self._cleanup(tmp, tmp_path)
+            self.cleanup(tmp, tmp_path)
             raise ShopError(f"I/O error downloading {char.id}: {exc}") from exc
         except ShopError:
-            self._cleanup(tmp, tmp_path)
+            self.cleanup(tmp, tmp_path)
             raise
         except Exception as exc:
-            self._cleanup(tmp, tmp_path)
+            self.cleanup(tmp, tmp_path)
             raise ShopError(f"Unexpected error downloading {char.id}: {exc}") from exc
 
-    def _resolve_download_url(self, char: CharEntry) -> str:
+    def resolve_download_url(self, char: CharEntry) -> str:
         url = char.download_url
         if url.startswith("http://") or url.startswith("https://"):
             return url
@@ -339,7 +339,7 @@ class ShopClient:
         return self.base_url + url
 
     @staticmethod
-    def _cleanup(tmp_file, tmp_path: Path) -> None:
+    def cleanup(tmp_file, tmp_path: Path) -> None:
         try:
             tmp_file.close()
         except Exception:

--- a/mycat/shop_ui.py
+++ b/mycat/shop_ui.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 # --- workers ------------------------------------------------------------------
 
 
-class _Signals(QtCore.QObject):
+class Signals(QtCore.QObject):
     catalog_ready = QtCore.Signal(object)               # Catalog
     catalog_failed = QtCore.Signal(str)
     download_progress = QtCore.Signal(str, int, int)    # char_id, done, total
@@ -36,85 +36,85 @@ class _Signals(QtCore.QObject):
     preview_ready = QtCore.Signal(str, str)             # char_id, local_path
 
 
-class _CatalogWorker(QtCore.QRunnable):
-    def __init__(self, client: ShopClient, signals: _Signals, force_refresh: bool = False) -> None:
+class CatalogWorker(QtCore.QRunnable):
+    def __init__(self, client: ShopClient, signals: Signals, force_refresh: bool = False) -> None:
         super().__init__()
-        self._client = client
-        self._signals = signals
-        self._force_refresh = force_refresh
+        self.client = client
+        self.signals = signals
+        self.force_refresh = force_refresh
 
     def run(self) -> None:
         try:
-            catalog = self._client.fetch_catalog(force_refresh=self._force_refresh)
-            self._signals.catalog_ready.emit(catalog)
+            catalog = self.client.fetch_catalog(force_refresh=self.force_refresh)
+            self.signals.catalog_ready.emit(catalog)
         except ShopError as exc:
-            self._signals.catalog_failed.emit(str(exc))
+            self.signals.catalog_failed.emit(str(exc))
         except Exception as exc:
             logger.exception("Unexpected error fetching catalog")
-            self._signals.catalog_failed.emit(f"Unexpected error: {exc}")
+            self.signals.catalog_failed.emit(f"Unexpected error: {exc}")
 
 
-class _DownloadWorker(QtCore.QRunnable):
+class DownloadWorker(QtCore.QRunnable):
     def __init__(
         self,
         client: ShopClient,
-        signals: _Signals,
+        signals: Signals,
         char: CharEntry,
         dest_dir: Path,
         auth_token: str | None = None,
     ) -> None:
         super().__init__()
-        self._client = client
-        self._signals = signals
-        self._char = char
-        self._dest_dir = dest_dir
-        self._auth_token = auth_token
+        self.client = client
+        self.signals = signals
+        self.char = char
+        self.dest_dir = dest_dir
+        self.auth_token = auth_token
 
     def run(self) -> None:
-        char_id = self._char.id
+        char_id = self.char.id
 
         def progress(done: int, total: int) -> None:
-            self._signals.download_progress.emit(char_id, done, total)
+            self.signals.download_progress.emit(char_id, done, total)
 
         try:
-            path = self._client.download_char(
-                self._char,
-                self._dest_dir,
+            path = self.client.download_char(
+                self.char,
+                self.dest_dir,
                 progress_cb=progress,
-                auth_token=self._auth_token,
+                auth_token=self.auth_token,
             )
             char_catalog.record_installed(
                 char_id,
-                version=self._char.version,
-                source=f"server-{self._char.tier}",
-                sha256=self._char.sha256,
-                size_bytes=self._char.size_bytes,
+                version=self.char.version,
+                source=f"server-{self.char.tier}",
+                sha256=self.char.sha256,
+                size_bytes=self.char.size_bytes,
             )
-            self._signals.download_finished.emit(char_id, str(path))
+            self.signals.download_finished.emit(char_id, str(path))
         except ShopError as exc:
-            self._signals.download_failed.emit(char_id, str(exc))
+            self.signals.download_failed.emit(char_id, str(exc))
         except Exception as exc:
             logger.exception("Unexpected error downloading %s", char_id)
-            self._signals.download_failed.emit(char_id, f"Unexpected error: {exc}")
+            self.signals.download_failed.emit(char_id, f"Unexpected error: {exc}")
 
 
-class _PreviewWorker(QtCore.QRunnable):
-    def __init__(self, client: ShopClient, signals: _Signals, char: CharEntry) -> None:
+class PreviewWorker(QtCore.QRunnable):
+    def __init__(self, client: ShopClient, signals: Signals, char: CharEntry) -> None:
         super().__init__()
-        self._client = client
-        self._signals = signals
-        self._char = char
+        self.client = client
+        self.signals = signals
+        self.char = char
 
     def run(self) -> None:
-        path = self._client.fetch_preview(self._char)
+        path = self.client.fetch_preview(self.char)
         if path is not None:
-            self._signals.preview_ready.emit(self._char.id, str(path))
+            self.signals.preview_ready.emit(self.char.id, str(path))
 
 
 # --- cards --------------------------------------------------------------------
 
 
-class _CharCard(QtWidgets.QFrame):
+class CharCard(QtWidgets.QFrame):
     install_requested = QtCore.Signal(str)
     uninstall_requested = QtCore.Signal(str)
 
@@ -167,12 +167,12 @@ class _CharCard(QtWidgets.QFrame):
         layout.addWidget(self.progress)
 
         self.button = QtWidgets.QPushButton()
-        self.button.clicked.connect(self._on_button)
+        self.button.clicked.connect(self.on_button)
         layout.addWidget(self.button)
 
-        self._refresh_button()
+        self.refresh_button()
 
-    def _on_button(self) -> None:
+    def on_button(self) -> None:
         if self.installed:
             self.uninstall_requested.emit(self.char.id)
         else:
@@ -181,9 +181,9 @@ class _CharCard(QtWidgets.QFrame):
     def set_installed(self, installed: bool) -> None:
         self.installed = installed
         self.progress.setVisible(False)
-        self._refresh_button()
+        self.refresh_button()
 
-    def _refresh_button(self) -> None:
+    def refresh_button(self) -> None:
         if self.installed:
             self.button.setText("✓ Installed — Uninstall")
         else:
@@ -212,7 +212,7 @@ class _CharCard(QtWidgets.QFrame):
             movie.setScaledSize(QtCore.QSize(120, 120))
             self.preview_label.setMovie(movie)
             movie.start()
-            self._movie = movie
+            self.movie = movie
             return
         pixmap = QtGui.QPixmap(local_path)
         if not pixmap.isNull():
@@ -256,20 +256,20 @@ class ShopDialog(QtWidgets.QDialog):
 
         if base_url is None:
             base_url = resolve_base_url(config_path)
-        self._client = ShopClient(base_url)
-        self._signals = _Signals()
-        self._pool = QtCore.QThreadPool.globalInstance()
-        self._cards: dict[str, _CharCard] = {}
-        self._catalog: Catalog | None = None
-        self._user_chars_dir = char_catalog.ensure_user_chars_dir()
+        self.client = ShopClient(base_url)
+        self.signals = Signals()
+        self.pool = QtCore.QThreadPool.globalInstance()
+        self.cards: dict[str, CharCard] = {}
+        self.catalog: Catalog | None = None
+        self.user_chars_dir = char_catalog.ensure_user_chars_dir()
 
-        self._build_ui()
-        self._wire_signals()
-        self._refresh_catalog()
+        self.build_ui()
+        self.wire_signals()
+        self.refresh_catalog()
 
     # ---- UI build ---------------------------------------------------------
 
-    def _build_ui(self) -> None:
+    def build_ui(self) -> None:
         root = QtWidgets.QVBoxLayout(self)
         root.setContentsMargins(8, 8, 8, 8)
         root.setSpacing(6)
@@ -280,11 +280,11 @@ class ShopDialog(QtWidgets.QDialog):
         header.addWidget(self.title_label)
         header.addStretch(1)
         self.refresh_button = QtWidgets.QPushButton("Refresh")
-        self.refresh_button.clicked.connect(lambda: self._refresh_catalog(force=True))
+        self.refresh_button.clicked.connect(lambda: self.refresh_catalog(force=True))
         header.addWidget(self.refresh_button)
         root.addLayout(header)
 
-        self.url_label = QtWidgets.QLabel(f"Server: {self._client.base_url}")
+        self.url_label = QtWidgets.QLabel(f"Server: {self.client.base_url}")
         self.url_label.setStyleSheet("color:#888; font-size:11px;")
         root.addWidget(self.url_label)
 
@@ -311,7 +311,7 @@ class ShopDialog(QtWidgets.QDialog):
         my_chars_layout.addWidget(self.my_chars_list, 1)
         buttons = QtWidgets.QHBoxLayout()
         self.uninstall_button = QtWidgets.QPushButton("Uninstall selected")
-        self.uninstall_button.clicked.connect(self._uninstall_selected)
+        self.uninstall_button.clicked.connect(self.uninstall_selected)
         buttons.addWidget(self.uninstall_button)
         buttons.addStretch(1)
         my_chars_layout.addLayout(buttons)
@@ -322,114 +322,114 @@ class ShopDialog(QtWidgets.QDialog):
         self.status_label.setStyleSheet("color:#888;")
         root.addWidget(self.status_label)
 
-    def _wire_signals(self) -> None:
-        self._signals.catalog_ready.connect(self._on_catalog_ready)
-        self._signals.catalog_failed.connect(self._on_catalog_failed)
-        self._signals.download_progress.connect(self._on_download_progress)
-        self._signals.download_finished.connect(self._on_download_finished)
-        self._signals.download_failed.connect(self._on_download_failed)
-        self._signals.preview_ready.connect(self._on_preview_ready)
+    def wire_signals(self) -> None:
+        self.signals.catalog_ready.connect(self.on_catalog_ready)
+        self.signals.catalog_failed.connect(self.on_catalog_failed)
+        self.signals.download_progress.connect(self.on_download_progress)
+        self.signals.download_finished.connect(self.on_download_finished)
+        self.signals.download_failed.connect(self.on_download_failed)
+        self.signals.preview_ready.connect(self.on_preview_ready)
 
     # ---- catalog flow -----------------------------------------------------
 
-    def _refresh_catalog(self, *, force: bool = False) -> None:
+    def refresh_catalog(self, *, force: bool = False) -> None:
         self.status_label.setText("Loading catalog…")
         self.refresh_button.setEnabled(False)
-        worker = _CatalogWorker(self._client, self._signals, force_refresh=force)
-        self._pool.start(worker)
+        worker = CatalogWorker(self.client, self.signals, force_refresh=force)
+        self.pool.start(worker)
 
-    def _on_catalog_ready(self, catalog: Catalog) -> None:
-        self._catalog = catalog
+    def on_catalog_ready(self, catalog: Catalog) -> None:
+        self.catalog = catalog
         self.refresh_button.setEnabled(True)
-        self._render_catalog()
-        self._refresh_my_chars()
+        self.render_catalog()
+        self.refresh_my_chars()
         self.status_label.setText(f"{len(catalog.chars)} chars available.")
 
-    def _on_catalog_failed(self, message: str) -> None:
+    def on_catalog_failed(self, message: str) -> None:
         self.refresh_button.setEnabled(True)
         self.status_label.setText(f"⚠ {message}")
 
-    def _render_catalog(self) -> None:
+    def render_catalog(self) -> None:
         # Clear old cards
         while self.catalog_grid.count():
             item = self.catalog_grid.takeAt(0)
             widget = item.widget()
             if widget is not None:
                 widget.deleteLater()
-        self._cards.clear()
+        self.cards.clear()
 
-        if not self._catalog or not self._catalog.chars:
+        if not self.catalog or not self.catalog.chars:
             empty = QtWidgets.QLabel("No chars available.")
             empty.setStyleSheet("color:#888;")
             self.catalog_grid.addWidget(empty, 0, 0)
             return
 
         columns = 3
-        for index, char in enumerate(self._catalog.chars):
+        for index, char in enumerate(self.catalog.chars):
             row, col = divmod(index, columns)
             installed = char_catalog.is_user_installed(char.id)
-            card = _CharCard(char, installed=installed, parent=self.catalog_content)
-            card.install_requested.connect(self._install_char)
-            card.uninstall_requested.connect(self._uninstall_char)
-            self._cards[char.id] = card
+            card = CharCard(char, installed=installed, parent=self.catalog_content)
+            card.install_requested.connect(self.install_char)
+            card.uninstall_requested.connect(self.uninstall_char)
+            self.cards[char.id] = card
             self.catalog_grid.addWidget(card, row, col)
-            self._pool.start(_PreviewWorker(self._client, self._signals, char))
+            self.pool.start(PreviewWorker(self.client, self.signals, char))
 
     # ---- install / uninstall ----------------------------------------------
 
-    def _install_char(self, char_id: str) -> None:
-        if not self._catalog:
+    def install_char(self, char_id: str) -> None:
+        if not self.catalog:
             return
-        char = next((s for s in self._catalog.chars if s.id == char_id), None)
+        char = next((s for s in self.catalog.chars if s.id == char_id), None)
         if char is None:
             return
         if char.tier != "free":
             # Premium tiers require entitlements; not in MVP.
             self.status_label.setText(f"⚠ Premium char '{char.name}' requires a subscription (coming soon).")
             return
-        worker = _DownloadWorker(self._client, self._signals, char, self._user_chars_dir)
-        self._pool.start(worker)
+        worker = DownloadWorker(self.client, self.signals, char, self.user_chars_dir)
+        self.pool.start(worker)
         self.status_label.setText(f"Downloading {char.name}…")
 
-    def _on_download_progress(self, char_id: str, done: int, total: int) -> None:
-        card = self._cards.get(char_id)
+    def on_download_progress(self, char_id: str, done: int, total: int) -> None:
+        card = self.cards.get(char_id)
         if card is not None:
             card.set_progress(done, total)
 
-    def _on_download_finished(self, char_id: str, path: str) -> None:
-        card = self._cards.get(char_id)
+    def on_download_finished(self, char_id: str, path: str) -> None:
+        card = self.cards.get(char_id)
         if card is not None:
             card.set_installed(True)
         self.status_label.setText(f"Installed: {char_id}")
-        self._refresh_my_chars()
+        self.refresh_my_chars()
         self.char_installed.emit(char_id)
 
-    def _on_download_failed(self, char_id: str, message: str) -> None:
-        card = self._cards.get(char_id)
+    def on_download_failed(self, char_id: str, message: str) -> None:
+        card = self.cards.get(char_id)
         if card is not None:
             card.set_failed(message)
         self.status_label.setText(f"⚠ Failed: {char_id} — {message}")
 
-    def _uninstall_char(self, char_id: str) -> None:
+    def uninstall_char(self, char_id: str) -> None:
         if char_catalog.remove_installed(char_id):
-            card = self._cards.get(char_id)
+            card = self.cards.get(char_id)
             if card is not None:
                 card.set_installed(False)
             self.status_label.setText(f"Uninstalled: {char_id}")
-            self._refresh_my_chars()
+            self.refresh_my_chars()
             self.char_uninstalled.emit(char_id)
         else:
             self.status_label.setText(f"⚠ Could not uninstall {char_id}")
 
-    def _uninstall_selected(self) -> None:
+    def uninstall_selected(self) -> None:
         item = self.my_chars_list.currentItem()
         if item is None:
             return
         char_id = item.data(QtCore.Qt.ItemDataRole.UserRole)
         if char_id:
-            self._uninstall_char(char_id)
+            self.uninstall_char(char_id)
 
-    def _refresh_my_chars(self) -> None:
+    def refresh_my_chars(self) -> None:
         self.my_chars_list.clear()
         meta = char_catalog.load_installed_metadata()
         for entry in meta.get("characters", []):
@@ -438,8 +438,8 @@ class ShopDialog(QtWidgets.QDialog):
             item.setData(QtCore.Qt.ItemDataRole.UserRole, entry.get("id"))
             self.my_chars_list.addItem(item)
 
-    def _on_preview_ready(self, char_id: str, local_path: str) -> None:
-        card = self._cards.get(char_id)
+    def on_preview_ready(self, char_id: str, local_path: str) -> None:
+        card = self.cards.get(char_id)
         if card is not None:
             card.set_preview(local_path)
 

--- a/mycat/update_check.py
+++ b/mycat/update_check.py
@@ -12,6 +12,8 @@ import logging
 import threading
 import urllib.request
 
+from . import github_api
+
 logger = logging.getLogger(__name__)
 
 LATEST_RELEASE_URL = "https://api.github.com/repos/yumiaura/myCat/releases/latest"
@@ -56,12 +58,16 @@ def parse_version(text: str) -> tuple:
     return tuple(parts)
 
 
-def latest_release_tag(url: str = LATEST_RELEASE_URL, timeout: float = 6.0, opener=None) -> str | None:
-    """Return the latest GitHub release tag, or None on any error."""
+def latest_release_tag(
+    url: str = LATEST_RELEASE_URL, timeout: float = 6.0, opener=None, token: str = ""
+) -> str | None:
+    """Return the latest GitHub release tag, or None on any error.
+
+    ``token`` (a GitHub PAT) authenticates the request so it isn't subject to the
+    anonymous 60 req/h per-IP rate limit; entry points resolve it via
+    github_api.github_token()."""
     open_fn = opener or urllib.request.urlopen
-    request = urllib.request.Request(
-        url, headers={"User-Agent": "mycat", "Accept": "application/vnd.github+json"}
-    )
+    request = github_api.build_request(url, token=token)
     try:
         with open_fn(request, timeout=timeout) as response:
             data = json.loads(response.read().decode("utf-8"))
@@ -86,7 +92,7 @@ def check_in_background(current: str) -> None:
     """Fire the release check on a daemon thread; log if an update is available."""
 
     def run() -> None:
-        latest = newer_release(current)
+        latest = newer_release(current, token=github_api.github_token())
         if latest:
             logger.info(
                 "Update available: mycat %s (you have %s) — %s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.24"
+version = "0.1.25"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -108,7 +108,7 @@ def test_activity_settings_round_trip(tmp_path):
     # Each track flips independently: activity off, mouse on, keyboard off.
     save_activity_settings(
         ActivitySettings(
-            enabled=False, mouse_enabled=True, keyboard_enabled=False, retention_days=30, prompted=True
+            enabled=False, mouse_enabled=True, keyboard_enabled=False, retention_days=30
         ),
         cfg_file=cfg,
     )
@@ -116,7 +116,6 @@ def test_activity_settings_round_trip(tmp_path):
     assert loaded.enabled is False  # opt-out round-trips
     assert loaded.mouse_enabled is True
     assert loaded.keyboard_enabled is False
-    assert loaded.prompted is True
     assert loaded.retention_days == 30
 
 

--- a/tests/test_char_engine.py
+++ b/tests/test_char_engine.py
@@ -60,32 +60,32 @@ def test_pack_loads_all_state_assets(qapp, tmp_path, monkeypatch):
 def test_yawn_then_sleep_then_wake(qapp, tmp_path, monkeypatch):
     w, _ = make_window(qapp, tmp_path, monkeypatch)
 
-    w._test_now = 0.5
-    assert w._update_pack_frame() == "open"          # awake
+    w.test_now = 0.5
+    assert w.update_pack_frame() == "open"          # awake
 
-    w._test_now = 1.5                                # cursor still > yawn_after
-    assert w._update_pack_frame() == "anim"          # yawn one-shot
+    w.test_now = 1.5                                # cursor still > yawn_after
+    assert w.update_pack_frame() == "anim"          # yawn one-shot
     assert w.yawned is True
 
-    w._test_now = 1.8                                # yawn (100ms) finished
-    assert w._update_pack_frame() == "open"
+    w.test_now = 1.8                                # yawn (100ms) finished
+    assert w.update_pack_frame() == "open"
 
-    w._test_now = 2.5                                # idle > sleep_after -> sleep_in
-    assert w._update_pack_frame() == "anim"
-    w._test_now = 2.8                                # sleep_in finished -> sleeping
-    assert w._update_pack_frame() == "sleep"
+    w.test_now = 2.5                                # idle > sleep_after -> sleep_in
+    assert w.update_pack_frame() == "anim"
+    w.test_now = 2.8                                # sleep_in finished -> sleeping
+    assert w.update_pack_frame() == "sleep"
     assert w.base_state == "sleeping"
 
-    w._test_now = 3.0                                # interaction wakes -> sleep_out
-    w._wake(w._pack_now())
-    assert w._update_pack_frame() == "anim"
-    w._test_now = 3.3                                # sleep_out finished -> awake
-    assert w._update_pack_frame() == "open"
+    w.test_now = 3.0                                # interaction wakes -> sleep_out
+    w.wake(w.pack_now())
+    assert w.update_pack_frame() == "anim"
+    w.test_now = 3.3                                # sleep_out finished -> awake
+    assert w.update_pack_frame() == "open"
     assert w.base_state == "awake"
 
 
 def test_click_plays_reaction(qapp, tmp_path, monkeypatch):
     w, _ = make_window(qapp, tmp_path, monkeypatch)
-    w._test_now = 4.0
-    w._on_pack_click()
-    assert w._update_pack_frame() == "anim"          # click1 one-shot
+    w.test_now = 4.0
+    w.on_pack_click()
+    assert w.update_pack_frame() == "anim"          # click1 one-shot


### PR DESCRIPTION
## Summary

Maintainability pass on top of 0.1.24 — two user-facing fixes plus a large internal refactor with **no behaviour change** (full test suite green throughout). Bumps to **0.1.25**.

### Fixes (user-facing)
- **autostart shows "myCat"** (was `Name=mycat`, inconsistent with the app-menu entry).
- **Skin switch no longer half-updates the window on a bad char** — `load_image` decodes into locals first and commits only on success (mirrors `switch_to_pack`); the old char (pack or legacy) stays fully intact on failure.

### Config consolidation (no behaviour change)
- **`paths.py`** — single source of truth for the config path (`~/.config/mycat`, unchanged on every OS), replacing the hardcoded `CFG_DIR` in 9 modules.
- **`config_store.py`** — shared `read_config` / `write_section` / `remove_section` / `bool_str`, replacing the per-feature ConfigParser copy-paste. Migrated: activity, focus, calendar, reminder, digest, github_notify. Per-field logic and legacy-key fallbacks stay in each feature; module `CFG_DIR`/`CFG_FILE` kept so tests' monkeypatching is unchanged.

### No leading-underscore identifiers (house style, whole repo)
Renamed every single-underscore identifier to a plain public name across **ai_char, llm_prompt, reminder, shop_api, main.py, shop_ui, llm_ui, reminder_ui** — ~600 sites. Handled along the way: collapsed a passthrough `reminder` property and a redundant `_toggle_chat` delegator; coordinated the four cross-file window hooks (set by `llm_ui`, read by `main.py`/`llm_settings_ui`); kept dunders and external `_MEIPASS`/`_PYI_*`. Final sweep confirms **no single-underscore identifiers remain in `mycat/`**.

### Small cleanups
- Fix stale contributor paths in `CLAUDE.md` (`chars/` folder + "Chars" menu, not `skins/`/"Images").
- Drop the dead `ActivitySettings.prompted` field and `llm_prompt`'s dead `_LEGACY_PROMPT_TEMPLATE_PATH`.

## Test plan

- [x] `ruff check .` clean (incl. F811 redefinition — catches rename collisions)
- [x] Full suite green throughout (226 tests), run in two batches to dodge a flaky offscreen-Qt teardown segfault
- [x] Config round-trip tests pass with each module's `CFG_FILE` monkeypatched (surface preserved)
- [x] Skin-switch fix verified end-to-end: happy path + two failure paths (no half-switch)
- [x] Both run modes import (`python -m mycat`, `python mycat/main.py`); class-introspection confirms no private methods remain on the renamed classes
- [ ] Manual: launch the app and exercise the untested UI dialogs (shop/llm/reminder) — GUI launch is flaky in CI's headless env, so verified by import + introspection instead