### PR TITLE
fix: bust the desktop icon cache with a content-hashed filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## Unreleased
+## [0.1.28] - 2026-07-27
 
 ### Fixed
 - **The Linux launcher icon actually updates when the app updates.** `install_desktop_entry()` copied the icon to a single stable path (`~/.local/share/mycat/icon.png`) and overwrote it in place. Desktop icon caches (GNOME/KDE) key on the path and kept serving the old bitmap, so after a `pip install -U mycat` the applications-menu / taskbar icon stayed on the previous cat. The copy is now named after the icon's content hash (`icon-<hash>.png`) and referenced from `Icon=`, so a changed icon lands at a fresh path the cache can't stale; older copies (and the legacy `icon.png`) are cleaned up. The running app's in-memory window icon still needs a restart, as before (branch `fix/desktop-icon-cache-bust`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Fixed
+- **The Linux launcher icon actually updates when the app updates.** `install_desktop_entry()` copied the icon to a single stable path (`~/.local/share/mycat/icon.png`) and overwrote it in place. Desktop icon caches (GNOME/KDE) key on the path and kept serving the old bitmap, so after a `pip install -U mycat` the applications-menu / taskbar icon stayed on the previous cat. The copy is now named after the icon's content hash (`icon-<hash>.png`) and referenced from `Icon=`, so a changed icon lands at a fresh path the cache can't stale; older copies (and the legacy `icon.png`) are cleaned up. The running app's in-memory window icon still needs a restart, as before (branch `fix/desktop-icon-cache-bust`).
+
 ## [0.1.27] - 2026-07-27
 
 ### Changed

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -12,6 +12,7 @@ pip install PySide6
 import argparse
 import configparser
 import getpass
+import hashlib
 import io
 import logging
 import math
@@ -2037,14 +2038,29 @@ def install_desktop_entry() -> None:
     source_icon = assets_dir() / "icon.png"
     if not source_icon.is_file():
         return
-    # Copy the icon to a stable path and reference it ABSOLUTELY in Icon= — the
-    # themed `Icon=mycat` form needs the user icon dir to be a full hicolor theme
-    # (index.theme + right size folder) and a refreshed cache, which often isn't
-    # there; an absolute path just works.
-    icon_target = share / "mycat" / "icon.png"
+    # Copy the icon and reference it ABSOLUTELY in Icon= — the themed `Icon=mycat`
+    # form needs the user icon dir to be a full hicolor theme (index.theme + right
+    # size folder) and a refreshed cache, which often isn't there; an absolute
+    # path just works.
+    #
+    # Name the copy after its content hash (icon-<hash>.png). A single stable path
+    # overwritten in place is invisible to desktop icon caches (GNOME/KDE keep
+    # serving the old bitmap for that path), so an updated app kept showing the
+    # old launcher icon. A fresh filename whenever the image changes sidesteps the
+    # cache entirely.
+    icon_dir = share / "mycat"
     try:
-        icon_target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(source_icon, icon_target)
+        digest = hashlib.sha256(source_icon.read_bytes()).hexdigest()[:12]
+        icon_target = icon_dir / f"icon-{digest}.png"
+        icon_dir.mkdir(parents=True, exist_ok=True)
+        if not icon_target.is_file():
+            shutil.copyfile(source_icon, icon_target)
+        # Drop older copies (previous hashes and the legacy stable-path icon.png)
+        # so the folder does not accumulate stale icons.
+        for stale in icon_dir.glob("icon-*.png"):
+            if stale != icon_target:
+                stale.unlink(missing_ok=True)
+        (icon_dir / "icon.png").unlink(missing_ok=True)
         user_desktop.parent.mkdir(parents=True, exist_ok=True)
         user_desktop.write_text(
             "[Desktop Entry]\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.27"
+version = "0.1.28"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

After a `pip install -U mycat`, the Linux applications-menu / taskbar icon kept showing the **previous** cat even though the released package (verified: the PyPI 0.1.27 wheel carries the new `icon.png` byte-for-byte) and the file on disk were already the new one.

**Cause:** `install_desktop_entry()` copied the icon to a single stable path (`~/.local/share/mycat/icon.png`) and overwrote it **in place**. Desktop icon caches (GNOME, KDE) key on the path, so they kept serving the old bitmap for that path.

**Fix:** name the copy after the icon's **content hash** (`icon-<hash>.png`) and reference it from `Icon=`. A changed icon now lands at a fresh path the cache can't stale. Older copies and the legacy `icon.png` are cleaned up so the folder doesn't accumulate.

The downgrade guard is untouched; `Icon=` stays an absolute path to an existing file. The running process's **in-memory window icon** still needs an app restart — that's inherent and unchanged.

## Test plan

- [x] `tests/test_desktop_entry.py` passes (3 passed) — `Icon=` is an absolute path to an existing file; never downgrades.
- [x] Functional smoke into a temp `HOME`: after install, the icon dir holds only `icon-<hash>.png`; a seeded legacy `icon.png` and an old `icon-*.png` are removed; `Icon=` points at the new hashed file and it exists.
- [ ] On a real GNOME/KDE box: `pip install -U`, launch once, and the menu icon updates without a re-login (previously needed a cache flush).