### PR TITLE
feat: hide unused menu entries via the Settings dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Hide menu entries you don't use.** A new **Settings…** entry (right-click / tray) opens the Settings dialog, where a *Show in menu* section lets you hide feature entries — Chat, LLM, Calendar, Reminder, GitHub, Activity, Chars — from both the cat's right-click menu and the tray menu. Hiding an entry only removes the shortcut; the feature keeps running. Settings, Quit and Close are always shown (branch `feat/menu-toggles`).
+
 ## [0.1.28] - 2026-07-27
 
 ### Fixed

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -41,6 +41,7 @@ if __package__:
         github_api,
         github_notify,
         llm,
+        menu_config,
         paths,
         reminder,
         secret_store,
@@ -53,6 +54,7 @@ else:
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
     llm = importlib.import_module("mycat.llm")
+    menu_config = importlib.import_module("mycat.menu_config")
     paths = importlib.import_module("mycat.paths")
     char_catalog = importlib.import_module("mycat.char_catalog")
     reminder = importlib.import_module("mycat.reminder")
@@ -1136,11 +1138,12 @@ class PixelCatWindow(QtWidgets.QWidget):
     def show_context_menu(self, pos: QtCore.QPoint) -> None:
         """Show context menu at the given position."""
         menu = QtWidgets.QMenu(self)
+        visible = menu_config.load_menu_visibility()
 
         # "Chat" appears only once Ollama is configured (a controller exists),
         # and is greyed out while the LLM is disabled.
         toggle_chat = getattr(self, "toggle_llm_chat", None)
-        if callable(toggle_chat):
+        if callable(toggle_chat) and visible["chat"]:
             chat_action = menu.addAction("Chat")
             chat_action.triggered.connect(toggle_chat)
             llm_is_enabled = getattr(self, "is_llm_enabled", None)
@@ -1148,22 +1151,18 @@ class PixelCatWindow(QtWidgets.QWidget):
                 chat_action.setEnabled(bool(llm_is_enabled()))
             menu.addSeparator()
 
-        # Settings entries, in the agreed order: LLM, Calendar, Reminder,
-        # GitHub, Activity.
-        llm_action = menu.addAction("LLM…")
-        llm_action.triggered.connect(self.open_llm_settings)
-
-        calendar_action = menu.addAction("Calendar…")
-        calendar_action.triggered.connect(self.open_calendar_settings)
-
-        reminder_action = menu.addAction("Reminder…")
-        reminder_action.triggered.connect(self.open_reminder)
-
-        github_action = menu.addAction("GitHub…")
-        github_action.triggered.connect(self.open_github_settings)
-
-        activity_action = menu.addAction("Activity…")
-        activity_action.triggered.connect(self.open_activity_dialog)
+        # Feature entries, in the agreed order: LLM, Calendar, Reminder,
+        # GitHub, Activity. Each can be hidden from the Settings dialog.
+        if visible["llm"]:
+            menu.addAction("LLM…").triggered.connect(self.open_llm_settings)
+        if visible["calendar"]:
+            menu.addAction("Calendar…").triggered.connect(self.open_calendar_settings)
+        if visible["reminder"]:
+            menu.addAction("Reminder…").triggered.connect(self.open_reminder)
+        if visible["github"]:
+            menu.addAction("GitHub…").triggered.connect(self.open_github_settings)
+        if visible["activity"]:
+            menu.addAction("Activity…").triggered.connect(self.open_activity_dialog)
 
         # Shop temporarily hidden from the menu (work in progress). The dialog
         # and its handler stay in the codebase; re-enable by uncommenting:
@@ -1175,7 +1174,7 @@ class PixelCatWindow(QtWidgets.QWidget):
 
         # Rebuild the list every time so freshly-installed chars appear without restart.
         self.available_images = char_catalog.scan_all()
-        if len(self.available_images) > 0:
+        if len(self.available_images) > 0 and visible["chars"]:
             images_menu = menu.addMenu("Chars")
             create_action = images_menu.addAction("Generate…")
             create_action.triggered.connect(self.open_ai_char)
@@ -1195,6 +1194,11 @@ class PixelCatWindow(QtWidgets.QWidget):
                     action.setChecked(True)
                 action.triggered.connect(lambda checked, name=img_name: self.load_image(name))
             menu.addSeparator()
+
+        # Settings is always shown (never hideable) — it's how hidden entries
+        # are brought back.
+        settings_action = menu.addAction("Settings…")
+        settings_action.triggered.connect(self.open_settings)
 
         reset_action = menu.addAction("Reset")
         reset_action.triggered.connect(self.reset_position)
@@ -1218,6 +1222,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         else:
             quit_action = menu.addAction("Quit")
             quit_action.triggered.connect(QtWidgets.QApplication.quit)
+        tidy_separators(menu)
         menu.exec(self.mapToGlobal(pos))
 
     def open_ai_char(self) -> None:
@@ -1270,6 +1275,21 @@ class PixelCatWindow(QtWidgets.QWidget):
             logger.exception("Failed to import LLM settings dialog")
             return
         dialog = LLMSettingsDialog(self, parent=self)
+        dialog.exec()
+
+    def open_settings(self) -> None:
+        """Open the general Settings dialog (wait time + which menu entries show)."""
+        try:
+            if __package__:
+                from .settings_ui import SettingsDialog
+            else:
+                import importlib
+
+                SettingsDialog = importlib.import_module("mycat.settings_ui").SettingsDialog
+        except Exception:
+            logger.exception("Failed to import Settings dialog")
+            return
+        dialog = SettingsDialog(self, config_path=CFG_FILE, main_window=self)
         dialog.exec()
 
     def open_github_settings(self) -> None:
@@ -1957,6 +1977,22 @@ def ensure_emoji_font(app) -> None:
     logger.info("No system emoji font — using the bundled %s fallback", bundled[0])
 
 
+def tidy_separators(menu: QtWidgets.QMenu) -> None:
+    """Drop leading, trailing and doubled separators left after hiding entries."""
+    prev_was_separator = True  # treat the top as a separator -> removes a leading one
+    for action in menu.actions():
+        if action.isSeparator():
+            if prev_was_separator:
+                menu.removeAction(action)
+            else:
+                prev_was_separator = True
+        else:
+            prev_was_separator = False
+    trailing = menu.actions()
+    if trailing and trailing[-1].isSeparator():
+        menu.removeAction(trailing[-1])
+
+
 def assets_dir() -> Path:
     """The bundled ``mycat/assets`` directory.
 
@@ -2109,40 +2145,47 @@ def setup_tray(app, window):
             show_window()
 
     menu = QtWidgets.QMenu(window)
-    toggle_chat = getattr(window, "toggle_llm_chat", None)
-    if callable(toggle_chat):
-        menu.addAction("Chat", toggle_chat)
-    # Same order as the context menu: LLM, Calendar, Reminder, GitHub, Activity.
-    menu.addAction("LLM…", window.open_llm_settings)
-    menu.addAction("Calendar…", window.open_calendar_settings)
-    menu.addAction("Reminder…", window.open_reminder)
-    menu.addAction("GitHub…", window.open_github_settings)
-    menu.addAction("Activity…", window.open_activity_dialog)
 
-    # Focus is fully automatic now (earned from activity) — no tray toggle.
+    def populate_tray_menu():
+        """Rebuild the tray menu each time it opens, honouring the hidden-entry
+        settings and showing the correct Open/Close label."""
+        menu.clear()
+        visible = menu_config.load_menu_visibility()
+        toggle_chat = getattr(window, "toggle_llm_chat", None)
+        if callable(toggle_chat) and visible["chat"]:
+            menu.addAction("Chat", toggle_chat)
+        # Same order as the context menu: LLM, Calendar, Reminder, GitHub, Activity.
+        if visible["llm"]:
+            menu.addAction("LLM…", window.open_llm_settings)
+        if visible["calendar"]:
+            menu.addAction("Calendar…", window.open_calendar_settings)
+        if visible["reminder"]:
+            menu.addAction("Reminder…", window.open_reminder)
+        if visible["github"]:
+            menu.addAction("GitHub…", window.open_github_settings)
+        if visible["activity"]:
+            menu.addAction("Activity…", window.open_activity_dialog)
 
-    menu.addAction("Reset", window.reset_position)
-    menu.addAction("Update…", window.open_update)
-    if autostart.is_supported():
+        # Settings is always shown — it's how hidden entries are brought back.
+        menu.addAction("Settings…", window.open_settings)
+        menu.addAction("Reset", window.reset_position)
+        menu.addAction("Update…", window.open_update)
+        if autostart.is_supported():
+            menu.addSeparator()
+            login_action = menu.addAction("Autostart")
+            login_action.setCheckable(True)
+            login_action.setChecked(autostart.is_enabled())
+            login_action.toggled.connect(autostart.set_enabled)
         menu.addSeparator()
-        login_action = menu.addAction("Autostart")
-        login_action.setCheckable(True)
-        login_action.setChecked(autostart.is_enabled())
-        login_action.toggled.connect(autostart.set_enabled)
-    menu.addSeparator()
-    toggle_action = menu.addAction("Close")
-    toggle_action.triggered.connect(toggle_window)
-    menu.addAction("Quit", QtWidgets.QApplication.quit)
-    # Dynamic label: "Open" when the cat is hidden, "Close" when it's on screen.
-    menu.aboutToShow.connect(
-        lambda: toggle_action.setText("Open" if not window.isVisible() else "Close")
-    )
+        # Dynamic label: "Open" when the cat is hidden, "Close" when on screen.
+        toggle_action = menu.addAction("Close" if window.isVisible() else "Open")
+        toggle_action.triggered.connect(toggle_window)
+        menu.addAction("Quit", QtWidgets.QApplication.quit)
+        tidy_separators(menu)
+
+    populate_tray_menu()
+    menu.aboutToShow.connect(populate_tray_menu)
     tray.setContextMenu(menu)
-
-    def sync_toggle_label():
-        toggle_action.setText("Close" if window.isVisible() else "Open")
-
-    menu.aboutToShow.connect(sync_toggle_label)
 
     def on_activated(reason):
         if reason == QtWidgets.QSystemTrayIcon.ActivationReason.DoubleClick:

--- a/mycat/menu_config.py
+++ b/mycat/menu_config.py
@@ -1,0 +1,49 @@
+"""Which feature entries appear in the cat / tray menus.
+
+Users can hide the feature entries they don't use (right-click / tray menu) from
+the Settings dialog; the choice lives in the ``[menu]`` section of config.ini.
+The utility entries (Reset / Update / Autostart), Settings itself and Close /
+Quit are always shown, so the app stays manageable and the toggles can always be
+reached again. Hiding an entry only removes the menu shortcut — the feature
+itself (reminders firing, activity tracking, …) keeps running.
+"""
+
+from pathlib import Path
+
+from . import config_store, paths
+
+MENU_SECTION = "menu"
+
+# (config key, menu label) for the hideable feature entries, in menu order.
+# "chars" only appears in the cat's right-click menu; the rest appear in both.
+MENU_ITEMS = [
+    ("chat", "Chat"),
+    ("llm", "LLM…"),
+    ("calendar", "Calendar…"),
+    ("reminder", "Reminder…"),
+    ("github", "GitHub…"),
+    ("activity", "Activity…"),
+    ("chars", "Chars"),
+]
+
+
+def load_menu_visibility(cfg_file: Path | None = None) -> dict:
+    """Map each menu entry key to whether it should be shown (default: all shown)."""
+    cfg_file = cfg_file or paths.config_file()
+    visible = {key: True for key, _ in MENU_ITEMS}
+    config = config_store.read_config(cfg_file)
+    if config is not None and config.has_section(MENU_SECTION):
+        for key, _ in MENU_ITEMS:
+            if config.has_option(MENU_SECTION, key):
+                try:
+                    visible[key] = config.getboolean(MENU_SECTION, key)
+                except ValueError:
+                    visible[key] = True
+    return visible
+
+
+def save_menu_visibility(visible: dict, cfg_file: Path | None = None) -> None:
+    """Persist the shown/hidden state of every menu entry into ``[menu]``."""
+    cfg_file = cfg_file or paths.config_file()
+    values = {key: config_store.bool_str(bool(visible.get(key, True))) for key, _ in MENU_ITEMS}
+    config_store.write_section(MENU_SECTION, values, cfg_file)

--- a/mycat/settings_ui.py
+++ b/mycat/settings_ui.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from PySide6 import QtWidgets
 
+from . import menu_config
+
 logger = logging.getLogger(__name__)
 
 class SettingsDialog(QtWidgets.QDialog):
@@ -33,6 +35,18 @@ class SettingsDialog(QtWidgets.QDialog):
         wait_layout.addWidget(wait_label)
         wait_layout.addWidget(self.wait_spinbox)
         layout.addLayout(wait_layout)
+
+        # Which feature entries show in the right-click / tray menu.
+        menu_group = QtWidgets.QGroupBox("Show in menu")
+        menu_group_layout = QtWidgets.QVBoxLayout(menu_group)
+        visible = menu_config.load_menu_visibility(self.config_path)
+        self.menu_checkboxes = {}
+        for key, label in menu_config.MENU_ITEMS:
+            checkbox = QtWidgets.QCheckBox(label.replace("…", ""))
+            checkbox.setChecked(visible.get(key, True))
+            self.menu_checkboxes[key] = checkbox
+            menu_group_layout.addWidget(checkbox)
+        layout.addWidget(menu_group)
 
         # Buttons
         button_box = QtWidgets.QDialogButtonBox(
@@ -70,5 +84,14 @@ class SettingsDialog(QtWidgets.QDialog):
             except Exception as e:
                 logger.error(f"Error saving settings to INI file: {e}")
                 QtWidgets.QMessageBox.critical(self, "Error", f"Failed to save settings:\n{e}")
+
+        # Persist which feature entries appear in the cat / tray menus.
+        try:
+            menu_config.save_menu_visibility(
+                {key: box.isChecked() for key, box in self.menu_checkboxes.items()},
+                self.config_path,
+            )
+        except Exception as e:
+            logger.error(f"Error saving menu visibility: {e}")
 
         super().accept()

--- a/tests/test_menu_config.py
+++ b/tests/test_menu_config.py
@@ -1,0 +1,33 @@
+"""Menu-entry visibility: defaults, persistence, and robustness."""
+
+from mycat import menu_config
+
+
+def test_all_entries_shown_by_default(tmp_path):
+    visible = menu_config.load_menu_visibility(tmp_path / "config.ini")
+    assert set(visible) == {key for key, _ in menu_config.MENU_ITEMS}
+    assert all(visible.values())
+
+
+def test_save_and_load_roundtrip(tmp_path):
+    cfg = tmp_path / "config.ini"
+    menu_config.save_menu_visibility({"chat": False, "github": False}, cfg)
+    visible = menu_config.load_menu_visibility(cfg)
+    assert visible["chat"] is False
+    assert visible["github"] is False
+    assert visible["reminder"] is True  # unlisted keys default to shown
+
+
+def test_bad_value_falls_back_to_shown(tmp_path):
+    cfg = tmp_path / "config.ini"
+    cfg.write_text("[menu]\nchat = notabool\n")
+    assert menu_config.load_menu_visibility(cfg)["chat"] is True
+
+
+def test_save_keeps_other_sections(tmp_path):
+    cfg = tmp_path / "config.ini"
+    cfg.write_text("[settings]\nwait_time = 3.0\n")
+    menu_config.save_menu_visibility({"activity": False}, cfg)
+    text = cfg.read_text()
+    assert "wait_time = 3.0" in text  # [settings] left intact
+    assert menu_config.load_menu_visibility(cfg)["activity"] is False


### PR DESCRIPTION
## Summary

Adds settings to **hide feature entries you don't use** from the cat's
right-click menu and the tray menu.

- New **Settings…** entry (always shown) opens the Settings dialog. It previously
  had no menu entry and was effectively unreachable — this wires it up.
- A **Show in menu** section in Settings toggles each feature entry: Chat, LLM,
  Calendar, Reminder, GitHub, Activity, Chars.
- Choices persist in the `[menu]` section of `config.ini` (all shown by default).
- Applies to **both** menus; the tray menu is rebuilt on open so toggles take
  effect live. Leftover separators are tidied when entries are hidden.
- **Settings, Quit and Close are never hideable**, so hidden entries can always
  be brought back.
- Hiding an entry only removes the menu shortcut — the feature itself (reminders
  firing, activity tracking, …) keeps running.

## Test plan

- [x] `ruff check .` clean
- [x] `tests/test_menu_config.py` — defaults (all shown), save/load round-trip,
  bad-value fallback, other config sections preserved
- [x] `tests/test_llm_settings_dialog.py` still green
- [ ] Manual: hide a few entries in Settings → gone from both menus; re-enable via
  Settings → back; Settings/Quit/Close always present