### PR TITLE
feat: i18n — add English/Simplified Chinese language switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ mycat                 # or, without installing:  python3 mycat/main.py
 - **Reminder** 🛩️ - set a message and a time (one-shot or daily) and the cat flies a little banner plane across the top of your screen. Right-click → *Reminder…* to set the message, direction, plane and color.
 - **Chat (Ollama)** 💬 - talk to the cat through a **local [Ollama](https://ollama.com) model**, no account or API key needed (see below).
 - **Create with AI** 🎨 - turn 1–3 photos into a custom chibi cat character with your own OpenAI key (right-click → *Chars → Create custom with AI…*). Reference photos are never stored; the result is an ordinary local char you can reuse or delete.
+- **Language** 🌐 — right-click the cat → **Language** to switch between English and Simplified Chinese at any time. The choice is remembered for next time.
 
 ## 💬 Chat with the cat (Ollama)
 

--- a/mycat/activity_ui.py
+++ b/mycat/activity_ui.py
@@ -16,15 +16,18 @@ from PySide6 import QtCore, QtGui, QtWidgets
 if __package__:
     from . import activity as activity_mod
     from . import focus as focus_mod
+    from . import i18n
     from .ui_theme import LIGHT_QSS
 else:
     import importlib
 
     activity_mod = importlib.import_module("mycat.activity")
     focus_mod = importlib.import_module("mycat.focus")
+    i18n = importlib.import_module("mycat.i18n")
     LIGHT_QSS = importlib.import_module("mycat.ui_theme").LIGHT_QSS
 
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 
 KIND_ICONS = {"focus": "🍅", "break": "☕", "long_break": "☕", "work": "💻"}
 
@@ -34,7 +37,17 @@ KIND_ICONS = {"focus": "🍅", "break": "☕", "long_break": "☕", "work": "�
 # no text glyph so it stays a colour emoji; the cursor's travel uses a plain path
 # symbol (⤳) that always renders monochrome.
 MONO = "︎"
-TABLE_COLUMNS = ["Session", "Duration", f"⌨{MONO} Keys", f"🖱{MONO} Mouse", "Active"]
+
+
+def table_columns() -> list:
+    """Column headers for the activity table (translated live)."""
+    return [
+        tr("Session"),
+        tr("Duration"),
+        f"⌨{MONO} {tr('Keys')}",
+        f"🖱{MONO} {tr('Mouse')}",
+        tr("Active"),
+    ]
 
 
 def active_pct(active_minutes: int, window_minutes: int) -> str:
@@ -228,7 +241,7 @@ class ActivityDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.collector = collector
         self.focus_controller = focus_controller
-        self.setWindowTitle("Activity")
+        self.setWindowTitle(tr("Activity"))
         self.setModal(False)
         self.setMinimumWidth(720)
         self.resize(760, 560)
@@ -255,36 +268,36 @@ class ActivityDialog(QtWidgets.QDialog):
 
         # Three independent toggles: Tracking drives only the cat's eyes, while
         # Mouse and Keyboard are the diary count tracks. None greys out the others.
-        self.enabled_box = QtWidgets.QCheckBox("Tracking")
+        self.enabled_box = QtWidgets.QCheckBox(tr("Tracking"))
         self.enabled_box.setToolTip(
-            "The cat's eyes follow your cursor; off, it looks at its own nose.\n"
-            "Purely visual — it records nothing."
+            tr("The cat's eyes follow your cursor; off, it looks at its own nose.\n"
+               "Purely visual — it records nothing.")
         )
         self.enabled_box.setChecked(settings.enabled)
-        self.mouse_box = QtWidgets.QCheckBox("Mouse")
-        self.mouse_box.setToolTip("Mouse click count in the private diary (never targets).")
+        self.mouse_box = QtWidgets.QCheckBox(tr("Mouse"))
+        self.mouse_box.setToolTip(tr("Mouse click count in the private diary (never targets)."))
         self.mouse_box.setChecked(settings.mouse_enabled)
-        self.keyboard_box = QtWidgets.QCheckBox("Keyboard")
-        self.keyboard_box.setToolTip("Keystroke count in the diary (never which keys).")
+        self.keyboard_box = QtWidgets.QCheckBox(tr("Keyboard"))
+        self.keyboard_box.setToolTip(tr("Keystroke count in the diary (never which keys)."))
         self.keyboard_box.setChecked(settings.keyboard_enabled)
         # Opt-in per-key heatmap collection (off by default). Session-only,
         # aggregate counts in memory — feeds the Keyboard heatmap window.
-        self.collect_box = QtWidgets.QCheckBox("Heatmap")
+        self.collect_box = QtWidgets.QCheckBox(tr("Heatmap"))
         self.collect_box.setToolTip(
-            "Count key presses per key for the Heatmap window. Aggregate counts only —\n"
-            "never the order, timing or text — kept in memory and gone on restart."
+            tr("Count key presses per key for the Heatmap window. Aggregate counts only —\n"
+               "never the order, timing or text — kept in memory and gone on restart.")
         )
         self.collect_box.setChecked(settings.key_heatmap_enabled)
         # Independent of the tracking tracks: whether hovering the cat shows the
         # live stats tooltip (driven by the FocusController).
-        self.tooltip_box = QtWidgets.QCheckBox("Tooltip")
-        self.tooltip_box.setToolTip("Show the live focus/activity stats when you hover over the cat.")
+        self.tooltip_box = QtWidgets.QCheckBox(tr("Tooltip"))
+        self.tooltip_box.setToolTip(tr("Show the live focus/activity stats when you hover over the cat."))
         self.tooltip_box.setChecked(self.tooltip_enabled())
         # An "Enable:" label leads the four toggles; the destructive Delete-all
         # lives in the bottom bar (next to Export) so this row never runs out of
         # width.
         toggles_row = QtWidgets.QHBoxLayout()
-        toggles_row.addWidget(QtWidgets.QLabel("Enable:"))
+        toggles_row.addWidget(QtWidgets.QLabel(tr("Enable:")))
         toggles_row.addWidget(self.enabled_box)
         toggles_row.addSpacing(16)
         toggles_row.addWidget(self.mouse_box)
@@ -298,8 +311,8 @@ class ActivityDialog(QtWidgets.QDialog):
         # it's unavailable here. The cursor path and the eyes work without it.
         if not activity_mod.counts_available():
             hint = QtWidgets.QLabel(
-                "Key/click counts aren't available here (needs X11, or macOS Input "
-                "Monitoring permission) — the cursor path still records."
+                tr("Key/click counts aren't available here (needs X11, or macOS Input "
+                   "Monitoring permission) — the cursor path still records.")
             )
             hint.setTextFormat(QtCore.Qt.TextFormat.RichText)
             hint.setWordWrap(True)
@@ -307,25 +320,25 @@ class ActivityDialog(QtWidgets.QDialog):
             layout.addWidget(hint)
 
         controls_row = QtWidgets.QHBoxLayout()
-        controls_row.addWidget(QtWidgets.QLabel("Show:"))
+        controls_row.addWidget(QtWidgets.QLabel(tr("Show:")))
         self.day_combo = QtWidgets.QComboBox()
-        self.day_combo.addItems(["Today", "Yesterday"])
+        self.day_combo.addItems([tr("Today"), tr("Yesterday")])
         self.day_combo.currentIndexChanged.connect(self.refresh_log)
         controls_row.addWidget(self.day_combo)
         controls_row.addSpacing(16)
         # The Pomodoro goal: a run this long earns a 🍅 (persisted to [focus]).
-        controls_row.addWidget(QtWidgets.QLabel("Pomodoro goal:"))
+        controls_row.addWidget(QtWidgets.QLabel(tr("Pomodoro goal:")))
         self.goal_spin = QtWidgets.QSpinBox()
         self.goal_spin.setRange(1, 240)
         self.goal_spin.setValue(self.focus_minutes())
-        self.goal_spin.setSuffix(" min")
+        self.goal_spin.setSuffix(tr(" min"))
         controls_row.addWidget(self.goal_spin)
         controls_row.addSpacing(16)
-        controls_row.addWidget(QtWidgets.QLabel("History:"))
+        controls_row.addWidget(QtWidgets.QLabel(tr("History:")))
         self.retention_spin = QtWidgets.QSpinBox()
         self.retention_spin.setRange(7, 3650)
         self.retention_spin.setValue(settings.retention_days)
-        self.retention_spin.setSuffix(" days")
+        self.retention_spin.setSuffix(tr(" days"))
         controls_row.addWidget(self.retention_spin)
         controls_row.addStretch(1)
         layout.addLayout(controls_row)
@@ -335,10 +348,10 @@ class ActivityDialog(QtWidgets.QDialog):
         self.timeline = DayTimeline()
         layout.addWidget(self.timeline)
         legend = QtWidgets.QLabel(
-            "<span style='color:#8bbf8b'>■</span> rest"
-            "&nbsp;&nbsp;&nbsp;<span style='color:#c0392b'>■</span> active"
-            "&nbsp;&nbsp;&nbsp;<span style='color:#c4c4cc'>■</span> future"
-            "&nbsp;&nbsp;&nbsp;<span style='color:#1f6feb'>│</span> now"
+            f"<span style='color:#8bbf8b'>■</span> {tr('rest')}"
+            f"&nbsp;&nbsp;&nbsp;<span style='color:#c0392b'>■</span> {tr('active')}"
+            f"&nbsp;&nbsp;&nbsp;<span style='color:#c4c4cc'>■</span> {tr('future')}"
+            f"&nbsp;&nbsp;&nbsp;<span style='color:#1f6feb'>│</span> {tr('now')}"
         )
         legend.setTextFormat(QtCore.Qt.TextFormat.RichText)
         legend.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -346,8 +359,8 @@ class ActivityDialog(QtWidgets.QDialog):
         # the swatch squares and the "now" bar are colour-coded (inline spans).
         layout.addWidget(legend)
 
-        self.table = QtWidgets.QTableWidget(0, len(TABLE_COLUMNS))
-        self.table.setHorizontalHeaderLabels(TABLE_COLUMNS)
+        self.table = QtWidgets.QTableWidget(0, len(table_columns()))
+        self.table.setHorizontalHeaderLabels(table_columns())
         self.table.verticalHeader().setVisible(False)
         self.table.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
         self.table.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.NoSelection)
@@ -362,7 +375,7 @@ class ActivityDialog(QtWidgets.QDialog):
 
         # TOTAL as a pinned one-row table under the columns — always visible, and
         # its cells line up under the main table (widths kept in sync below).
-        self.totals_table = QtWidgets.QTableWidget(1, len(TABLE_COLUMNS))
+        self.totals_table = QtWidgets.QTableWidget(1, len(table_columns()))
         self.totals_table.horizontalHeader().setVisible(False)
         self.totals_table.verticalHeader().setVisible(False)
         self.totals_table.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
@@ -377,7 +390,7 @@ class ActivityDialog(QtWidgets.QDialog):
         self.totals_table.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
         self.totals_table.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.totals_table.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        for column in range(len(TABLE_COLUMNS)):
+        for column in range(len(table_columns())):
             self.totals_table.horizontalHeader().setSectionResizeMode(column, QtWidgets.QHeaderView.ResizeMode.Fixed)
         self.totals_table.verticalHeader().setDefaultSectionSize(22)
         self.totals_table.setRowHeight(0, 22)
@@ -393,22 +406,22 @@ class ActivityDialog(QtWidgets.QDialog):
 
         # Export · Delete-all (left) · Save, Close (right), same style as the others.
         button_row = QtWidgets.QHBoxLayout()
-        self.export_button = QtWidgets.QPushButton("Export CSV…")
+        self.export_button = QtWidgets.QPushButton(tr("Export CSV…"))
         self.export_button.clicked.connect(self.export_csv)
         button_row.addWidget(self.export_button)
-        self.delete_button = QtWidgets.QPushButton("Delete all…")
+        self.delete_button = QtWidgets.QPushButton(tr("Delete all…"))
         self.delete_button.clicked.connect(self.delete_all)
         button_row.addWidget(self.delete_button)
         button_row.addStretch(1)
-        self.keyboard_button = QtWidgets.QPushButton("Heatmap")
-        self.keyboard_button.setToolTip("Open a live keyboard heatmap of key presses this session.")
+        self.keyboard_button = QtWidgets.QPushButton(tr("Heatmap"))
+        self.keyboard_button.setToolTip(tr("Open a live keyboard heatmap of key presses this session."))
         # Only usable once the Heatmap toggle is on — nothing is collected otherwise.
         self.keyboard_button.setEnabled(self.collect_box.isChecked())
         self.collect_box.toggled.connect(self.keyboard_button.setEnabled)
         self.keyboard_button.clicked.connect(self.open_keyboard_heatmap)
         button_row.addWidget(self.keyboard_button)
-        self.save_button = QtWidgets.QPushButton("Save")
-        self.close_button = QtWidgets.QPushButton("Close")
+        self.save_button = QtWidgets.QPushButton(tr("Save"))
+        self.close_button = QtWidgets.QPushButton(tr("Close"))
         self.save_button.clicked.connect(self.save_settings)
         self.close_button.clicked.connect(self.reject)
         button_row.addWidget(self.save_button)
@@ -425,9 +438,11 @@ class ActivityDialog(QtWidgets.QDialog):
         controller = self.focus_controller
         status = controller.status_text() if controller is not None else ""
         if status:
-            self.now_label.setText(f"Current: {status}")
+            self.now_label.setText(tr("Current: {status}").format(status=status))
         else:
-            self.now_label.setText("Current: idle — start working and a 🍅 builds after 25 min.")
+            self.now_label.setText(
+                tr("Current: idle — start working and a 🍅 builds after 25 min.")
+            )
 
         # On the Today view, rebuild every second so the live current row and
         # the timeline stay current (the table is small — a rebuild is cheap).
@@ -513,7 +528,7 @@ class ActivityDialog(QtWidgets.QDialog):
             runs = activity_mod.graded_runs(store, day, self.focus_minutes())
         except Exception:  # noqa: BLE001 - a broken DB shows an empty table, not a crash
             logger.exception("Failed to build activity table")
-            self.set_totals(["Could not read the activity database.", "", "", "", "", ""])
+            self.set_totals([tr("Could not read the activity database."), "", "", "", ""])
             return
 
         now = self.collector.now_fn()
@@ -598,7 +613,7 @@ class ActivityDialog(QtWidgets.QDialog):
         # columns, so it stays visible even when the rows scroll.
         self.set_totals(
             [
-                f"TOTAL 🍅 {tomatoes}",
+                tr("TOTAL 🍅 {tomatoes}").format(tomatoes=tomatoes),
                 format_hm(totals["active"] * 60),
                 f"{totals['keys']:,}",
                 f"{totals['clicks']:,} / {format_meters(totals['mouse_px'], self.dpi)}",
@@ -732,7 +747,7 @@ class ActivityDialog(QtWidgets.QDialog):
         day = self.selected_day()
         default_name = f"mycat-activity-{day.isoformat()}.csv"
         path, chosen = QtWidgets.QFileDialog.getSaveFileName(
-            self, "Export activity to CSV", default_name, "CSV files (*.csv)"
+            self, tr("Export activity to CSV"), default_name, tr("CSV files (*.csv)")
         )
         if not path:
             return
@@ -742,10 +757,15 @@ class ActivityDialog(QtWidgets.QDialog):
             count = self.write_csv(path)
         except OSError:
             logger.exception("Failed to export activity CSV")
-            self.set_status("Could not write the CSV file.", ok=False)
+            self.set_status(tr("Could not write the CSV file."), ok=False)
             return
         logger.info("Activity exported to CSV (%d periods) -> %s", count, path)
-        self.set_status(f"Exported {count} periods to {Path(path).name}.", ok=True)
+        self.set_status(
+            tr("Exported {count} periods to {name}.").format(
+                count=count, name=Path(path).name
+            ),
+            ok=True,
+        )
 
     def set_status(self, text: str, ok: bool | None = None) -> None:
         """Status line above the buttons: green when ok, red when not."""
@@ -756,8 +776,9 @@ class ActivityDialog(QtWidgets.QDialog):
     def delete_all(self) -> None:
         answer = QtWidgets.QMessageBox.question(
             self,
-            "Delete activity history",
-            "Delete ALL recorded activity and focus sessions from this computer?\nThis cannot be undone.",
+            tr("Delete activity history"),
+            tr("Delete ALL recorded activity and focus sessions from this computer?\n"
+               "This cannot be undone."),
             QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
             QtWidgets.QMessageBox.StandardButton.No,
         )
@@ -825,14 +846,24 @@ class ActivityDialog(QtWidgets.QDialog):
         if settings.enabled:
             mouse = "✓" if settings.mouse_enabled else "✗"
             keyboard = "✓" if settings.keyboard_enabled else "✗"
-            status = (
-                f"Saved: activity on · mouse {mouse} · keyboard {keyboard} · "
-                f"goal {goal} min · tooltip {tooltip}, keep {settings.retention_days} days."
+            status = tr(
+                "Saved: activity on · mouse {mouse} · keyboard {keyboard} · "
+                "goal {goal} min · tooltip {tooltip}, keep {days} days."
+            ).format(
+                mouse=mouse,
+                keyboard=keyboard,
+                goal=goal,
+                tooltip=tooltip,
+                days=settings.retention_days,
             )
         else:
-            status = (
-                f"Saved: activity off · goal {goal} min · tooltip {tooltip}, "
-                f"keep {settings.retention_days} days."
+            status = tr(
+                "Saved: activity off · goal {goal} min · tooltip {tooltip}, "
+                "keep {days} days."
+            ).format(
+                goal=goal,
+                tooltip=tooltip,
+                days=settings.retention_days,
             )
         self.set_status(status, ok=True)
 

--- a/mycat/ai_char_ui.py
+++ b/mycat/ai_char_ui.py
@@ -14,10 +14,11 @@ from pathlib import Path
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from . import ai_backends, ai_char, char_catalog, secret_store
+from . import ai_backends, ai_char, char_catalog, i18n, secret_store
 from .ui_theme import LIGHT_QSS
 
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 
 BACKEND_LABELS = [
     ("OpenAI (hosted, transparent)", "openai"),
@@ -103,7 +104,7 @@ class AICharDialog(QtWidgets.QDialog):
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
-        self.setWindowTitle("Generate a custom char with AI")
+        self.setWindowTitle(tr("Generate a custom char with AI"))
         self.setMinimumWidth(640)
         self.setStyleSheet(LIGHT_QSS)
         self.pool = QtCore.QThreadPool(self)
@@ -113,20 +114,20 @@ class AICharDialog(QtWidgets.QDialog):
         self.current_kind = self.settings.get("backend", "openai")
 
         intro = QtWidgets.QLabel(
-            "Turn 1–3 photos of the same person into a custom char, or generate one "
-            "from the prompt. Reference photos are not stored by myCat."
+            tr("Turn 1–3 photos of the same person into a custom char, or generate one "
+               "from the prompt. Reference photos are not stored by myCat.")
         )
         intro.setWordWrap(True)
 
         self.name_edit = QtWidgets.QLineEdit()
-        self.name_edit.setPlaceholderText("Example: Mina chibi char")
+        self.name_edit.setPlaceholderText(tr("Example: Mina chibi char"))
 
         self.backend_combo = QtWidgets.QComboBox()
         for label, data in BACKEND_LABELS:
-            self.backend_combo.addItem(label, data)
+            self.backend_combo.addItem(tr(label), data)
         self.mode_combo = QtWidgets.QComboBox()
         for label, data in MODE_LABELS:
-            self.mode_combo.addItem(label, data)
+            self.mode_combo.addItem(tr(label), data)
 
         # --- OpenAI group -----------------------------------------------------
         self.key_edit = QtWidgets.QLineEdit()
@@ -134,30 +135,30 @@ class AICharDialog(QtWidgets.QDialog):
         saved_key = secret_store.get_secret(ai_char.SECRET_NAME)
         self.key_edit.setText(saved_key or os.getenv("OPENAI_API_KEY", ""))
         self.key_edit.setPlaceholderText("sk-… (or OPENAI_API_KEY)")
-        self.remember_box = QtWidgets.QCheckBox("Remember key in the operating system keyring")
+        self.remember_box = QtWidgets.QCheckBox(tr("Remember key in the operating system keyring"))
         self.remember_box.setChecked(bool(saved_key))
         self.remember_box.setEnabled(secret_store.keyring_available())
         if not self.remember_box.isEnabled():
-            self.remember_box.setToolTip("Install mycat[secure] and configure an OS keyring to enable this.")
+            self.remember_box.setToolTip(tr("Install mycat[secure] and configure an OS keyring to enable this."))
         self.model_combo = QtWidgets.QComboBox()
         for model in ai_backends.OPENAI_MODELS:
             self.model_combo.addItem(model, model)
         self.quality_combo = QtWidgets.QComboBox()
-        self.quality_combo.addItem("Low — cheaper, good for a mascot", "low")
-        self.quality_combo.addItem("Medium — more detail, costs more", "medium")
+        self.quality_combo.addItem(tr("Low — cheaper, good for a mascot"), "low")
+        self.quality_combo.addItem(tr("Medium — more detail, costs more"), "medium")
 
         openai_form = QtWidgets.QFormLayout()
-        openai_form.addRow("OpenAI API key", self.key_edit)
+        openai_form.addRow(tr("OpenAI API key"), self.key_edit)
         openai_form.addRow("", self.remember_box)
-        openai_form.addRow("Model", self.model_combo)
-        openai_form.addRow("Quality", self.quality_combo)
-        self.openai_group = QtWidgets.QGroupBox("OpenAI")
+        openai_form.addRow(tr("Model"), self.model_combo)
+        openai_form.addRow(tr("Quality"), self.quality_combo)
+        self.openai_group = QtWidgets.QGroupBox(tr("OpenAI"))
         self.openai_group.setLayout(openai_form)
 
         # --- Self-hosted server group ----------------------------------------
         self.url_edit = QtWidgets.QLineEdit()
         self.url_edit.setPlaceholderText("http://127.0.0.1:7860")
-        self.load_btn = QtWidgets.QPushButton("Load models")
+        self.load_btn = QtWidgets.QPushButton(tr("Load models"))
         self.load_btn.clicked.connect(self.load_models)
         url_row = QtWidgets.QHBoxLayout()
         url_row.addWidget(self.url_edit, 1)
@@ -171,14 +172,14 @@ class AICharDialog(QtWidgets.QDialog):
         for label, method_id in ai_char.background_removal_choices():
             self.background_combo.addItem(label, method_id)
         self.background_combo.setToolTip(
-            "Keep leaves the opaque image as generated. Remove clears a corner-connected, near-uniform background."
+            tr("Keep leaves the opaque image as generated. Remove clears a corner-connected, near-uniform background.")
         )
         local_form = QtWidgets.QFormLayout()
-        local_form.addRow("Server address", url_row)
-        local_form.addRow("Checkpoint", self.checkpoint_combo)
-        local_form.addRow("Steps", self.steps_spin)
-        local_form.addRow("Background", self.background_combo)
-        self.local_group = QtWidgets.QGroupBox("Self-hosted server")
+        local_form.addRow(tr("Server address"), url_row)
+        local_form.addRow(tr("Checkpoint"), self.checkpoint_combo)
+        local_form.addRow(tr("Steps"), self.steps_spin)
+        local_form.addRow(tr("Background"), self.background_combo)
+        self.local_group = QtWidgets.QGroupBox(tr("Self-hosted server"))
         self.local_group.setLayout(local_form)
 
         # Editable prompt (per backend style) + negative (self-hosted only).
@@ -187,15 +188,15 @@ class AICharDialog(QtWidgets.QDialog):
         self.prompt_edit.setSizePolicy(  # grows so the prompt block ends level with references
             QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Expanding
         )
-        self.negative_label = QtWidgets.QLabel("Negative prompt")
+        self.negative_label = QtWidgets.QLabel(tr("Negative prompt"))
         self.negative_edit = QtWidgets.QPlainTextEdit()
         self.negative_edit.setMinimumHeight(48)  # never let the negative box collapse out of view
         self.negative_edit.setMaximumHeight(70)
         self.negative_edit.setToolTip(
-            "Things to avoid. OpenAI has no negative field, so it's folded into the "
-            "prompt as 'the image must not contain: …'."
+            tr("Things to avoid. OpenAI has no negative field, so it's folded into the "
+               "prompt as 'the image must not contain: …'.")
         )
-        self.reset_prompt_btn = QtWidgets.QPushButton("Reset")
+        self.reset_prompt_btn = QtWidgets.QPushButton(tr("Reset"))
         self.reset_prompt_btn.clicked.connect(self.reset_prompts)
 
         self.reference_list = QtWidgets.QListWidget()
@@ -204,8 +205,8 @@ class AICharDialog(QtWidgets.QDialog):
         self.reference_list.setSizePolicy(
             QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Expanding
         )
-        add_btn = QtWidgets.QPushButton("Add photos…")
-        remove_btn = QtWidgets.QPushButton("Remove selected")
+        add_btn = QtWidgets.QPushButton(tr("Add photos…"))
+        remove_btn = QtWidgets.QPushButton(tr("Remove selected"))
         add_btn.clicked.connect(self.add_references)
         remove_btn.clicked.connect(self.remove_selected)
         # Stacked, so the reference column stays within its 1/3 and never pushes
@@ -215,9 +216,9 @@ class AICharDialog(QtWidgets.QDialog):
         photo_buttons.addWidget(remove_btn)
 
         top_form = QtWidgets.QFormLayout()
-        top_form.addRow("Character name", self.name_edit)
-        top_form.addRow("Generate with", self.backend_combo)
-        top_form.addRow("Mode", self.mode_combo)
+        top_form.addRow(tr("Character name"), self.name_edit)
+        top_form.addRow(tr("Generate with"), self.backend_combo)
+        top_form.addRow(tr("Mode"), self.mode_combo)
 
         self.status_is_error = False
         self.status_label = ClickableLabel("")
@@ -232,7 +233,7 @@ class AICharDialog(QtWidgets.QDialog):
         block1.addStretch(1)
 
         # Preview (top-right): its height tracks block 1, not the whole window.
-        self.preview_label = ClickableLabel("The generated char\nwill appear here.")
+        self.preview_label = ClickableLabel(tr("The generated char\nwill appear here."))
         self.preview_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         self.preview_label.setWordWrap(True)
         self.preview_label.setMinimumSize(160, 120)
@@ -247,7 +248,7 @@ class AICharDialog(QtWidgets.QDialog):
         # Prompts (bottom-left, 2/3). The positive prompt box expands so this block
         # ends level with the reference block (list + Add/Remove).
         prompt_col = QtWidgets.QVBoxLayout()
-        prompt_col.addWidget(QtWidgets.QLabel("Prompt"))
+        prompt_col.addWidget(QtWidgets.QLabel(tr("Prompt")))
         prompt_col.addWidget(self.prompt_edit)
         prompt_col.addWidget(self.negative_label)
         prompt_col.addWidget(self.negative_edit)
@@ -255,14 +256,14 @@ class AICharDialog(QtWidgets.QDialog):
         # Reference photos (bottom-right, 1/3, under the preview). The list fills
         # the height so this block matches the prompt block; buttons sit beneath it.
         ref_col = QtWidgets.QVBoxLayout()
-        ref_col.addWidget(QtWidgets.QLabel("Reference photos (maximum 3)"))
+        ref_col.addWidget(QtWidgets.QLabel(tr("Reference photos (maximum 3)")))
         ref_col.addWidget(self.reference_list)
         ref_col.addLayout(photo_buttons)
 
-        self.generate_btn = QtWidgets.QPushButton("Generate")
-        self.save_btn = QtWidgets.QPushButton("Save")
+        self.generate_btn = QtWidgets.QPushButton(tr("Generate"))
+        self.save_btn = QtWidgets.QPushButton(tr("Save"))
         self.save_btn.setEnabled(False)  # nothing to save until a generation lands
-        close_btn = QtWidgets.QPushButton("Close")
+        close_btn = QtWidgets.QPushButton(tr("Close"))
         self.generate_btn.clicked.connect(self.generate)
         self.save_btn.clicked.connect(self.save_character)
         close_btn.clicked.connect(self.reject)
@@ -395,10 +396,10 @@ class AICharDialog(QtWidgets.QDialog):
         if kind not in ("a1111", "comfyui"):
             return
         if not url:
-            self.set_status("Enter the server address first.", error=True)
+            self.set_status(tr("Enter the server address first."), error=True)
             return
         self.load_btn.setEnabled(False)
-        self.set_status("Loading models…")
+        self.set_status(tr("Loading models…"))
         worker = ModelLoadWorker(kind, url)
         worker.signals.loaded.connect(self.on_models_loaded)
         worker.signals.failed.connect(self.on_models_failed)
@@ -411,7 +412,7 @@ class AICharDialog(QtWidgets.QDialog):
         self.checkpoint_combo.addItems(models)
         if current and current in models:
             self.checkpoint_combo.setCurrentText(current)
-        self.set_status(f"Loaded {len(models)} model(s).")
+        self.set_status(tr("Loaded {count} model(s).").format(count=len(models)))
 
     def on_models_failed(self, message: str) -> None:
         self.load_btn.setEnabled(True)
@@ -424,7 +425,7 @@ class AICharDialog(QtWidgets.QDialog):
         self.status_label.setText(text)
         if error and text:
             self.status_label.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
-            self.status_label.setToolTip("Click to copy this error")
+            self.status_label.setToolTip(tr("Click to copy this error"))
         else:
             self.status_label.setCursor(QtCore.Qt.CursorShape.ArrowCursor)
             self.status_label.setToolTip("")
@@ -439,21 +440,21 @@ class AICharDialog(QtWidgets.QDialog):
         QtWidgets.QApplication.clipboard().setText(text)
         # Flash a confirmation, then restore the error so it stays visible/copyable.
         self.status_label.setStyleSheet("color: #2e7d32;")
-        self.status_label.setText("Copied to clipboard.")
+        self.status_label.setText(tr("Copied to clipboard."))
         QtCore.QTimer.singleShot(1200, lambda: self.restore_error(text))
 
     def restore_error(self, text: str) -> None:
-        if self.status_label.text() == "Copied to clipboard.":
+        if self.status_label.text() == tr("Copied to clipboard."):
             self.status_label.setStyleSheet("color: #c0392b;")
             self.status_label.setText(text)
 
     def add_references(self) -> None:
         remaining = ai_char.MAX_REFERENCES - len(self.reference_paths)
         if remaining <= 0:
-            self.set_status("You already selected the maximum of 3 photos.", error=True)
+            self.set_status(tr("You already selected the maximum of 3 photos."), error=True)
             return
         names, _ = QtWidgets.QFileDialog.getOpenFileNames(
-            self, "Choose reference photos", "", "Images (*.png *.jpg *.jpeg *.webp);;All files (*)"
+            self, tr("Choose reference photos"), "", tr("Images (*.png *.jpg *.jpeg *.webp);;All files (*)")
         )
         for name in names[:remaining]:
             path = Path(name)
@@ -464,7 +465,7 @@ class AICharDialog(QtWidgets.QDialog):
             item.setData(QtCore.Qt.ItemDataRole.UserRole, str(path))
             self.reference_list.addItem(item)
         if len(names) > remaining:
-            self.set_status("Only the first 3 photos were added.")
+            self.set_status(tr("Only the first 3 photos were added."))
 
     def remove_selected(self) -> None:
         for item in self.reference_list.selectedItems():
@@ -482,30 +483,30 @@ class AICharDialog(QtWidgets.QDialog):
         key = self.key_edit.text().strip() or os.getenv("OPENAI_API_KEY", "")
 
         if mode == "img2img" and not self.reference_paths:
-            self.set_status("img2img needs at least one reference photo (or switch to txt2img).", error=True)
+            self.set_status(tr("img2img needs at least one reference photo (or switch to txt2img)."), error=True)
             return
         if kind == "openai" and not key:
-            self.set_status("Enter an OpenAI API key.", error=True)
+            self.set_status(tr("Enter an OpenAI API key."), error=True)
             return
         if kind in ("a1111", "comfyui") and not self.url_edit.text().strip():
-            self.set_status("Enter the self-hosted server address.", error=True)
+            self.set_status(tr("Enter the self-hosted server address."), error=True)
             return
         if not self.prompt_edit.toPlainText().strip():
-            self.set_status("Enter a prompt.", error=True)
+            self.set_status(tr("Enter a prompt."), error=True)
             return
 
         if kind == "openai":
             if self.remember_box.isChecked():
                 if not secret_store.set_secret(ai_char.SECRET_NAME, key):
-                    self.set_status("The keyring could not save the key. Generation will continue.", error=True)
+                    self.set_status(tr("The keyring could not save the key. Generation will continue."), error=True)
             elif secret_store.get_secret(ai_char.SECRET_NAME):
                 secret_store.delete_secret(ai_char.SECRET_NAME)
 
         ai_backends.save_generation_settings(settings)
         self.generate_btn.setEnabled(False)
         self.save_btn.setEnabled(False)
-        note = " One API request will be charged." if kind == "openai" else ""
-        self.set_status("Generating… this can take a bit." + note)
+        note = tr(" One API request will be charged.") if kind == "openai" else ""
+        self.set_status(tr("Generating… this can take a bit.") + note)
         worker = GenerationWorker(self.name_edit.text().strip(), list(self.reference_paths), settings, key)
         worker.signals.completed.connect(self.on_generated)
         worker.signals.failed.connect(self.on_failed)
@@ -516,13 +517,13 @@ class AICharDialog(QtWidgets.QDialog):
         self.generate_btn.setEnabled(True)
         self.save_btn.setEnabled(True)
         self.show_preview(image)
-        self.set_status("Generated. Click Save to keep it, or Generate again.")
+        self.set_status(tr("Generated. Click Save to keep it, or Generate again."))
 
     def show_preview(self, image_bytes: bytes) -> None:
         pixmap = QtGui.QPixmap()
         pixmap.loadFromData(image_bytes)
         if pixmap.isNull():
-            self.preview_label.setText("Preview unavailable.")
+            self.preview_label.setText(tr("Preview unavailable."))
             return
         self.preview_label.setPixmap(
             pixmap.scaled(
@@ -532,7 +533,7 @@ class AICharDialog(QtWidgets.QDialog):
             )
         )
         self.preview_label.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
-        self.preview_label.setToolTip("Click to copy the image")
+        self.preview_label.setToolTip(tr("Click to copy the image"))
 
     def copy_preview(self) -> None:
         """Copy the generated image to the clipboard (a click on the preview)."""
@@ -543,7 +544,7 @@ class AICharDialog(QtWidgets.QDialog):
         if image.isNull():
             return
         QtWidgets.QApplication.clipboard().setImage(image)
-        self.set_status("Image copied to clipboard.")
+        self.set_status(tr("Image copied to clipboard."))
 
     def save_character(self) -> None:
         """Install the previewed image as a char and close."""
@@ -557,8 +558,10 @@ class AICharDialog(QtWidgets.QDialog):
             return
         if char_catalog.find_char(char_id) is not None:
             answer = QtWidgets.QMessageBox.question(
-                self, "Replace character?",
-                f'A character named "{char_id}" already exists. Replace it?',
+                self, tr("Replace character?"),
+                tr('A character named "{char_id}" already exists. Replace it?').format(
+                    char_id=char_id
+                ),
             )
             if answer != QtWidgets.QMessageBox.StandardButton.Yes:
                 return

--- a/mycat/calendar_ui.py
+++ b/mycat/calendar_ui.py
@@ -6,8 +6,7 @@ import logging
 from PySide6 import QtCore, QtWidgets
 
 if __package__:
-    from . import calendar_ics
-    from . import i18n
+    from . import calendar_ics, i18n
     from .ui_theme import LIGHT_QSS
 else:
     import importlib

--- a/mycat/calendar_ui.py
+++ b/mycat/calendar_ui.py
@@ -7,14 +7,17 @@ from PySide6 import QtCore, QtWidgets
 
 if __package__:
     from . import calendar_ics
+    from . import i18n
     from .ui_theme import LIGHT_QSS
 else:
     import importlib
 
     calendar_ics = importlib.import_module("mycat.calendar_ics")
+    i18n = importlib.import_module("mycat.i18n")
     LIGHT_QSS = importlib.import_module("mycat.ui_theme").LIGHT_QSS
 
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 
 
 class CalendarDialog(QtWidgets.QDialog):
@@ -23,40 +26,40 @@ class CalendarDialog(QtWidgets.QDialog):
     def __init__(self, controller, parent=None) -> None:
         super().__init__(parent)
         self.controller = controller
-        self.setWindowTitle("Calendar")
+        self.setWindowTitle(tr("Calendar"))
         self.setModal(False)
         self.setStyleSheet(LIGHT_QSS)
 
         settings = controller.settings
         layout = QtWidgets.QVBoxLayout(self)
 
-        self.enabled_box = QtWidgets.QCheckBox("Enabled — announces upcoming events")
+        self.enabled_box = QtWidgets.QCheckBox(tr("Enabled — announces upcoming events"))
         self.enabled_box.setChecked(settings.enabled)
         layout.addWidget(self.enabled_box)
 
         form = QtWidgets.QFormLayout()
         self.url_edit = QtWidgets.QLineEdit(settings.url)
         self.url_edit.setPlaceholderText("https://…/basic.ics (or webcal://…)")
-        form.addRow("ICS URL:", self.url_edit)
+        form.addRow(tr("ICS URL:"), self.url_edit)
 
         self.remind_spin = QtWidgets.QSpinBox()
         self.remind_spin.setRange(1, 120)
         self.remind_spin.setValue(settings.remind_minutes)
-        self.remind_spin.setSuffix(" min before")
-        form.addRow("Remind:", self.remind_spin)
+        self.remind_spin.setSuffix(tr(" min before"))
+        form.addRow(tr("Remind:"), self.remind_spin)
 
         self.poll_spin = QtWidgets.QSpinBox()
         self.poll_spin.setRange(5, 120)
         self.poll_spin.setValue(settings.poll_minutes)
-        self.poll_spin.setSuffix(" min")
-        form.addRow("Refresh every:", self.poll_spin)
+        self.poll_spin.setSuffix(tr(" min"))
+        form.addRow(tr("Refresh every:"), self.poll_spin)
         layout.addLayout(form)
 
         hint = QtWidgets.QLabel(
-            "Google Calendar → Settings → <i>Secret address in iCal format</i>. "
-            "Apple/Outlook: any private calendar link works.<br>"
-            "Treat the URL as a password — it's stored in the owner-only config. "
-            "Calendar banners fly even during a focus session."
+            tr("Google Calendar → Settings → <i>Secret address in iCal format</i>. "
+               "Apple/Outlook: any private calendar link works.<br>"
+               "Treat the URL as a password — it's stored in the owner-only config. "
+               "Calendar banners fly even during a focus session.")
         )
         hint.setWordWrap(True)
         hint.setStyleSheet("color: #555;")
@@ -68,9 +71,9 @@ class CalendarDialog(QtWidgets.QDialog):
 
         # Test (left) · Save, Close (right); Save keeps the dialog open.
         button_row = QtWidgets.QHBoxLayout()
-        self.test_button = QtWidgets.QPushButton("Test")
-        self.save_button = QtWidgets.QPushButton("Save")
-        self.close_button = QtWidgets.QPushButton("Close")
+        self.test_button = QtWidgets.QPushButton(tr("Test"))
+        self.save_button = QtWidgets.QPushButton(tr("Save"))
+        self.close_button = QtWidgets.QPushButton(tr("Close"))
         self.test_button.clicked.connect(self.run_test)
         self.save_button.clicked.connect(self.save_settings)
         self.close_button.clicked.connect(self.reject)
@@ -101,19 +104,21 @@ class CalendarDialog(QtWidgets.QDialog):
         self.controller.apply_settings(settings)
         logger.info("Calendar settings saved (enabled=%s)", settings.enabled)
         state = "on" if settings.enabled else "off"
-        url_note = "URL set" if settings.url else "no URL"
+        url_note = tr("URL set") if settings.url else tr("no URL")
         self.set_status(
-            f"Saved ({state}): {url_note}, remind {settings.remind_minutes} min before, "
-            f"refresh every {settings.poll_minutes} min.",
+            tr("Saved ({state}): {url_note}, remind {min} min before, "
+               "refresh every {poll} min.").format(
+                state=state, url_note=url_note, min=settings.remind_minutes, poll=settings.poll_minutes
+            ),
             ok=True,
         )
 
     def run_test(self) -> None:
         url = self.url_edit.text().strip()
         if not url:
-            self.set_status("Paste the secret ICS URL first.", ok=False)
+            self.set_status(tr("Paste the secret ICS URL first."), ok=False)
             return
-        self.set_status("Fetching…")
+        self.set_status(tr("Fetching…"))
         self.test_button.setEnabled(False)
         worker = calendar_ics.FetchWorker(url, "")
         worker.emitter.finished.connect(self.show_test_result)
@@ -122,16 +127,21 @@ class CalendarDialog(QtWidgets.QDialog):
     def show_test_result(self, result: dict) -> None:
         self.test_button.setEnabled(True)
         if result.get("error"):
-            self.set_status(f"Failed: {result['error']}", ok=False)
+            self.set_status(tr("Failed: {error}").format(error=result["error"]), ok=False)
             return
         events = list(result.get("events", []))
         if not events:
-            self.set_status("OK — feed reachable, no events in the next 24 h.", ok=True)
+            self.set_status(tr("OK — feed reachable, no events in the next 24 h."), ok=True)
             return
         nearest = events[0]
         when = nearest["start"].strftime("%H:%M")
-        text = f"📅 {nearest['summary']} — at {when}"
-        self.set_status(f"OK — {len(events)} event(s) in 24 h · {text}", ok=True)
+        text = tr("📅 {summary} — at {when}").format(
+            summary=nearest["summary"], when=when
+        )
+        self.set_status(
+            tr("OK — {count} event(s) in 24 h · {text}").format(count=len(events), text=text),
+            ok=True,
+        )
         # Fly the nearest event as a real banner — same plane as every other
         # announcement.
         announcer = getattr(self.controller, "announcer", None)

--- a/mycat/digest.py
+++ b/mycat/digest.py
@@ -18,15 +18,17 @@ from PySide6 import QtCore, QtGui
 
 if __package__:
     from . import activity as activity_mod
-    from . import config_store, paths
+    from . import config_store, i18n, paths
 else:
     import importlib
 
     activity_mod = importlib.import_module("mycat.activity")
     config_store = importlib.import_module("mycat.config_store")
+    i18n = importlib.import_module("mycat.i18n")
     paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 
 CFG_DIR = paths.config_dir()
 CFG_FILE = paths.config_file()
@@ -58,10 +60,10 @@ def compose_digest(summary: dict) -> str:
     if summary["focus_count"]:
         parts.append(f"🍅 {summary['focus_count']}")
     if summary["best_focus_minutes"]:
-        parts.append(f"best focus {summary['best_focus_minutes']} min")
+        parts.append(tr("best focus {min} min").format(min=summary["best_focus_minutes"]))
     if not parts:
         return ""
-    return "Yesterday: " + " · ".join(parts)
+    return tr("Yesterday: ") + " · ".join(parts)
 
 
 def screen_dpi() -> float:

--- a/mycat/focus.py
+++ b/mycat/focus.py
@@ -25,16 +25,18 @@ from PySide6 import QtCore
 
 if __package__:
     from . import activity as activity_mod
-    from . import activity_store, config_store, paths
+    from . import activity_store, config_store, i18n, paths
 else:
     import importlib
 
     activity_mod = importlib.import_module("mycat.activity")
     activity_store = importlib.import_module("mycat.activity_store")
     config_store = importlib.import_module("mycat.config_store")
+    i18n = importlib.import_module("mycat.i18n")
     paths = importlib.import_module("mycat.paths")
 
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 
 # Same config file the rest of the app uses (see main.py / reminder.py).
 CFG_DIR = paths.config_dir()
@@ -156,7 +158,7 @@ class FocusController(QtCore.QObject):
             km = cursor_km_estimate(stats["mouse_px"])
             path = f"{km:.1f} km" if km >= 0.1 else f"{int(km * 1000)} m"
             parts.append(f"🖱 {stats['clicks']:,} / {path}")
-            parts.append(f"{stats['active_pct']}% active")
+            parts.append(f"{stats['active_pct']}% {tr('active')}")
         return " · ".join(parts)
 
     def status_text(self) -> str:
@@ -197,7 +199,11 @@ class FocusController(QtCore.QObject):
     def announce_rest(self, milestone: int) -> None:
         if self.announcer is None:
             return
-        text = "🍅 earned — time to rest" if milestone == 1 else "Still at it — time to rest 🍅"
+        text = (
+            tr("🍅 earned — time to rest")
+            if milestone == 1
+            else tr("Still at it — time to rest 🍅")
+        )
         self.announcer.announce(text)
         logger.info("Focus rest nudge (milestone %d, %d min)", milestone, milestone * self.settings.focus_minutes)
 
@@ -218,7 +224,7 @@ class FocusController(QtCore.QObject):
             except Exception:  # noqa: BLE001 - a tooltip must never break the timer
                 pass
             return
-        text = self.status_text() or f"🍅 {self.today_count()} today · idle"
+        text = self.status_text() or tr("🍅 {count} today · idle").format(count=self.today_count())
         window.setToolTip(text)
         # While the tooltip is on screen, keep its clock/stats ticking.
         try:

--- a/mycat/github_ui.py
+++ b/mycat/github_ui.py
@@ -13,8 +13,7 @@ import os
 from PySide6 import QtCore, QtWidgets
 
 if __package__:
-    from . import github_notify
-    from . import i18n
+    from . import github_notify, i18n
     from .ui_theme import LIGHT_QSS
 else:
     import importlib

--- a/mycat/github_ui.py
+++ b/mycat/github_ui.py
@@ -66,7 +66,7 @@ class GitHubDialog(QtWidgets.QDialog):
         public_box = QtWidgets.QGroupBox(tr("Public options"))
         public_layout = QtWidgets.QVBoxLayout(public_box)
         for key, label in PUBLIC_CHOICES:
-            box = QtWidgets.QCheckBox(label)
+            box = QtWidgets.QCheckBox(tr(label))
             box.setChecked(key in settings.categories)
             self.category_boxes[key] = box
             public_layout.addWidget(box)
@@ -75,7 +75,7 @@ class GitHubDialog(QtWidgets.QDialog):
         self.inbox_box = QtWidgets.QGroupBox(tr("Private options (token required)"))
         inbox_layout = QtWidgets.QVBoxLayout(self.inbox_box)
         for key, label in INBOX_CHOICES:
-            box = QtWidgets.QCheckBox(label)
+            box = QtWidgets.QCheckBox(tr(label))
             box.setChecked(key in settings.categories)
             self.category_boxes[key] = box
             inbox_layout.addWidget(box)

--- a/mycat/github_ui.py
+++ b/mycat/github_ui.py
@@ -14,14 +14,17 @@ from PySide6 import QtCore, QtWidgets
 
 if __package__:
     from . import github_notify
+    from . import i18n
     from .ui_theme import LIGHT_QSS
 else:
     import importlib
 
     github_notify = importlib.import_module("mycat.github_notify")
+    i18n = importlib.import_module("mycat.i18n")
     LIGHT_QSS = importlib.import_module("mycat.ui_theme").LIGHT_QSS
 
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 
 INBOX_CHOICES = [(key, github_notify.CATEGORY_LABELS[key]) for key in github_notify.INBOX_CATEGORIES]
 PUBLIC_CHOICES = [(key, github_notify.CATEGORY_LABELS[key]) for key in github_notify.PUBLIC_CATEGORIES]
@@ -33,7 +36,7 @@ class GitHubDialog(QtWidgets.QDialog):
     def __init__(self, notifier, parent=None) -> None:
         super().__init__(parent)
         self.notifier = notifier
-        self.setWindowTitle("GitHub notifications")
+        self.setWindowTitle(tr("GitHub notifications"))
         self.setModal(False)
         self.resize(400, 500)
         self.setStyleSheet(LIGHT_QSS)
@@ -43,24 +46,24 @@ class GitHubDialog(QtWidgets.QDialog):
         self.has_token = bool(settings.resolve_token())
         layout = QtWidgets.QVBoxLayout(self)
 
-        self.enabled_box = QtWidgets.QCheckBox("Enabled — announces GitHub activity")
+        self.enabled_box = QtWidgets.QCheckBox(tr("Enabled — announces GitHub activity"))
         self.enabled_box.setChecked(settings.enabled)
         layout.addWidget(self.enabled_box)
 
         form = QtWidgets.QFormLayout()
         self.me_edit = QtWidgets.QLineEdit(settings.me_login)
-        self.me_edit.setPlaceholderText("auto-filled when you verify a token")
-        form.addRow("GitHub username:", self.me_edit)
+        self.me_edit.setPlaceholderText(tr("auto-filled when you verify a token"))
+        form.addRow(tr("GitHub username:"), self.me_edit)
         self.token_edit = QtWidgets.QLineEdit(settings.token)
         self.token_edit.setEchoMode(QtWidgets.QLineEdit.EchoMode.Password)
         self.token_edit.setPlaceholderText(f"empty → ${settings.token_env}")
         self.token_edit.textChanged.connect(self.on_token_changed)
-        form.addRow("Token (optional):", self.token_edit)
+        form.addRow(tr("Token (optional):"), self.token_edit)
         layout.addLayout(form)
 
         self.category_boxes: dict = {}
 
-        public_box = QtWidgets.QGroupBox("Public options")
+        public_box = QtWidgets.QGroupBox(tr("Public options"))
         public_layout = QtWidgets.QVBoxLayout(public_box)
         for key, label in PUBLIC_CHOICES:
             box = QtWidgets.QCheckBox(label)
@@ -69,7 +72,7 @@ class GitHubDialog(QtWidgets.QDialog):
             public_layout.addWidget(box)
         layout.addWidget(public_box)
 
-        self.inbox_box = QtWidgets.QGroupBox("Private options (token required)")
+        self.inbox_box = QtWidgets.QGroupBox(tr("Private options (token required)"))
         inbox_layout = QtWidgets.QVBoxLayout(self.inbox_box)
         for key, label in INBOX_CHOICES:
             box = QtWidgets.QCheckBox(label)
@@ -77,8 +80,8 @@ class GitHubDialog(QtWidgets.QDialog):
             self.category_boxes[key] = box
             inbox_layout.addWidget(box)
         self.inbox_box.setToolTip(
-            "Enter a token to configure these options; Test verifies it. They are served only with a\n"
-            "token (read-only Notifications scope is enough); requests go straight to api.github.com."
+            tr("Enter a token to configure these options; Test verifies it. They are served only with a\n"
+               "token (read-only Notifications scope is enough); requests go straight to api.github.com.")
         )
         layout.addWidget(self.inbox_box)
         self.set_inbox_enabled(self.has_token)
@@ -90,9 +93,9 @@ class GitHubDialog(QtWidgets.QDialog):
         # Test (left) · Save, Close (right). Save applies without closing,
         # so the flow "save, then test" works in one open dialog.
         button_row = QtWidgets.QHBoxLayout()
-        self.test_button = QtWidgets.QPushButton("Test")
-        self.save_button = QtWidgets.QPushButton("Save")
-        self.close_button = QtWidgets.QPushButton("Close")
+        self.test_button = QtWidgets.QPushButton(tr("Test"))
+        self.save_button = QtWidgets.QPushButton(tr("Save"))
+        self.close_button = QtWidgets.QPushButton(tr("Close"))
         self.test_button.clicked.connect(self.run_test)
         self.save_button.clicked.connect(self.save_settings)
         self.close_button.clicked.connect(self.reject)
@@ -145,12 +148,18 @@ class GitHubDialog(QtWidgets.QDialog):
         public_on = sum(1 for key, label in PUBLIC_CHOICES if self.category_boxes[key].isChecked())
         private_on = sum(1 for key, label in INBOX_CHOICES if self.category_boxes[key].isChecked())
         state = "on" if settings.enabled else "off"
-        who = settings.me_login or "no username"
-        token_note = "token verified" if self.token_verified else (
-            "token not verified" if settings.resolve_token() else "no token"
+        who = settings.me_login or tr("no username")
+        token_note = tr("token verified") if self.token_verified else (
+            tr("token not verified") if settings.resolve_token() else tr("no token")
         )
         self.set_status(
-            f"Saved ({state}): {who} · {public_on} public + {private_on} private options · {token_note}.",
+            tr("Saved ({state}): {who} · {public} public + {private} private options · {token}.").format(
+                state=state,
+                who=who,
+                public=public_on,
+                private=private_on,
+                token=token_note,
+            ),
             ok=True,
         )
 
@@ -159,9 +168,9 @@ class GitHubDialog(QtWidgets.QDialog):
         token = settings.resolve_token()
         accounts = list(self.sample_accounts(settings))
         if not token and not accounts:
-            self.set_status("Enter your username, list accounts, or paste a token.", ok=False)
+            self.set_status(tr("Enter your username, list accounts, or paste a token."), ok=False)
             return
-        self.set_status("Checking…")
+        self.set_status(tr("Checking…"))
         self.test_button.setEnabled(False)
 
         if token:
@@ -193,7 +202,7 @@ class GitHubDialog(QtWidgets.QDialog):
             if result.get("error") or int(result.get("status", 0)) != 200:
                 self.token_verified = False
                 self.set_inbox_enabled(bool(self.collect_settings().resolve_token()))
-                self.set_status("Token rejected — check the PAT (read-only Notifications scope).", ok=False)
+                self.set_status(tr("Token rejected — check the PAT (read-only Notifications scope)."), ok=False)
                 return
             login = str(result.get("login", ""))
             self.token_verified = True
@@ -203,15 +212,19 @@ class GitHubDialog(QtWidgets.QDialog):
             items = list(result.get("items", []))
             if items:
                 text = github_notify.notification_text(items[0])
-                self.set_status(f"OK · verified as {login} · {text}", ok=True)
+                self.set_status(
+                    tr("OK · verified as {login} · {text}").format(login=login, text=text), ok=True
+                )
                 url = github_notify.subject_html_url(items[0].get("subject") or {}, items[0].get("repository") or {})
                 self.fly_sample(text, url)
             else:
-                self.set_status(f"OK · verified as {login} · no notifications.", ok=True)
+                self.set_status(
+                    tr("OK · verified as {login} · no notifications.").format(login=login), ok=True
+                )
             return
 
         if result.get("error"):
-            self.set_status(f"Failed: {result['error']}", ok=False)
+            self.set_status(tr("Failed: {error}").format(error=result["error"]), ok=False)
             return
 
         items = list(result.get("items", []))
@@ -225,10 +238,10 @@ class GitHubDialog(QtWidgets.QDialog):
             latest = items[0]  # quiet feed: show the newest event of any kind
         if latest is not None:
             text = github_notify.event_text(latest)
-            self.set_status(f"OK · {text}", ok=True)
+            self.set_status(tr("OK · {text}").format(text=text), ok=True)
             self.fly_sample(text, github_notify.event_html_url(latest))
         else:
-            self.set_status("OK — public mode, no recent activity.", ok=True)
+            self.set_status(tr("OK — public mode, no recent activity."), ok=True)
 
 
 __all__ = ["GitHubDialog"]

--- a/mycat/i18n.py
+++ b/mycat/i18n.py
@@ -300,6 +300,7 @@ _TRANSLATIONS = {
     "Error: {message}": "错误：{message}",
 
     # --- AI character generator ---
+    "Generate": "生成",
     "Generate a custom char with AI": "使用 AI 生成自定义角色",
     "Turn 1–3 photos of the same person into a custom char, or generate one "
     "from the prompt. Reference photos are not stored by myCat.":

--- a/mycat/i18n.py
+++ b/mycat/i18n.py
@@ -1,0 +1,494 @@
+"""Lightweight i18n for mycat: English (default) and Simplified Chinese.
+
+Language is chosen from the main interface (right-click menu / tray →
+Language) and persisted in the config file under ``[settings] language``.
+Short strings are looked up through :func:`tr`; the English source string is
+the dictionary key, so untranslated strings simply fall through to English.
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Language code -> display name shown in the Language submenu.
+LANGUAGES = {
+    "en": "English",
+    "zh": "简体中文",
+}
+
+CONFIG_KEY = "language"
+DEFAULT_LANGUAGE = "en"
+
+_current = DEFAULT_LANGUAGE
+
+
+# English source string -> Simplified Chinese translation.
+_TRANSLATIONS = {
+    # --- main context menu / tray ---
+    "Chat": "聊天",
+    "LLM…": "LLM…",
+    "Calendar…": "日历…",
+    "Reminder…": "提醒…",
+    "GitHub…": "GitHub…",
+    "Activity…": "活动…",
+    "Chars": "角色",
+    "Generate…": "生成…",
+    "Delete…": "删除…",
+    "Reset": "重置位置",
+    "Update…": "更新…",
+    "Autostart": "开机自启",
+    "Close": "关闭",
+    "Close to tray": "关闭到托盘",
+    "Quit": "退出",
+    "Open": "显示",
+    "Language": "语言",
+    "English": "English",
+    "简体中文": "简体中文",
+
+    # --- first-run autostart prompt ---
+    "Keep mycat on screen every time you log in?\n\n"
+    "You can change this any time from the right-click menu → Autostart.":
+        "每次登录时都让 mycat 显示在屏幕上吗？\n\n"
+        "你可以随时通过右键菜单 → 开机自启 来更改。",
+
+    # --- AI character generator ---
+    "AI character": "AI 角色",
+    "Delete custom character?": "删除自定义角色？",
+    "Delete custom character": "删除自定义角色",
+    'Delete "{char_id}" from this computer? This cannot be undone.':
+        '确定从这台电脑上删除 "{char_id}" 吗？此操作无法撤销。',
+    "The character could not be deleted.": "无法删除该角色。",
+
+    # --- update dialog ---
+    "Current: {current}": "当前版本：{current}",
+    "Current: {current}\nLatest: {latest}": "当前版本：{current}\n最新版本：{latest}",
+    "Couldn't reach GitHub — try again in a bit.": "无法连接 GitHub，请稍后再试。",
+    "No update needed — you're on the latest version. 🐱": "无需更新，你已是最新版本。🐱",
+    "Update available. Update with:\n\n    {hint}": "有可用更新。请执行以下命令更新：\n\n    {hint}",
+    "Update available — click Update to download and restart.": "有可用更新 — 点击“更新”即可下载并重启。",
+    "Releases": "发行版",
+    "Update": "更新",
+    "Downloading update…": "正在下载更新…",
+    "Updating myCat": "正在更新 myCat",
+    "Cancel": "取消",
+    "Restarting…": "正在重启…",
+    "Update failed": "更新失败",
+    "Couldn't update: {message}": "更新失败：{message}",
+
+    # --- settings dialog ---
+    "Settings": "设置",
+    "Animation Wait Time (s):": "动画等待时间（秒）：",
+    "Failed to save settings:\n{e}": "保存设置失败：\n{e}",
+
+    # --- activity dialog ---
+    "Activity": "活动",
+    "Tracking": "视线追踪",
+    "Mouse": "鼠标",
+    "Keyboard": "键盘",
+    "Heatmap": "热力图",
+    "Tooltip": "悬停提示",
+    "Enable:": "启用：",
+    "Show:": "显示：",
+    "Today": "今天",
+    "Yesterday": "昨天",
+    "Pomodoro goal:": "番茄钟目标：",
+    "History:": "历史记录：",
+    " min": " 分钟",
+    " days": " 天",
+    "Session": "时段",
+    "Duration": "时长",
+    "Keys": "按键",
+    "Active": "活跃",
+    "rest": "休息",
+    "active": "活跃",
+    "future": "未来",
+    "now": "现在",
+    "Export CSV…": "导出 CSV…",
+    "Delete all…": "全部删除…",
+    "Save": "保存",
+    "Close": "关闭",
+    "Current: {status}": "当前：{status}",
+    "Current: idle — start working and a 🍅 builds after 25 min.":
+        "当前：空闲 — 开始工作，坚持 25 分钟后即可获得一个 🍅。",
+    "Could not read the activity database.": "无法读取活动数据库。",
+    "TOTAL 🍅 {tomatoes}": "总计 🍅 {tomatoes}",
+    "Delete activity history": "删除活动历史",
+    "Delete ALL recorded activity and focus sessions from this computer?\n"
+    "This cannot be undone.": "确定删除这台电脑上记录的所有活动和专注时段？\n此操作无法撤销。",
+    "Export activity to CSV": "将活动导出为 CSV",
+    "CSV files (*.csv)": "CSV 文件 (*.csv)",
+    "Could not write the CSV file.": "无法写入 CSV 文件。",
+    "Exported {count} periods to {name}.": "已将 {count} 个时段导出到 {name}。",
+    "Open a live keyboard heatmap of key presses this session.":
+        "打开本次会话按键的实时键盘热力图。",
+    "The cat's eyes follow your cursor; off, it looks at its own nose.\n"
+    "Purely visual — it records nothing.":
+        "开启后小猫的眼睛会跟随你的光标；关闭时它会看向自己的鼻子。\n纯视觉效果，不记录任何数据。",
+    "Mouse click count in the private diary (never targets).":
+        "在私人日记中记录鼠标点击次数（绝不涉及目标内容）。",
+    "Keystroke count in the diary (never which keys).":
+        "在日记中记录按键次数（绝不记录具体按键）。",
+    "Count key presses per key for the Heatmap window. Aggregate counts only —\n"
+    "never the order, timing or text — kept in memory and gone on restart.":
+        "为热力图窗口统计每个按键的按压次数。仅聚合计数——\n不记录顺序、时机或内容，仅保存在内存中，重启后即消失。",
+    "Show the live focus/activity stats when you hover over the cat.":
+        "悬停在小猫上方时显示实时的专注/活动统计。",
+    "Key/click counts aren't available here (needs X11, or macOS Input "
+    "Monitoring permission) — the cursor path still records.":
+        "此处无法统计按键/点击次数（需要 X11，或 macOS 的输入监控权限）——光标轨迹仍会记录。",
+    "Saved: activity on · mouse {mouse} · keyboard {keyboard} · "
+    "goal {goal} min · tooltip {tooltip}, keep {days} days.":
+        "已保存：活动已开启 · 鼠标 {mouse} · 键盘 {keyboard} · "
+        "目标 {goal} 分钟 · 悬停提示 {tooltip}，保留 {days} 天。",
+    "Saved: activity off · goal {goal} min · tooltip {tooltip}, "
+    "keep {days} days.":
+        "已保存：活动已关闭 · 目标 {goal} 分钟 · 悬停提示 {tooltip}，保留 {days} 天。",
+
+    # --- calendar dialog ---
+    "Calendar": "日历",
+    "Enabled — announces upcoming events": "启用 — 播报即将到来的事件",
+    "ICS URL:": "ICS 地址：",
+    "Remind:": "提前提醒：",
+    "Refresh every:": "刷新间隔：",
+    " min before": " 分钟前",
+    "Test": "测试",
+    "Paste the secret ICS URL first.": "请先粘贴私密的 ICS 地址。",
+    "Fetching…": "正在获取…",
+    "Failed: {error}": "失败：{error}",
+    "OK — feed reachable, no events in the next 24 h.": "正常 — 源可访问，未来 24 小时内没有事件。",
+    "OK — {count} event(s) in 24 h · {text}": "正常 — 24 小时内 {count} 个事件 · {text}",
+    "URL set": "地址已设置",
+    "no URL": "未设置地址",
+    "Saved ({state}): {url_note}, remind {min} min before, "
+    "refresh every {poll} min.":
+        "已保存（{state}）：{url_note}，提前 {min} 分钟提醒，每 {poll} 分钟刷新。",
+    "Google Calendar → Settings → <i>Secret address in iCal format</i>. "
+    "Apple/Outlook: any private calendar link works.<br>"
+    "Treat the URL as a password — it's stored in the owner-only config. "
+    "Calendar banners fly even during a focus session.":
+        "Google 日历 → 设置 → <i>以 iCal 格式查看私密地址</i>。"
+        "Apple/Outlook：任何私有日历链接均可使用。<br>"
+        "请把这个地址当作密码保管——它会被保存在仅限本人的配置中。"
+        "即使在专注时段，日历横幅也会正常播报。",
+    "📅 {summary} — at {when}": "📅 {summary} — 于 {when}",
+
+    # --- github dialog ---
+    "GitHub notifications": "GitHub 通知",
+    "Enabled — announces GitHub activity": "启用 — 播报 GitHub 活动",
+    "GitHub username:": "GitHub 用户名：",
+    "Token (optional):": "令牌（可选）：",
+    "Public options": "公开选项",
+    "Private options (token required)": "私有选项（需要令牌）",
+    "auto-filled when you verify a token": "验证令牌后自动填写",
+    "Enter your username, list accounts, or paste a token.": "请输入用户名、列出账号，或粘贴令牌。",
+    "Checking…": "正在检查…",
+    "Token rejected — check the PAT (read-only Notifications scope).": "令牌被拒绝 — 请检查 PAT（只读 Notifications 权限）。",
+    "OK · verified as {login} · {text}": "正常 · 已验证为 {login} · {text}",
+    "OK · verified as {login} · no notifications.": "正常 · 已验证为 {login} · 没有通知。",
+    "OK · {text}": "正常 · {text}",
+    "OK — public mode, no recent activity.": "正常 — 公开模式，暂无最近活动。",
+    "no username": "未设置用户名",
+    "no token": "无令牌",
+    "token verified": "令牌已验证",
+    "token not verified": "令牌未验证",
+    "Saved ({state}): {who} · {public} public + {private} private options · {token}.":
+        "已保存（{state}）：{who} · {public} 个公开 + {private} 个私有选项 · {token}。",
+    "Enter a token to configure these options; Test verifies it. They are served only with a\n"
+    "token (read-only Notifications scope is enough); requests go straight to api.github.com.":
+        "输入令牌以配置这些选项；点击“测试”验证。它们仅在提供令牌时才会启用\n"
+        "（只读 Notifications 权限即可）；请求将直接发往 api.github.com。",
+
+    # --- reminder dialog ---
+    "Reminder": "提醒",
+    "Drag to move • Right-click for options": "拖拽移动 • 右键查看选项",
+    "Double-click to open • Drag to move • Right-click for options":
+        "双击打开 • 拖拽移动 • 右键查看选项",
+    "Message": "内容",
+    "Direction": "方向",
+    "Plane": "飞机",
+    "Plane color": "飞机颜色",
+    "Plane width": "飞机宽度",
+    "Left → Right": "左 → 右",
+    "Right → Left": "右 → 左",
+    "In": "在",
+    "At": "于",
+    "now": "现在",
+    "When": "时间",
+    "Repeat daily": "每天重复",
+    " px": " 像素",
+    "min": "分钟",
+    "sec": "秒",
+    ", daily": "，每天",
+    "Reminder in {left}. ({at}{daily})": "提醒时间：{left} 后（{at}{daily}）",
+    "Reminder cleared.": "提醒已清除。",
+    "Reminder set.": "提醒已设置。",
+    "Open link": "打开链接",
+    "Resume flight": "继续飞行",
+    "Pause flight": "暂停飞行",
+    "What should the cat remind you about?": "希望小猫提醒你什么？",
+
+    # --- keyboard heatmap ---
+    "Keyboard heatmap": "键盘热力图",
+    "Collection is off — tick “Heatmap” in the Activity window and Save.":
+        "采集已关闭 — 请在“活动”窗口中勾选“热力图”并保存。",
+    "Key counting isn't available here (needs X11, or macOS Input Monitoring "
+    "permission), so nothing can be collected.":
+        "此处无法统计按键次数（需要 X11，或 macOS 的输入监控权限），因此无法采集任何数据。",
+
+    # --- settings dialog ---
+    "Error": "错误",
+
+    # --- LLM settings dialog ---
+    "Chat / LLM settings": "聊天 / LLM 设置",
+    "LLM enabled": "启用 LLM",
+    "Vendor": "服务商",
+    "Name": "名称",
+    "Type": "类型",
+    "Base URL": "基础地址",
+    "Model": "模型",
+    "API key": "API 密钥",
+    "Ollama (local)": "Ollama（本地）",
+    "OpenAI-compatible": "OpenAI 兼容",
+    "Load models": "加载模型",
+    "➕ Add custom…": "➕ 添加自定义…",
+    "Enter a base URL first.": "请先输入基础地址。",
+    "Loading models…": "正在加载模型…",
+    "Found {count} model(s).": "找到 {count} 个模型。",
+    "Could not load models: {message}": "无法加载模型：{message}",
+    "Testing {model}…": "正在测试 {model}…",
+    "OK — {elapsed:.2f} s (reply: {reply})": "正常 — {elapsed:.2f} 秒（回复：{reply}）",
+    "Test failed: {message}": "测试失败：{message}",
+    "Enter a vendor name.": "请输入服务商名称。",
+    "Pick a model first.": "请先选择模型。",
+    "Could not save: {exc}": "无法保存：{exc}",
+    "Saved, but live apply failed: {exc}": "已保存，但实时应用失败：{exc}",
+    "Saved ✓ ({state}): {name} · {model}": "已保存 ✓（{state}）：{name} · {model}",
+
+    # --- chat dialog ---
+    "Chat with a cat ({suffix})": "与小猫聊天（{suffix}）",
+    "Write a message…": "输入消息…",
+    "Write something...": "随便写点什么…",
+    "Send": "发送",
+    "Request": "请求",
+    "Response": "回复",
+    "Error: {message}": "错误：{message}",
+
+    # --- AI character generator ---
+    "Generate a custom char with AI": "使用 AI 生成自定义角色",
+    "Turn 1–3 photos of the same person into a custom char, or generate one "
+    "from the prompt. Reference photos are not stored by myCat.":
+        "用同一个人的 1–3 张照片生成自定义角色，或直接根据提示词生成。参考照片不会被 myCat 保存。",
+    "Example: Mina chibi char": "示例：Mina 的 Q 版角色",
+    "OpenAI (hosted, transparent)": "OpenAI（托管，透明）",
+    "Stable Diffusion — self-hosted": "Stable Diffusion — 自托管",
+    "ComfyUI — self-hosted": "ComfyUI — 自托管",
+    "img2img — turn my photos into a char": "img2img — 把我的照片变成角色",
+    "txt2img — from the prompt only": "txt2img — 仅根据提示词生成",
+    "Remember key in the operating system keyring": "将密钥保存在操作系统钥匙串中",
+    "Install mycat[secure] and configure an OS keyring to enable this.":
+        "安装 mycat[secure] 并配置操作系统钥匙串后即可启用。",
+    "Low — cheaper, good for a mascot": "低 — 更便宜，适合做吉祥物",
+    "Medium — more detail, costs more": "中 — 细节更多，费用更高",
+    "OpenAI API key": "OpenAI API 密钥",
+    "Quality": "质量",
+    "OpenAI": "OpenAI",
+    "Server address": "服务器地址",
+    "Checkpoint": "检查点",
+    "Steps": "步数",
+    "Background": "背景",
+    "Self-hosted server": "自托管服务器",
+    "Keep leaves the opaque image as generated. Remove clears a corner-connected, near-uniform background.":
+        "“保留”会按生成结果保留不透明图像。“移除”会清除与角落相连、颜色接近统一的背景。",
+    "Negative prompt": "负面提示词",
+    "Things to avoid. OpenAI has no negative field, so it's folded into the "
+    "prompt as 'the image must not contain: …'.":
+        "需要避免的内容。OpenAI 没有独立的负面提示词字段，因此会合并到提示词中，"
+        "形如“图像中不得包含：……”。",
+    "Add photos…": "添加照片…",
+    "Remove selected": "移除所选",
+    "Character name": "角色名称",
+    "Generate with": "使用以下方式生成",
+    "Mode": "模式",
+    "The generated char\nwill appear here.": "生成的角色\n将显示在这里。",
+    "Prompt": "提示词",
+    "Reference photos (maximum 3)": "参考照片（最多 3 张）",
+    "Enter the server address first.": "请先输入服务器地址。",
+    "Loaded {count} model(s).": "已加载 {count} 个模型。",
+    "Click to copy this error": "点击复制此错误",
+    "Copied to clipboard.": "已复制到剪贴板。",
+    "You already selected the maximum of 3 photos.": "你已选择了最多 3 张照片。",
+    "Choose reference photos": "选择参考照片",
+    "Images (*.png *.jpg *.jpeg *.webp);;All files (*)": "图片 (*.png *.jpg *.jpeg *.webp);;所有文件 (*)",
+    "Only the first 3 photos were added.": "仅添加了前 3 张照片。",
+    "img2img needs at least one reference photo (or switch to txt2img).":
+        "img2img 至少需要一张参考照片（或切换到 txt2img）。",
+    "Enter an OpenAI API key.": "请输入 OpenAI API 密钥。",
+    "Enter the self-hosted server address.": "请输入自托管服务器地址。",
+    "Enter a prompt.": "请输入提示词。",
+    "The keyring could not save the key. Generation will continue.":
+        "钥匙串无法保存密钥，将继续生成。",
+    " One API request will be charged.": " 将产生一次 API 请求费用。",
+    "Generating… this can take a bit.": "正在生成…可能需要一些时间。",
+    "Generated. Click Save to keep it, or Generate again.":
+        "已生成。点击“保存”保留，或再次点击“生成”。",
+    "Preview unavailable.": "无法显示预览。",
+    "Click to copy the image": "点击复制该图片",
+    "Image copied to clipboard.": "图片已复制到剪贴板。",
+    "Replace character?": "替换角色？",
+    'A character named "{char_id}" already exists. Replace it?':
+        '已存在名为 "{char_id}" 的角色。是否替换？',
+
+    # --- shop dialog ---
+    "myCat Shop": "myCat 商店",
+    "Refresh": "刷新",
+    "Server: {url}": "服务器：{url}",
+    "Catalog": "目录",
+    "My Chars": "我的角色",
+    "Uninstall selected": "卸载所选",
+    "Loading catalog…": "正在加载目录…",
+    "{count} chars available.": "共有 {count} 个角色可用。",
+    "No chars available.": "暂无可用角色。",
+    "⚠ Premium char '{name}' requires a subscription (coming soon).":
+        "⚠ 高级角色“{name}”需要订阅（即将推出）。",
+    "Downloading {name}…": "正在下载 {name}…",
+    "Installed: {id}": "已安装：{id}",
+    "⚠ Failed: {id} — {message}": "⚠ 失败：{id} — {message}",
+    "Uninstalled: {id}": "已卸载：{id}",
+    "⚠ Could not uninstall {id}": "⚠ 无法卸载 {id}",
+    "✓ Installed — Uninstall": "✓ 已安装 — 卸载",
+    "Install": "安装",
+    "Downloading… {kb} KB": "正在下载… {kb} KB",
+    "Retry": "重试",
+    "by {author}": "作者：{author}",
+    "unknown": "未知",
+}
+
+# Runtime-updated strings (messages that are built dynamically).
+_runtime = {}
+
+
+def current_language() -> str:
+    """Return the active language code ("en" or "zh")."""
+    return _current
+
+
+def is_chinese() -> bool:
+    return _current == "zh"
+
+
+def tr(text: str) -> str:
+    """Return ``text`` translated to the current language (English fallback)."""
+    if _current == "zh":
+        return _TRANSLATIONS.get(text, _runtime.get(text, text))
+    return text
+
+
+def register(key: str, zh: str) -> None:
+    """Register a runtime translation for a dynamically-built string key."""
+    _runtime[key] = zh
+
+
+def config_file() -> Path:
+    """Path to the shared ``config.ini`` (same single source of truth as paths.py)."""
+    from mycat import paths
+
+    return paths.config_file()
+
+
+def load_language(config_path: Path | None = None) -> str:
+    """Read the persisted language from config (falls back to default)."""
+    global _current
+    path = Path(config_path) if config_path else config_file()
+    try:
+        if path.exists():
+            config = configparser.ConfigParser()
+            config.read(path)
+            value = config.get("settings", CONFIG_KEY, fallback=DEFAULT_LANGUAGE).strip().lower()
+            if value in LANGUAGES:
+                _current = value
+    except Exception as exc:  # noqa: BLE001 - a bad config must not crash startup
+        logger.debug("Could not read language from config: %s", exc)
+    return _current
+
+
+def set_language(code: str, config_path: Path | None = None) -> str:
+    """Switch the active language and persist it to ``[settings] language``."""
+    global _current
+    code = (code or DEFAULT_LANGUAGE).strip().lower()
+    if code not in LANGUAGES:
+        code = DEFAULT_LANGUAGE
+    _current = code
+    path = Path(config_path) if config_path else config_file()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        config = configparser.ConfigParser()
+        if path.exists():
+            config.read(path)
+        if "settings" not in config:
+            config.add_section("settings")
+        config["settings"][CONFIG_KEY] = code
+        with open(path, "w") as f:
+            config.write(f)
+        try:
+            from mycat import secret_store
+
+            secret_store.secure_file(path)
+        except Exception:  # noqa: BLE001 - securing the file is best-effort
+            pass
+    except Exception as exc:  # noqa: BLE001 - language still applies in-memory
+        logger.error("Could not persist language setting: %s", exc)
+    logger.info("Language set to %s", code)
+    return code
+
+
+def build_language_menu(parent, config_path: Path | None = None) -> "QMenu":
+    """Append a 'Language' submenu (English / 简体中文 radio actions) to ``parent``.
+
+    ``parent`` should be a QMenu. When a language is chosen, the language is
+    persisted and the window's menus are rebuilt via the menu's parent window's
+    ``rebuild_menus`` (attached to the main window) so the switch applies at once.
+    """
+    from PySide6 import QtGui, QtWidgets  # local import to keep module import-light
+
+    menu = QtWidgets.QMenu("Language", parent)
+    radio_group = QtGui.QActionGroup(menu)
+    radio_group.setExclusive(True)
+    for code, label in LANGUAGES.items():
+        action = menu.addAction(label)
+        action.setCheckable(True)
+        action.setChecked(code == _current)
+        radio_group.addAction(action)
+        action.triggered.connect(
+            lambda checked=False, c=code: _on_language_chosen(c, parent, config_path)
+        )
+    parent.addMenu(menu)
+    return menu
+
+
+def _on_language_chosen(code: str, parent_menu, config_path: Path | None) -> None:
+    set_language(code, config_path)
+    # The menu is created with the main window as its QWidget parent, so
+    # ``parent()`` reliably reaches the window even while the menu is shown as
+    # a top-level popup (``window()`` would return the popup itself).
+    window = getattr(parent_menu, "parent", None)
+    window = window() if callable(window) else None
+    rebuild = getattr(window, "rebuild_menus", None)
+    if callable(rebuild):
+        rebuild()
+
+
+__all__ = [
+    "LANGUAGES",
+    "current_language",
+    "is_chinese",
+    "tr",
+    "register",
+    "load_language",
+    "set_language",
+    "build_language_menu",
+]

--- a/mycat/i18n.py
+++ b/mycat/i18n.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import configparser
 import logging
-import os
 from pathlib import Path
+
+from PySide6 import QtWidgets
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +112,6 @@ _TRANSLATIONS = {
     "Export CSV…": "导出 CSV…",
     "Delete all…": "全部删除…",
     "Save": "保存",
-    "Close": "关闭",
     "Current: {status}": "当前：{status}",
     "Current: idle — start working and a 🍅 builds after 25 min.":
         "当前：空闲 — 开始工作，坚持 25 分钟后即可获得一个 🍅。",
@@ -187,7 +187,8 @@ _TRANSLATIONS = {
     "auto-filled when you verify a token": "验证令牌后自动填写",
     "Enter your username, list accounts, or paste a token.": "请输入用户名、列出账号，或粘贴令牌。",
     "Checking…": "正在检查…",
-    "Token rejected — check the PAT (read-only Notifications scope).": "令牌被拒绝 — 请检查 PAT（只读 Notifications 权限）。",
+    "Token rejected — check the PAT (read-only Notifications scope).":
+        "令牌被拒绝 — 请检查 PAT（只读 Notifications 权限）。",
     "OK · verified as {login} · {text}": "正常 · 已验证为 {login} · {text}",
     "OK · verified as {login} · no notifications.": "正常 · 已验证为 {login} · 没有通知。",
     "OK · {text}": "正常 · {text}",
@@ -227,7 +228,6 @@ _TRANSLATIONS = {
     "Right → Left": "右 → 左",
     "In": "在",
     "At": "于",
-    "now": "现在",
     "When": "时间",
     "Repeat daily": "每天重复",
     " px": " 像素",
@@ -459,7 +459,7 @@ def set_language(code: str, config_path: Path | None = None) -> str:
     return code
 
 
-def build_language_menu(parent, config_path: Path | None = None) -> "QMenu":
+def build_language_menu(parent, config_path: Path | None = None) -> QtWidgets.QMenu:
     """Append a 'Language' submenu (English / 简体中文 radio actions) to ``parent``.
 
     ``parent`` should be a QMenu. When a language is chosen, the language is

--- a/mycat/i18n.py
+++ b/mycat/i18n.py
@@ -202,6 +202,16 @@ _TRANSLATIONS = {
     "token (read-only Notifications scope is enough); requests go straight to api.github.com.":
         "输入令牌以配置这些选项；点击“测试”验证。它们仅在提供令牌时才会启用\n"
         "（只读 Notifications 权限即可）；请求将直接发往 api.github.com。",
+    "Review requested": "请求评审",
+    "Mentions": "@提及",
+    "Assigned to me": "分配给我",
+    "CI status": "CI 状态",
+    "Issue activity": "Issue 活动",
+    "PR activity": "PR 活动",
+    "Star on my repo": "我的仓库被点赞",
+    "Fork of my repo": "我的仓库被 Fork",
+    "New follower": "新关注者",
+    "My stars & follows": "我的点赞与关注",
 
     # --- reminder dialog ---
     "Reminder": "提醒",
@@ -231,6 +241,7 @@ _TRANSLATIONS = {
     "Resume flight": "继续飞行",
     "Pause flight": "暂停飞行",
     "What should the cat remind you about?": "希望小猫提醒你什么？",
+    "Do you feed mycat?": "你喂过 mycat 了吗？",
 
     # --- keyboard heatmap ---
     "Keyboard heatmap": "键盘热力图",
@@ -243,6 +254,15 @@ _TRANSLATIONS = {
     # --- settings dialog ---
     "Error": "错误",
 
+    # --- focus tooltip / rest banner ---
+    "🍅 earned — time to rest": "🍅 达成 — 该休息一下了。",
+    "Still at it — time to rest 🍅": "继续加油 — 该休息一下了 🍅",
+    "🍅 {count} today · idle": "🍅 今日 {count} 个 · 空闲",
+
+    # --- morning digest ---
+    "best focus {min} min": "最长专注 {min} 分钟",
+    "Yesterday: ": "昨日： ",
+
     # --- LLM settings dialog ---
     "Chat / LLM settings": "聊天 / LLM 设置",
     "LLM enabled": "启用 LLM",
@@ -252,6 +272,7 @@ _TRANSLATIONS = {
     "Base URL": "基础地址",
     "Model": "模型",
     "API key": "API 密钥",
+    "leave empty to use ${env}": "留空则使用 ${env}",
     "Ollama (local)": "Ollama（本地）",
     "OpenAI-compatible": "OpenAI 兼容",
     "Load models": "加载模型",
@@ -368,9 +389,6 @@ _TRANSLATIONS = {
     "unknown": "未知",
 }
 
-# Runtime-updated strings (messages that are built dynamically).
-_runtime = {}
-
 
 def current_language() -> str:
     """Return the active language code ("en" or "zh")."""
@@ -384,13 +402,8 @@ def is_chinese() -> bool:
 def tr(text: str) -> str:
     """Return ``text`` translated to the current language (English fallback)."""
     if _current == "zh":
-        return _TRANSLATIONS.get(text, _runtime.get(text, text))
+        return _TRANSLATIONS.get(text, text)
     return text
-
-
-def register(key: str, zh: str) -> None:
-    """Register a runtime translation for a dynamically-built string key."""
-    _runtime[key] = zh
 
 
 def config_file() -> Path:
@@ -455,7 +468,7 @@ def build_language_menu(parent, config_path: Path | None = None) -> "QMenu":
     """
     from PySide6 import QtGui, QtWidgets  # local import to keep module import-light
 
-    menu = QtWidgets.QMenu("Language", parent)
+    menu = QtWidgets.QMenu(tr("Language"), parent)
     radio_group = QtGui.QActionGroup(menu)
     radio_group.setExclusive(True)
     for code, label in LANGUAGES.items():
@@ -487,7 +500,6 @@ __all__ = [
     "current_language",
     "is_chinese",
     "tr",
-    "register",
     "load_language",
     "set_language",
     "build_language_menu",

--- a/mycat/key_heatmap_ui.py
+++ b/mycat/key_heatmap_ui.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import activity as activity_mod
+from . import i18n
 from . import key_heatmap
 from .ui_theme import LIGHT_QSS
+
+tr = i18n.tr
 
 GREY = QtGui.QColor(210, 210, 210)
 GREY_BORDER = QtGui.QColor(170, 170, 170)
@@ -142,7 +145,7 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
         # done on the refresh timer. It can't change while the window is open.
         self.counting_available = activity_mod.counts_available()
         self.last_counts: dict[str, int] | None = None
-        self.setWindowTitle("Keyboard heatmap")
+        self.setWindowTitle(tr("Keyboard heatmap"))
         self.setModal(False)
         self.setMinimumWidth(700)
         self.resize(720, 400)
@@ -167,7 +170,7 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
 
         button_row = QtWidgets.QHBoxLayout()
         button_row.addStretch(1)
-        self.close_button = QtWidgets.QPushButton("Close")
+        self.close_button = QtWidgets.QPushButton(tr("Close"))
         self.close_button.clicked.connect(self.reject)
         button_row.addWidget(self.close_button)
         layout.addLayout(button_row)
@@ -182,12 +185,12 @@ class KeyboardHeatmapDialog(QtWidgets.QDialog):
 
     def update_note(self) -> None:
         if not self.counting_available:
-            text = (
+            text = tr(
                 "Key counting isn't available here (needs X11, or macOS Input Monitoring "
                 "permission), so nothing can be collected."
             )
         elif not self.collector.settings.key_heatmap_enabled:
-            text = "Collection is off — tick “Heatmap” in the Activity window and Save."
+            text = tr("Collection is off — tick “Heatmap” in the Activity window and Save.")
         else:
             text = ""
         if text != self.note.text():

--- a/mycat/key_heatmap_ui.py
+++ b/mycat/key_heatmap_ui.py
@@ -12,8 +12,7 @@ from __future__ import annotations
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import activity as activity_mod
-from . import i18n
-from . import key_heatmap
+from . import i18n, key_heatmap
 from .ui_theme import LIGHT_QSS
 
 tr = i18n.tr

--- a/mycat/llm_settings_ui.py
+++ b/mycat/llm_settings_ui.py
@@ -9,10 +9,12 @@ import time
 
 from PySide6 import QtCore, QtWidgets
 
+from . import i18n
 from . import llm_ollama, llm_openai_compat, llm_prompt, llm_vendors
 from .ui_theme import LIGHT_QSS
 
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 
 STATUS_OK = "color: #1c7c2f;"
 STATUS_ERR = "color: #c0392b;"
@@ -88,7 +90,7 @@ class LLMSettingsDialog(QtWidgets.QDialog):
     def __init__(self, window: QtWidgets.QWidget, parent=None) -> None:
         super().__init__(parent)
         self.host_window = window
-        self.setWindowTitle("Chat / LLM settings")
+        self.setWindowTitle(tr("Chat / LLM settings"))
         self.setMinimumWidth(460)
         self.setStyleSheet(LIGHT_QSS)
         self.pool = QtCore.QThreadPool(self)
@@ -96,39 +98,39 @@ class LLMSettingsDialog(QtWidgets.QDialog):
         self.vendors = llm_vendors.load_vendors()
         self.current_api_key_env = ""
 
-        self.enabled_box = QtWidgets.QCheckBox("LLM enabled")
+        self.enabled_box = QtWidgets.QCheckBox(tr("LLM enabled"))
         self.enabled_box.setChecked(self.current_enabled())
 
         self.vendor_combo = QtWidgets.QComboBox()
         self.name_edit = QtWidgets.QLineEdit()
         self.kind_combo = QtWidgets.QComboBox()
-        self.kind_combo.addItem("Ollama (local)", llm_vendors.KIND_OLLAMA)
-        self.kind_combo.addItem("OpenAI-compatible", llm_vendors.KIND_OPENAI)
+        self.kind_combo.addItem(tr("Ollama (local)"), llm_vendors.KIND_OLLAMA)
+        self.kind_combo.addItem(tr("OpenAI-compatible"), llm_vendors.KIND_OPENAI)
         self.base_url_edit = QtWidgets.QLineEdit()
         self.key_edit = QtWidgets.QLineEdit()
         self.key_edit.setEchoMode(QtWidgets.QLineEdit.EchoMode.Password)
-        self.key_label = QtWidgets.QLabel("API key")
+        self.key_label = QtWidgets.QLabel(tr("API key"))
         self.model_combo = QtWidgets.QComboBox()
         self.model_combo.setEditable(True)
-        self.load_btn = QtWidgets.QPushButton("Load models")
+        self.load_btn = QtWidgets.QPushButton(tr("Load models"))
         self.load_btn.setAutoDefault(False)
         self.status_label = QtWidgets.QLabel("")
         self.status_label.setWordWrap(True)
-        self.test_btn = QtWidgets.QPushButton("Test")
-        self.save_btn = QtWidgets.QPushButton("Save")
-        close_btn = QtWidgets.QPushButton("Close")
+        self.test_btn = QtWidgets.QPushButton(tr("Test"))
+        self.save_btn = QtWidgets.QPushButton(tr("Save"))
+        close_btn = QtWidgets.QPushButton(tr("Close"))
 
         form = QtWidgets.QFormLayout()
         form.addRow(self.enabled_box)
-        form.addRow("Vendor", self.vendor_combo)
-        form.addRow("Name", self.name_edit)
-        form.addRow("Type", self.kind_combo)
-        form.addRow("Base URL", self.base_url_edit)
+        form.addRow(tr("Vendor"), self.vendor_combo)
+        form.addRow(tr("Name"), self.name_edit)
+        form.addRow(tr("Type"), self.kind_combo)
+        form.addRow(tr("Base URL"), self.base_url_edit)
         form.addRow(self.key_label, self.key_edit)
         model_row = QtWidgets.QHBoxLayout()
         model_row.addWidget(self.model_combo, 1)
         model_row.addWidget(self.load_btn)
-        form.addRow("Model", model_row)
+        form.addRow(tr("Model"), model_row)
 
         # Test (left) · Save, Close (right) — same order in every dialog.
         buttons = QtWidgets.QHBoxLayout()
@@ -145,7 +147,7 @@ class LLMSettingsDialog(QtWidgets.QDialog):
         # Populate the vendor dropdown: presets/custom first, then "Add custom…".
         for name, vendor in self.vendors.items():
             self.vendor_combo.addItem(vendor.label or name, name)
-        self.vendor_combo.addItem(ADD_CUSTOM, None)
+        self.vendor_combo.addItem(tr(ADD_CUSTOM), None)
 
         self.vendor_combo.currentIndexChanged.connect(self.on_vendor_changed)
         self.kind_combo.currentIndexChanged.connect(self.refresh_key_visibility)
@@ -241,10 +243,10 @@ class LLMSettingsDialog(QtWidgets.QDialog):
     def on_load(self) -> None:
         base_url = self.base_url_edit.text().strip()
         if not base_url:
-            self.set_status("Enter a base URL first.", STATUS_ERR)
+            self.set_status(tr("Enter a base URL first."), STATUS_ERR)
             return
         self.load_btn.setEnabled(False)
-        self.set_status("Loading models…", STATUS_INFO)
+        self.set_status(tr("Loading models…"), STATUS_INFO)
         worker = ModelsWorker(self.kind_value(), base_url, self.effective_key(), 10.0)
         worker.signals.models.connect(self.on_models)
         worker.signals.error.connect(self.on_load_error)
@@ -263,12 +265,12 @@ class LLMSettingsDialog(QtWidgets.QDialog):
         if keep:
             self.model_combo.setCurrentText(keep)
         self.model_combo.blockSignals(False)
-        self.set_status(f"Found {len(names)} model(s).", STATUS_OK)
+        self.set_status(tr("Found {count} model(s).").format(count=len(names)), STATUS_OK)
         self.on_model_changed()
 
     def on_load_error(self, message: str) -> None:
         self.load_btn.setEnabled(True)
-        self.set_status(f"Could not load models: {message}", STATUS_ERR)
+        self.set_status(tr("Could not load models: {message}").format(message=message), STATUS_ERR)
 
     # -- model / actions ----------------------------------------------------
 
@@ -285,7 +287,7 @@ class LLMSettingsDialog(QtWidgets.QDialog):
         if not model:
             return
         self.test_btn.setEnabled(False)
-        self.set_status(f"Testing {model}…", STATUS_INFO)
+        self.set_status(tr("Testing {model}…").format(model=model), STATUS_INFO)
         worker = TestWorker(
             self.kind_value(),
             self.base_url_edit.text().strip(),
@@ -302,18 +304,18 @@ class LLMSettingsDialog(QtWidgets.QDialog):
         short = reply.strip().replace("\n", " ")
         if len(short) > 40:
             short = short[:40] + "…"
-        self.set_status(f"OK — {elapsed:.2f} s (reply: {short})", STATUS_OK)
+        self.set_status(tr("OK — {elapsed:.2f} s (reply: {reply})").format(elapsed=elapsed, reply=short), STATUS_OK)
 
     def on_test_error(self, message: str) -> None:
         self.test_btn.setEnabled(True)
-        self.set_status(f"Test failed: {message}", STATUS_ERR)
+        self.set_status(tr("Test failed: {message}").format(message=message), STATUS_ERR)
 
     # -- save ---------------------------------------------------------------
 
     def build_vendor(self) -> llm_vendors.Vendor | None:
         name = self.name_edit.text().strip()
         if not name:
-            self.set_status("Enter a vendor name.", STATUS_ERR)
+            self.set_status(tr("Enter a vendor name."), STATUS_ERR)
             return None
         base = self.vendors.get(name)
         return llm_vendors.Vendor(
@@ -331,23 +333,28 @@ class LLMSettingsDialog(QtWidgets.QDialog):
         if vendor is None:
             return
         if not vendor.model:
-            self.set_status("Pick a model first.", STATUS_ERR)
+            self.set_status(tr("Pick a model first."), STATUS_ERR)
             return
         enabled = self.enabled_box.isChecked()
         try:
             llm_vendors.save_vendor(vendor, make_active=True)
             llm_prompt.save_llm_enabled(enabled)
         except OSError as exc:
-            self.set_status(f"Could not save: {exc}", STATUS_ERR)
+            self.set_status(tr("Could not save: {exc}").format(exc=exc), STATUS_ERR)
             return
         try:
             self.apply_live(vendor, enabled)
         except Exception as exc:  # noqa: BLE001 - config is saved regardless
             logger.exception("Failed to apply LLM settings live")
-            self.set_status(f"Saved, but live apply failed: {exc}", STATUS_ERR)
+            self.set_status(tr("Saved, but live apply failed: {exc}").format(exc=exc), STATUS_ERR)
             return
         state = "on" if enabled else "off"
-        self.set_status(f"Saved ✓ ({state}): {vendor.name} · {vendor.model}", STATUS_OK)
+        self.set_status(
+            tr("Saved ✓ ({state}): {name} · {model}").format(
+                state=state, name=vendor.name, model=vendor.model
+            ),
+            STATUS_OK,
+        )
 
     def apply_live(self, vendor: llm_vendors.Vendor, enabled: bool) -> None:
         from . import llm, llm_ui

--- a/mycat/llm_settings_ui.py
+++ b/mycat/llm_settings_ui.py
@@ -206,7 +206,7 @@ class LLMSettingsDialog(QtWidgets.QDialog):
             self.base_url_edit.setText("")
             self.base_url_edit.setPlaceholderText("https://api.example.com/v1")
             self.key_edit.setText("")
-            self.key_edit.setPlaceholderText("API key")
+            self.key_edit.setPlaceholderText(tr("API key"))
             self.current_api_key_env = ""
         else:
             vendor = self.vendors[self.vendor_combo.currentData()]
@@ -218,7 +218,9 @@ class LLMSettingsDialog(QtWidgets.QDialog):
             self.current_api_key_env = vendor.api_key_env
             self.key_edit.setText(vendor.api_key)
             self.key_edit.setPlaceholderText(
-                f"leave empty to use ${vendor.api_key_env}" if vendor.api_key_env else "API key"
+                tr("leave empty to use ${env}").format(env=vendor.api_key_env)
+                if vendor.api_key_env
+                else tr("API key")
             )
         # Drop the previous vendor's model list so stale entries (e.g. Ollama
         # models) don't linger if the new vendor's load fails or hasn't run yet.

--- a/mycat/llm_settings_ui.py
+++ b/mycat/llm_settings_ui.py
@@ -9,8 +9,7 @@ import time
 
 from PySide6 import QtCore, QtWidgets
 
-from . import i18n
-from . import llm_ollama, llm_openai_compat, llm_prompt, llm_vendors
+from . import i18n, llm_ollama, llm_openai_compat, llm_prompt, llm_vendors
 from .ui_theme import LIGHT_QSS
 
 logger = logging.getLogger(__name__)

--- a/mycat/llm_ui.py
+++ b/mycat/llm_ui.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from . import i18n
-from . import llm_prompt
+from . import i18n, llm_prompt
 
 if TYPE_CHECKING:
     from .llm import LLMContext

--- a/mycat/llm_ui.py
+++ b/mycat/llm_ui.py
@@ -10,12 +10,14 @@ from typing import TYPE_CHECKING
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from . import i18n
 from . import llm_prompt
 
 if TYPE_CHECKING:
     from .llm import LLMContext
 
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 
 
 def attach_chat(window: QtWidgets.QWidget, context: LLMContext, enabled: bool = True) -> None:
@@ -142,7 +144,7 @@ class ChatDialog(QtWidgets.QDialog):
             | QtCore.Qt.WindowType.WindowStaysOnTopHint
         )
         title_suffix = controller.context.backend_name.capitalize()
-        self.setWindowTitle(f"Chat with a cat ({title_suffix})")
+        self.setWindowTitle(tr("Chat with a cat ({suffix})").format(suffix=title_suffix))
         self.resize(360, 420)
         self.setMinimumSize(320, 260)
         self.setSizeGripEnabled(True)
@@ -195,7 +197,7 @@ class ChatDialog(QtWidgets.QDialog):
             }
         """
         self.input_field = QtWidgets.QLineEdit()
-        self.input_field.setPlaceholderText("Write a message…")
+        self.input_field.setPlaceholderText(tr("Write a message…"))
         self.input_field.setMinimumHeight(34)
         self.input_field.setStyleSheet(
             """
@@ -217,7 +219,7 @@ class ChatDialog(QtWidgets.QDialog):
         )
         input_layout.addWidget(self.input_field, 1)
 
-        self.send_button = QtWidgets.QPushButton("Send")
+        self.send_button = QtWidgets.QPushButton(tr("Send"))
         self.send_button.setMinimumHeight(34)
         self.send_button.setCursor(QtCore.Qt.CursorShape.PointingHandCursor)
         self.send_button.setStyleSheet(button_style)
@@ -240,7 +242,7 @@ class ChatDialog(QtWidgets.QDialog):
     def show_welcome_message(self) -> None:
         self.messages = []
         self.clear_message_widgets()
-        label = QtWidgets.QLabel("Write something...")
+        label = QtWidgets.QLabel(tr("Write something..."))
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         label.setStyleSheet("color: #888; font-style: italic; margin-top: 40px;")
         self.messages_layout.addWidget(label)
@@ -296,7 +298,7 @@ class ChatDialog(QtWidgets.QDialog):
 
     def on_ai_error(self, message: str) -> None:
         logger.error("LLM backend error: %s", message)
-        self.append_message("cat", f"Error: {message}")
+        self.append_message("cat", tr("Error: {message}").format(message=message))
         self.schedule_scroll()
         self.log_request_summary(message, success=False)
 
@@ -455,7 +457,7 @@ class MessageBubble(QtWidgets.QWidget):
         inner.setContentsMargins(6, 4, 6, 4)
         inner.setSpacing(2)
 
-        header = QtWidgets.QLabel("Request" if role == "user" else "Response")
+        header = QtWidgets.QLabel(tr("Request") if role == "user" else tr("Response"))
         header.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft)
         header.setStyleSheet("font-size: 13px; color: #1c1c1c;")
 

--- a/mycat/main.py
+++ b/mycat/main.py
@@ -40,6 +40,7 @@ if __package__:
         focus,
         github_api,
         github_notify,
+        i18n,
         llm,
         paths,
         reminder,
@@ -68,6 +69,7 @@ else:
     digest = importlib.import_module("mycat.digest")
     update_check = importlib.import_module("mycat.update_check")
     updater = importlib.import_module("mycat.updater")
+    i18n = importlib.import_module("mycat.i18n")
 
 from PySide6 import QtCore, QtGui, QtNetwork, QtWidgets
 
@@ -89,6 +91,7 @@ LOGGING = {
 }
 logging.basicConfig(**LOGGING)
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 logger.debug("LLM integration module path: %s", getattr(llm, "__file__", "builtin"))
 
 # Config paths — single source of truth in paths.py (stays ~/.config/mycat).
@@ -447,8 +450,8 @@ def offer_autostart_on_first_run(window: QtWidgets.QWidget) -> None:
     answer = QtWidgets.QMessageBox.question(
         window,
         "mycat",
-        "Keep mycat on screen every time you log in?\n\n"
-        "You can change this any time from the right-click menu → Autostart.",
+        tr("Keep mycat on screen every time you log in?\n\n"
+           "You can change this any time from the right-click menu → Autostart."),
         QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No,
         QtWidgets.QMessageBox.StandardButton.Yes,
     )
@@ -1141,7 +1144,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         # and is greyed out while the LLM is disabled.
         toggle_chat = getattr(self, "toggle_llm_chat", None)
         if callable(toggle_chat):
-            chat_action = menu.addAction("Chat")
+            chat_action = menu.addAction(tr("Chat"))
             chat_action.triggered.connect(toggle_chat)
             llm_is_enabled = getattr(self, "is_llm_enabled", None)
             if callable(llm_is_enabled):
@@ -1150,19 +1153,19 @@ class PixelCatWindow(QtWidgets.QWidget):
 
         # Settings entries, in the agreed order: LLM, Calendar, Reminder,
         # GitHub, Activity.
-        llm_action = menu.addAction("LLM…")
+        llm_action = menu.addAction(tr("LLM…"))
         llm_action.triggered.connect(self.open_llm_settings)
 
-        calendar_action = menu.addAction("Calendar…")
+        calendar_action = menu.addAction(tr("Calendar…"))
         calendar_action.triggered.connect(self.open_calendar_settings)
 
-        reminder_action = menu.addAction("Reminder…")
+        reminder_action = menu.addAction(tr("Reminder…"))
         reminder_action.triggered.connect(self.open_reminder)
 
-        github_action = menu.addAction("GitHub…")
+        github_action = menu.addAction(tr("GitHub…"))
         github_action.triggered.connect(self.open_github_settings)
 
-        activity_action = menu.addAction("Activity…")
+        activity_action = menu.addAction(tr("Activity…"))
         activity_action.triggered.connect(self.open_activity_dialog)
 
         # Shop temporarily hidden from the menu (work in progress). The dialog
@@ -1176,12 +1179,12 @@ class PixelCatWindow(QtWidgets.QWidget):
         # Rebuild the list every time so freshly-installed chars appear without restart.
         self.available_images = char_catalog.scan_all()
         if len(self.available_images) > 0:
-            images_menu = menu.addMenu("Chars")
-            create_action = images_menu.addAction("Generate…")
+            images_menu = menu.addMenu(tr("Chars"))
+            create_action = images_menu.addAction(tr("Generate…"))
             create_action.triggered.connect(self.open_ai_char)
             generated_chars = char_catalog.ai_generated_chars()
             if generated_chars:
-                delete_menu = images_menu.addMenu("Delete…")
+                delete_menu = images_menu.addMenu(tr("Delete…"))
                 for custom_id in generated_chars:
                     delete_action = delete_menu.addAction(custom_id)
                     delete_action.triggered.connect(
@@ -1196,27 +1199,31 @@ class PixelCatWindow(QtWidgets.QWidget):
                 action.triggered.connect(lambda checked, name=img_name: self.load_image(name))
             menu.addSeparator()
 
-        reset_action = menu.addAction("Reset")
+        reset_action = menu.addAction(tr("Reset"))
         reset_action.triggered.connect(self.reset_position)
 
-        update_action = menu.addAction("Update…")
+        update_action = menu.addAction(tr("Update…"))
         update_action.triggered.connect(self.open_update)
 
         if autostart.is_supported():
-            login_action = menu.addAction("Autostart")
+            login_action = menu.addAction(tr("Autostart"))
             login_action.setCheckable(True)
             login_action.setChecked(autostart.is_enabled())
             login_action.toggled.connect(autostart.set_enabled)
+
+        # Language switcher (English / 简体中文) — retranslates the tray menu live.
+        menu.addSeparator()
+        i18n.build_language_menu(menu, CFG_FILE)
 
         # With a system tray, "Close" from the cat menu only hides it to the tray
         # (reopen from the tray's Open, or a tray double-click); the real Quit
         # lives only in the tray menu. Without a tray there's nowhere to hide, so
         # keep a real Quit here.
         if getattr(self, "tray_icon", None) is not None:
-            close_action = menu.addAction("Close")
+            close_action = menu.addAction(tr("Close"))
             close_action.triggered.connect(self.hide)
         else:
-            quit_action = menu.addAction("Quit")
+            quit_action = menu.addAction(tr("Quit"))
             quit_action.triggered.connect(QtWidgets.QApplication.quit)
         menu.exec(self.mapToGlobal(pos))
 
@@ -1234,20 +1241,24 @@ class PixelCatWindow(QtWidgets.QWidget):
             dialog.exec()
         except Exception as exc:  # noqa: BLE001 - keep the desktop companion alive
             logger.exception("Failed to open AI character generator")
-            QtWidgets.QMessageBox.warning(self, "AI character", str(exc))
+            QtWidgets.QMessageBox.warning(self, tr("AI character"), str(exc))
 
     def delete_ai_char(self, char_id: str) -> None:
         """Delete a generated pack locally; this never makes an API request."""
         answer = QtWidgets.QMessageBox.question(
             self,
-            "Delete custom character?",
-            f'Delete "{char_id}" from this computer? This cannot be undone.',
+            tr("Delete custom character?"),
+            tr('Delete "{char_id}" from this computer? This cannot be undone.').format(
+                char_id=char_id
+            ),
         )
         if answer != QtWidgets.QMessageBox.StandardButton.Yes:
             return
         was_active = self.file_name == char_id
         if not char_catalog.remove_installed(char_id):
-            QtWidgets.QMessageBox.warning(self, "Delete custom character", "The character could not be deleted.")
+            QtWidgets.QMessageBox.warning(
+                self, tr("Delete custom character"), tr("The character could not be deleted.")
+            )
             return
         self.available_images = char_catalog.scan_all()
         if was_active:
@@ -1396,8 +1407,8 @@ class PixelCatWindow(QtWidgets.QWidget):
         box.setText(text)
         box.setInformativeText(informative)
         box.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
-        releases_button = box.addButton("Releases", QtWidgets.QMessageBox.ButtonRole.ActionRole)
-        update_button = box.addButton("Update", QtWidgets.QMessageBox.ButtonRole.ActionRole)
+        releases_button = box.addButton(tr("Releases"), QtWidgets.QMessageBox.ButtonRole.ActionRole)
+        update_button = box.addButton(tr("Update"), QtWidgets.QMessageBox.ButtonRole.ActionRole)
         update_button.setEnabled(can_update)
         box.addButton(QtWidgets.QMessageBox.StandardButton.Close)
         box.exec()
@@ -1415,19 +1426,21 @@ class PixelCatWindow(QtWidgets.QWidget):
             # this IP). Don't claim we're up to date — say the check failed.
             self.update_box(
                 "myCat",
-                f"Current: {current}",
-                "Couldn't reach GitHub — try again in a bit.",
+                tr("Current: {current}").format(current=current),
+                tr("Couldn't reach GitHub — try again in a bit."),
                 kind,
                 can_update=False,
             )
             return
-        versions = f"Current: {current}\nLatest: {latest}"
+        versions = tr("Current: {current}\nLatest: {latest}").format(
+            current=current, latest=latest
+        )
         if update_check.parse_version(latest) <= update_check.parse_version(current):
             # Up to date — nothing to update, so Update stays greyed out.
             self.update_box(
                 "myCat",
                 versions,
-                "No update needed — you're on the latest version. 🐱",
+                tr("No update needed — you're on the latest version. 🐱"),
                 kind,
                 can_update=False,
             )
@@ -1437,7 +1450,9 @@ class PixelCatWindow(QtWidgets.QWidget):
             self.update_box(
                 "myCat",
                 versions,
-                f"Update available. Update with:\n\n    {updater.update_hint(kind)}",
+                tr("Update available. Update with:\n\n    {hint}").format(
+                    hint=updater.update_hint(kind)
+                ),
                 kind,
                 can_update=False,
             )
@@ -1446,15 +1461,15 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.update_box(
             "myCat",
             versions,
-            "Update available — click Update to download and restart.",
+            tr("Update available — click Update to download and restart."),
             kind,
             can_update=True,
         )
 
     def download_update(self, kind: str) -> None:
         signals = self.update_signals
-        dialog = QtWidgets.QProgressDialog("Downloading update…", "Cancel", 0, 100, self)
-        dialog.setWindowTitle("Updating myCat")
+        dialog = QtWidgets.QProgressDialog(tr("Downloading update…"), tr("Cancel"), 0, 100, self)
+        dialog.setWindowTitle(tr("Updating myCat"))
         dialog.setMinimumDuration(0)
         dialog.setAutoClose(False)
         dialog.setAutoReset(False)
@@ -1465,7 +1480,7 @@ class PixelCatWindow(QtWidgets.QWidget):
         signals.progress.connect(
             lambda done, total: dialog.setValue(int(done * 100 / total) if total else 0)
         )
-        signals.applied.connect(lambda: (dialog.setLabelText("Restarting…"), self.finish_update()))
+        signals.applied.connect(lambda: (dialog.setLabelText(tr("Restarting…")), self.finish_update()))
         signals.failed.connect(lambda message: (dialog.close(), self.on_update_failed(message)))
 
         def worker() -> None:
@@ -1502,7 +1517,9 @@ class PixelCatWindow(QtWidgets.QWidget):
 
     def on_update_failed(self, message: str) -> None:
         logger.warning("Update failed: %s", message)
-        QtWidgets.QMessageBox.warning(self, "Update failed", f"Couldn't update: {message}")
+        QtWidgets.QMessageBox.warning(
+            self, tr("Update failed"), tr("Couldn't update: {message}").format(message=message)
+        )
 
     def on_char_installed(self, _char_id: str) -> None:
         self.available_images = char_catalog.scan_all()
@@ -1511,7 +1528,57 @@ class PixelCatWindow(QtWidgets.QWidget):
         self.available_images = char_catalog.scan_all()
         if self.file_name == char_id and self.available_images:
             self.load_image(self.available_images[0])
-    
+
+    def build_tray_menu(self):
+        """(Re)build the system-tray context menu in the current language."""
+        tray = getattr(self, "tray_icon", None)
+        if tray is None:
+            return None
+        menu = QtWidgets.QMenu(self)
+        toggle_chat = getattr(self, "toggle_llm_chat", None)
+        if callable(toggle_chat):
+            menu.addAction(tr("Chat"), toggle_chat)
+        # Same order as the context menu: LLM, Calendar, Reminder, GitHub, Activity.
+        menu.addAction(tr("LLM…"), self.open_llm_settings)
+        menu.addAction(tr("Calendar…"), self.open_calendar_settings)
+        menu.addAction(tr("Reminder…"), self.open_reminder)
+        menu.addAction(tr("GitHub…"), self.open_github_settings)
+        menu.addAction(tr("Activity…"), self.open_activity_dialog)
+
+        # Focus is fully automatic now (earned from activity) — no tray toggle.
+
+        menu.addAction(tr("Reset"), self.reset_position)
+        menu.addAction(tr("Update…"), self.open_update)
+        if autostart.is_supported():
+            menu.addSeparator()
+            login_action = menu.addAction(tr("Autostart"))
+            login_action.setCheckable(True)
+            login_action.setChecked(autostart.is_enabled())
+            login_action.toggled.connect(autostart.set_enabled)
+        menu.addSeparator()
+        i18n.build_language_menu(menu, CFG_FILE)
+        toggle_action = menu.addAction(tr("Close"))
+        toggle_action.triggered.connect(self.toggle_tray_window)
+        menu.addAction(tr("Quit"), QtWidgets.QApplication.quit)
+        # Dynamic label: "Open" when the cat is hidden, "Close" when it's on screen.
+        menu.aboutToShow.connect(
+            lambda: toggle_action.setText(tr("Open") if not self.isVisible() else tr("Close"))
+        )
+        tray.setContextMenu(menu)
+        return menu
+
+    def toggle_tray_window(self) -> None:
+        if self.isVisible():
+            self.hide()
+        else:
+            self.show()
+            self.raise_()
+
+    def rebuild_menus(self) -> None:
+        """Retranslate the tray menu after a language switch."""
+        if getattr(self, "tray_icon", None) is not None:
+            self.build_tray_menu()
+
     def schedule_next_animation(self) -> None:
         """Schedule the next PNG -> GIF transition with a single-shot timer."""
         delay_ms = max(0, int(self.wait_time * 1000))
@@ -2102,47 +2169,8 @@ def setup_tray(app, window):
         window.show()
         window.raise_()
 
-    def toggle_window():
-        if window.isVisible():
-            window.hide()
-        else:
-            show_window()
-
-    menu = QtWidgets.QMenu(window)
-    toggle_chat = getattr(window, "toggle_llm_chat", None)
-    if callable(toggle_chat):
-        menu.addAction("Chat", toggle_chat)
-    # Same order as the context menu: LLM, Calendar, Reminder, GitHub, Activity.
-    menu.addAction("LLM…", window.open_llm_settings)
-    menu.addAction("Calendar…", window.open_calendar_settings)
-    menu.addAction("Reminder…", window.open_reminder)
-    menu.addAction("GitHub…", window.open_github_settings)
-    menu.addAction("Activity…", window.open_activity_dialog)
-
-    # Focus is fully automatic now (earned from activity) — no tray toggle.
-
-    menu.addAction("Reset", window.reset_position)
-    menu.addAction("Update…", window.open_update)
-    if autostart.is_supported():
-        menu.addSeparator()
-        login_action = menu.addAction("Autostart")
-        login_action.setCheckable(True)
-        login_action.setChecked(autostart.is_enabled())
-        login_action.toggled.connect(autostart.set_enabled)
-    menu.addSeparator()
-    toggle_action = menu.addAction("Close")
-    toggle_action.triggered.connect(toggle_window)
-    menu.addAction("Quit", QtWidgets.QApplication.quit)
-    # Dynamic label: "Open" when the cat is hidden, "Close" when it's on screen.
-    menu.aboutToShow.connect(
-        lambda: toggle_action.setText("Open" if not window.isVisible() else "Close")
-    )
-    tray.setContextMenu(menu)
-
-    def sync_toggle_label():
-        toggle_action.setText("Close" if window.isVisible() else "Open")
-
-    menu.aboutToShow.connect(sync_toggle_label)
+    # Menu is built (and rebuilt) by the window so a language switch retranslates it.
+    window.build_tray_menu()
 
     def on_activated(reason):
         if reason == QtWidgets.QSystemTrayIcon.ActivationReason.DoubleClick:
@@ -2161,6 +2189,9 @@ def setup_tray(app, window):
 def main() -> None:
     """Main entry point."""
     args = parse_args()
+
+    # Restore the persisted UI language before any window/menu is built.
+    i18n.load_language(CFG_FILE)
 
     if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/mycat/reminder_ui.py
+++ b/mycat/reminder_ui.py
@@ -221,7 +221,8 @@ class FlybyWindow(QtWidgets.QWidget):
         if self.link_url:
             self.setToolTip(tr("Double-click to open • Drag to move • Right-click for options"))
 
-        self.text = (reminder.text or reminder_mod.DEFAULT_TEXT).strip() or reminder_mod.DEFAULT_TEXT
+        default_text = tr(reminder_mod.DEFAULT_TEXT)
+        self.text = (reminder.text or default_text).strip() or default_text
         self.ltr = reminder.normalized_direction() != DIRECTION_RTL
         self.progress = 0.0
         # Set on start(); paintEvent reads monotonic time so the flag ripple and

--- a/mycat/reminder_ui.py
+++ b/mycat/reminder_ui.py
@@ -22,12 +22,15 @@ from PySide6 import QtCore, QtGui, QtWidgets
 
 if __package__:
     from . import reminder as reminder_mod
+    from . import i18n
 else:
     import importlib
 
     reminder_mod = importlib.import_module("mycat.reminder")
+    i18n = importlib.import_module("mycat.i18n")
 
 Reminder = reminder_mod.Reminder
+tr = i18n.tr
 
 
 def has_no_x11_compositor() -> bool:
@@ -186,7 +189,7 @@ class FlybyWindow(QtWidgets.QWidget):
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_DeleteOnClose, True)
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
         self.setCursor(QtCore.Qt.CursorShape.OpenHandCursor)
-        self.setToolTip("Drag to move • Right-click for options")
+        self.setToolTip(tr("Drag to move • Right-click for options"))
 
         # Drag state — clicking the plane pauses the flight and lets the user
         # park it; right-click brings up a resume/close menu.
@@ -216,7 +219,7 @@ class FlybyWindow(QtWidgets.QWidget):
         # attach a URL; a double-click or the context menu opens it.
         self.link_url = str(getattr(reminder, "url", "") or "")
         if self.link_url:
-            self.setToolTip("Double-click to open • Drag to move • Right-click for options")
+            self.setToolTip(tr("Double-click to open • Drag to move • Right-click for options"))
 
         self.text = (reminder.text or reminder_mod.DEFAULT_TEXT).strip() or reminder_mod.DEFAULT_TEXT
         self.ltr = reminder.normalized_direction() != DIRECTION_RTL
@@ -670,14 +673,14 @@ class FlybyWindow(QtWidgets.QWidget):
 
         menu = QtWidgets.QMenu(self)
         if self.link_url:
-            menu.addAction("Open link", self.open_link)
+            menu.addAction(tr("Open link"), self.open_link)
             menu.addSeparator()
         if main_paused or exit_paused or self.anim.state() == QtCore.QAbstractAnimation.State.Stopped:
-            menu.addAction("Resume flight", self.resume_flight)
+            menu.addAction(tr("Resume flight"), self.resume_flight)
         elif main_running or exit_running:
-            menu.addAction("Pause flight", self.pause_flight)
+            menu.addAction(tr("Pause flight"), self.pause_flight)
         menu.addSeparator()
-        menu.addAction("Close", self.close)
+        menu.addAction(tr("Close"), self.close)
         menu.exec(event.globalPos())
 
     def open_link(self) -> None:
@@ -781,7 +784,7 @@ class ReminderDialog(QtWidgets.QDialog):
     def __init__(self, controller, reminder, parent=None) -> None:
         super().__init__(parent)
         self.controller = controller
-        self.setWindowTitle("Reminder")
+        self.setWindowTitle(tr("Reminder"))
         self.setMinimumWidth(380)
         # Force a complete light theme on the whole dialog. Styling only the input
         # fields left the dialog background, labels, group box and buttons to the
@@ -816,16 +819,16 @@ class ReminderDialog(QtWidgets.QDialog):
         form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
 
         self.text_edit = QtWidgets.QLineEdit(existing.text)
-        self.text_edit.setPlaceholderText("What should the cat remind you about?")
+        self.text_edit.setPlaceholderText(tr("What should the cat remind you about?"))
         self.text_edit.setMaxLength(120)
-        form.addRow("Message", self.text_edit)
+        form.addRow(tr("Message"), self.text_edit)
 
         self.direction = QtWidgets.QComboBox()
-        self.direction.addItem("Left → Right", DIRECTION_LTR)
-        self.direction.addItem("Right → Left", DIRECTION_RTL)
+        self.direction.addItem(tr("Left → Right"), DIRECTION_LTR)
+        self.direction.addItem(tr("Right → Left"), DIRECTION_RTL)
         idx = self.direction.findData(existing.normalized_direction())
         self.direction.setCurrentIndex(max(0, idx))
-        form.addRow("Direction", self.direction)
+        form.addRow(tr("Direction"), self.direction)
 
         self.plane_combo = QtWidgets.QComboBox()
         self.plane_combo.setIconSize(QtCore.QSize(48, 24))
@@ -846,7 +849,7 @@ class ReminderDialog(QtWidgets.QDialog):
             self.plane_combo.addItem(icon, name.capitalize(), name)
         idx = self.plane_combo.findData(existing.plane)
         self.plane_combo.setCurrentIndex(max(0, idx))
-        form.addRow("Plane", self.plane_combo)
+        form.addRow(tr("Plane"), self.plane_combo)
 
         self.color = QtWidgets.QComboBox()
         for name, qcolor in PLANE_COLORS.items():
@@ -855,30 +858,30 @@ class ReminderDialog(QtWidgets.QDialog):
             self.color.addItem(QtGui.QIcon(swatch), name.capitalize(), name)
         idx = self.color.findData(existing.plane_color)
         self.color.setCurrentIndex(max(0, idx))
-        form.addRow("Plane color", self.color)
+        form.addRow(tr("Plane color"), self.color)
 
         self.plane_width_spin = QtWidgets.QSpinBox()
         self.plane_width_spin.setRange(120, 500)
-        self.plane_width_spin.setSuffix(" px")
+        self.plane_width_spin.setSuffix(tr(" px"))
         # Height follows the sprite's aspect ratio — only the width is user-set.
         self.plane_width_spin.setValue(max(120, int(existing.plane_width)))
-        form.addRow("Plane width", self.plane_width_spin)
+        form.addRow(tr("Plane width"), self.plane_width_spin)
 
         layout.addLayout(form)
 
         # Timing: "in N minutes" or "at HH:MM".
-        timing_box = QtWidgets.QGroupBox("When")
+        timing_box = QtWidgets.QGroupBox(tr("When"))
         timing_layout = QtWidgets.QGridLayout(timing_box)
 
-        self.in_radio = QtWidgets.QRadioButton("In")
+        self.in_radio = QtWidgets.QRadioButton(tr("In"))
         self.in_spin = QtWidgets.QSpinBox()
         self.in_spin.setRange(0, 1440)
-        self.in_spin.setSuffix(" min")
+        self.in_spin.setSuffix(tr(" min"))
         # 0 = fire on the very next scheduler tick (within ~1s).
-        self.in_spin.setSpecialValueText("now")
+        self.in_spin.setSpecialValueText(tr("now"))
         self.in_spin.setValue(max(0, existing.in_minutes))
 
-        self.at_radio = QtWidgets.QRadioButton("At")
+        self.at_radio = QtWidgets.QRadioButton(tr("At"))
         self.at_time = QtWidgets.QTimeEdit()
         self.at_time.setDisplayFormat("HH:mm")
         if existing.mode == "at" and existing.fire_at is not None:
@@ -891,7 +894,7 @@ class ReminderDialog(QtWidgets.QDialog):
         timing_layout.addWidget(self.at_radio, 1, 0)
         timing_layout.addWidget(self.at_time, 1, 1)
 
-        self.repeat = QtWidgets.QCheckBox("Repeat daily")
+        self.repeat = QtWidgets.QCheckBox(tr("Repeat daily"))
         self.repeat.setChecked(existing.repeat_daily)
         timing_layout.addWidget(self.repeat, 2, 0, 1, 2)
 
@@ -907,10 +910,10 @@ class ReminderDialog(QtWidgets.QDialog):
         # Buttons: Test, Reset (left) · Save, Close (right) — same order as
         # every other mycat dialog.
         buttons = QtWidgets.QHBoxLayout()
-        test_btn = QtWidgets.QPushButton("Test")
-        reset_btn = QtWidgets.QPushButton("Reset")
-        close_btn = QtWidgets.QPushButton("Close")
-        save_btn = QtWidgets.QPushButton("Save")
+        test_btn = QtWidgets.QPushButton(tr("Test"))
+        reset_btn = QtWidgets.QPushButton(tr("Reset"))
+        close_btn = QtWidgets.QPushButton(tr("Close"))
+        save_btn = QtWidgets.QPushButton(tr("Save"))
         save_btn.setDefault(True)
         test_btn.clicked.connect(self.on_test)
         reset_btn.clicked.connect(self.on_clear)
@@ -951,13 +954,15 @@ class ReminderDialog(QtWidgets.QDialog):
             self.status_label.clear()
             return
         if remaining >= 60:
-            left = f"{(remaining + 59) // 60} min"  # ceil, so 10:00 shows "10 min"
+            left = f"{(remaining + 59) // 60} {tr('min')}"  # ceil, so 10:00 shows "10 min"
         else:
-            left = f"{remaining} sec"
+            left = f"{remaining} {tr('sec')}"
         at = reminder.fire_at.strftime("%H:%M")
-        daily = ", daily" if reminder.repeat_daily else ""
+        daily = tr(", daily") if reminder.repeat_daily else ""
         self.status_label.setStyleSheet("color: #1c7c2f;")
-        self.status_label.setText(f"Reminder in {left}. ({at}{daily})")
+        self.status_label.setText(
+            tr("Reminder in {left}. ({at}{daily})").format(left=left, at=at, daily=daily)
+        )
 
     def sync_timing_enabled(self) -> None:
         in_mode = self.in_radio.isChecked()
@@ -1034,7 +1039,7 @@ class ReminderDialog(QtWidgets.QDialog):
         self.at_time.setTime(QtCore.QTime.currentTime().addSecs(600))
         self.sync_timing_enabled()
         self.status_label.setStyleSheet("color: #777777;")
-        self.status_label.setText("Reminder cleared.")
+        self.status_label.setText(tr("Reminder cleared."))
 
     def on_save(self) -> None:
         reminder = self.build_reminder()
@@ -1046,4 +1051,4 @@ class ReminderDialog(QtWidgets.QDialog):
             self.countdown.start()
         else:
             self.status_label.setStyleSheet("color: #1c7c2f;")
-            self.status_label.setText("Reminder set.")
+            self.status_label.setText(tr("Reminder set."))

--- a/mycat/reminder_ui.py
+++ b/mycat/reminder_ui.py
@@ -21,8 +21,8 @@ from pathlib import Path
 from PySide6 import QtCore, QtGui, QtWidgets
 
 if __package__:
-    from . import reminder as reminder_mod
     from . import i18n
+    from . import reminder as reminder_mod
 else:
     import importlib
 

--- a/mycat/settings_ui.py
+++ b/mycat/settings_ui.py
@@ -4,12 +4,14 @@ from pathlib import Path
 
 from PySide6 import QtWidgets
 
+from .i18n import tr
+
 logger = logging.getLogger(__name__)
 
 class SettingsDialog(QtWidgets.QDialog):
     def __init__(self, parent=None, config_path: Path = None, main_window=None):
         super().__init__(parent)
-        self.setWindowTitle("Settings")
+        self.setWindowTitle(tr("Settings"))
         self.config_path = config_path
         self.main_window = main_window
         self.setMinimumWidth(300)
@@ -19,7 +21,7 @@ class SettingsDialog(QtWidgets.QDialog):
 
         # Wait Time
         wait_layout = QtWidgets.QHBoxLayout()
-        wait_label = QtWidgets.QLabel("Animation Wait Time (s):")
+        wait_label = QtWidgets.QLabel(tr("Animation Wait Time (s):"))
         self.wait_spinbox = QtWidgets.QDoubleSpinBox()
         self.wait_spinbox.setRange(0.5, 60.0)
         self.wait_spinbox.setSingleStep(0.5)
@@ -69,6 +71,8 @@ class SettingsDialog(QtWidgets.QDialog):
 
             except Exception as e:
                 logger.error(f"Error saving settings to INI file: {e}")
-                QtWidgets.QMessageBox.critical(self, "Error", f"Failed to save settings:\n{e}")
+                QtWidgets.QMessageBox.critical(
+                    self, tr("Error"), tr("Failed to save settings:\n{e}").format(e=e)
+                )
 
         super().accept()

--- a/mycat/shop_ui.py
+++ b/mycat/shop_ui.py
@@ -12,8 +12,7 @@ from pathlib import Path
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from . import char_catalog
-from . import i18n
+from . import char_catalog, i18n
 from .shop_api import (
     Catalog,
     CharEntry,

--- a/mycat/shop_ui.py
+++ b/mycat/shop_ui.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from . import char_catalog
+from . import i18n
 from .shop_api import (
     Catalog,
     CharEntry,
@@ -22,6 +23,7 @@ from .shop_api import (
 )
 
 logger = logging.getLogger(__name__)
+tr = i18n.tr
 
 
 # --- workers ------------------------------------------------------------------
@@ -141,7 +143,7 @@ class CharCard(QtWidgets.QFrame):
         name.setWordWrap(True)
         layout.addWidget(name)
 
-        author = QtWidgets.QLabel(f"by {char.author or 'unknown'}")
+        author = QtWidgets.QLabel(tr("by {author}").format(author=char.author or tr("unknown")))
         author.setStyleSheet("color:#666; font-size:11px;")
         layout.addWidget(author)
 
@@ -185,9 +187,9 @@ class CharCard(QtWidgets.QFrame):
 
     def refresh_button(self) -> None:
         if self.installed:
-            self.button.setText("✓ Installed — Uninstall")
+            self.button.setText(tr("✓ Installed — Uninstall"))
         else:
-            self.button.setText("Install")
+            self.button.setText(tr("Install"))
         self.button.setEnabled(True)
 
     def set_progress(self, done: int, total: int) -> None:
@@ -197,12 +199,12 @@ class CharCard(QtWidgets.QFrame):
             self.progress.setValue(min(100, int(done * 100 / total)))
         else:
             self.progress.setRange(0, 0)
-        self.button.setText(f"Downloading… {done // 1024 or 1} KB")
+        self.button.setText(tr("Downloading… {kb} KB").format(kb=done // 1024 or 1))
         self.button.setEnabled(False)
 
     def set_failed(self, message: str) -> None:
         self.progress.setVisible(False)
-        self.button.setText("Retry")
+        self.button.setText(tr("Retry"))
         self.button.setEnabled(True)
         self.button.setToolTip(message)
 
@@ -244,7 +246,7 @@ class ShopDialog(QtWidgets.QDialog):
         config_path: Path | None = None,
     ) -> None:
         super().__init__(parent)
-        self.setWindowTitle("myCat Shop")
+        self.setWindowTitle(tr("myCat Shop"))
         self.resize(760, 540)
         self.setMinimumSize(560, 380)
         self.setModal(False)
@@ -279,12 +281,12 @@ class ShopDialog(QtWidgets.QDialog):
         self.title_label = QtWidgets.QLabel("<b>myCat Shop</b>")
         header.addWidget(self.title_label)
         header.addStretch(1)
-        self.refresh_button = QtWidgets.QPushButton("Refresh")
+        self.refresh_button = QtWidgets.QPushButton(tr("Refresh"))
         self.refresh_button.clicked.connect(lambda: self.refresh_catalog(force=True))
         header.addWidget(self.refresh_button)
         root.addLayout(header)
 
-        self.url_label = QtWidgets.QLabel(f"Server: {self.client.base_url}")
+        self.url_label = QtWidgets.QLabel(tr("Server: {url}").format(url=self.client.base_url))
         self.url_label.setStyleSheet("color:#888; font-size:11px;")
         root.addWidget(self.url_label)
 
@@ -301,7 +303,7 @@ class ShopDialog(QtWidgets.QDialog):
         self.catalog_grid.setVerticalSpacing(8)
         self.catalog_grid.setAlignment(QtCore.Qt.AlignmentFlag.AlignTop)
         self.catalog_scroll.setWidget(self.catalog_content)
-        self.tabs.addTab(self.catalog_scroll, "Catalog")
+        self.tabs.addTab(self.catalog_scroll, tr("Catalog"))
 
         # My Chars tab
         my_chars_widget = QtWidgets.QWidget()
@@ -310,12 +312,12 @@ class ShopDialog(QtWidgets.QDialog):
         self.my_chars_list = QtWidgets.QListWidget()
         my_chars_layout.addWidget(self.my_chars_list, 1)
         buttons = QtWidgets.QHBoxLayout()
-        self.uninstall_button = QtWidgets.QPushButton("Uninstall selected")
+        self.uninstall_button = QtWidgets.QPushButton(tr("Uninstall selected"))
         self.uninstall_button.clicked.connect(self.uninstall_selected)
         buttons.addWidget(self.uninstall_button)
         buttons.addStretch(1)
         my_chars_layout.addLayout(buttons)
-        self.tabs.addTab(my_chars_widget, "My Chars")
+        self.tabs.addTab(my_chars_widget, tr("My Chars"))
 
         # Footer
         self.status_label = QtWidgets.QLabel("")
@@ -333,7 +335,7 @@ class ShopDialog(QtWidgets.QDialog):
     # ---- catalog flow -----------------------------------------------------
 
     def refresh_catalog(self, *, force: bool = False) -> None:
-        self.status_label.setText("Loading catalog…")
+        self.status_label.setText(tr("Loading catalog…"))
         self.refresh_button.setEnabled(False)
         worker = CatalogWorker(self.client, self.signals, force_refresh=force)
         self.pool.start(worker)
@@ -343,7 +345,7 @@ class ShopDialog(QtWidgets.QDialog):
         self.refresh_button.setEnabled(True)
         self.render_catalog()
         self.refresh_my_chars()
-        self.status_label.setText(f"{len(catalog.chars)} chars available.")
+        self.status_label.setText(tr("{count} chars available.").format(count=len(catalog.chars)))
 
     def on_catalog_failed(self, message: str) -> None:
         self.refresh_button.setEnabled(True)
@@ -359,7 +361,7 @@ class ShopDialog(QtWidgets.QDialog):
         self.cards.clear()
 
         if not self.catalog or not self.catalog.chars:
-            empty = QtWidgets.QLabel("No chars available.")
+            empty = QtWidgets.QLabel(tr("No chars available."))
             empty.setStyleSheet("color:#888;")
             self.catalog_grid.addWidget(empty, 0, 0)
             return
@@ -385,11 +387,15 @@ class ShopDialog(QtWidgets.QDialog):
             return
         if char.tier != "free":
             # Premium tiers require entitlements; not in MVP.
-            self.status_label.setText(f"⚠ Premium char '{char.name}' requires a subscription (coming soon).")
+            self.status_label.setText(
+                tr("⚠ Premium char '{name}' requires a subscription (coming soon).").format(
+                    name=char.name
+                )
+            )
             return
         worker = DownloadWorker(self.client, self.signals, char, self.user_chars_dir)
         self.pool.start(worker)
-        self.status_label.setText(f"Downloading {char.name}…")
+        self.status_label.setText(tr("Downloading {name}…").format(name=char.name))
 
     def on_download_progress(self, char_id: str, done: int, total: int) -> None:
         card = self.cards.get(char_id)
@@ -400,7 +406,7 @@ class ShopDialog(QtWidgets.QDialog):
         card = self.cards.get(char_id)
         if card is not None:
             card.set_installed(True)
-        self.status_label.setText(f"Installed: {char_id}")
+        self.status_label.setText(tr("Installed: {id}").format(id=char_id))
         self.refresh_my_chars()
         self.char_installed.emit(char_id)
 
@@ -408,18 +414,20 @@ class ShopDialog(QtWidgets.QDialog):
         card = self.cards.get(char_id)
         if card is not None:
             card.set_failed(message)
-        self.status_label.setText(f"⚠ Failed: {char_id} — {message}")
+        self.status_label.setText(
+            tr("⚠ Failed: {id} — {message}").format(id=char_id, message=message)
+        )
 
     def uninstall_char(self, char_id: str) -> None:
         if char_catalog.remove_installed(char_id):
             card = self.cards.get(char_id)
             if card is not None:
                 card.set_installed(False)
-            self.status_label.setText(f"Uninstalled: {char_id}")
+            self.status_label.setText(tr("Uninstalled: {id}").format(id=char_id))
             self.refresh_my_chars()
             self.char_uninstalled.emit(char_id)
         else:
-            self.status_label.setText(f"⚠ Could not uninstall {char_id}")
+            self.status_label.setText(tr("⚠ Could not uninstall {id}").format(id=char_id))
 
     def uninstall_selected(self) -> None:
         item = self.my_chars_list.currentItem()

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,66 @@
+"""i18n: translation lookup, language persistence and the language menu."""
+
+import configparser
+
+from PySide6 import QtWidgets
+
+from mycat import i18n
+
+
+def test_default_language_is_english(monkeypatch):
+    monkeypatch.setattr(i18n, "_current", "en")
+    assert i18n.current_language() == "en"
+    assert i18n.is_chinese() is False
+
+
+def test_tr_returns_english_in_english_mode(monkeypatch):
+    monkeypatch.setattr(i18n, "_current", "en")
+    # English mode returns the source string unchanged.
+    assert i18n.tr("Close") == "Close"
+    assert i18n.tr("No such string") == "No such string"
+
+
+def test_tr_translates_in_chinese_mode(monkeypatch):
+    monkeypatch.setattr(i18n, "_current", "zh")
+    assert i18n.tr("Close") == "关闭"
+    # Untranslated strings fall through to English.
+    assert i18n.tr("No such string") == "No such string"
+
+
+def test_tr_keeps_format_placeholders(monkeypatch):
+    monkeypatch.setattr(i18n, "_current", "zh")
+    translated = i18n.tr("Current: {status}")
+    assert "{status}" in translated
+    assert translated.format(status="工作") == "当前：工作"
+
+
+def test_set_language_persists_to_config(tmp_path):
+    config_file = tmp_path / "config.ini"
+    i18n.set_language("zh", config_file)
+    config = configparser.ConfigParser()
+    config.read(config_file)
+    assert config["settings"]["language"] == "zh"
+
+
+def test_load_language_restores_persisted_language(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.ini"
+    i18n.set_language("zh", config_file)
+    monkeypatch.setattr(i18n, "_current", "en")
+    assert i18n.load_language(config_file) == "zh"
+    assert i18n.is_chinese() is True
+
+
+def test_set_language_falls_back_on_unknown_code(tmp_path):
+    config_file = tmp_path / "config.ini"
+    i18n.set_language("fr", config_file)
+    assert i18n.current_language() == i18n.DEFAULT_LANGUAGE
+
+
+def test_build_language_menu_has_radio_actions(qapp):
+    menu = QtWidgets.QMenu()
+    i18n.build_language_menu(menu, config_path=None)
+    # The "Language" submenu carries the two radio actions.
+    submenus = [a.menu() for a in menu.actions() if a.menu() is not None]
+    language_menu = submenus[0]
+    labels = [action.text() for action in language_menu.actions()]
+    assert set(labels) == {"English", "简体中文"}


### PR DESCRIPTION
This PR adds full internationalization support to myCat, allowing users to switch
between English and Simplified Chinese from the system-tray context menu.

### Changes

- **`mycat/i18n.py`** — Core translation module with `tr()` function, language
  persistence to `config.ini`, and a `build_language_menu()` helper.
- **`mycat/main.py`** — System-tray menu rebuilt on every language switch; added
  a "Language" submenu with radio‑button selection.
- **All UI files** — Every visible string in `activity_ui.py`, `ai_char_ui.py`,
  `calendar_ui.py`, `github_ui.py`, `key_heatmap_ui.py`, `llm_settings_ui.py`,
  `llm_ui.py`, `reminder_ui.py`, `settings_ui.py`, `shop_ui.py` is wrapped in
  `tr()`.
- **`mycat/digest.py`**, **`mycat/focus.py`** — Translated notification and
  focus‑mode messages.
- **`tests/test_i18n.py`** — Unit tests covering translation lookup, language
  persistence, menu building, and edge cases.
- **`README.md`** — Mentioned the language‑switch feature in the feature list.

### How to use

Right‑click the desktop cat → **Language** → **English** / **简体中文**.
The choice is remembered for next launch.

### Notes

- Untranslated strings fall through to English, so the app remains usable even
  if a string is missed.
- The language setting is stored in `config.ini` under `[settings] language`.