### PR TITLE
ci: isolate each test in its own process (fix offscreen Qt crash/hang)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install package + dev tools
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pytest
+          pip install ruff pytest pytest-forked pytest-timeout
           # [calendar] pulls icalendar/recurring-ical-events so the calendar
           # tests actually run (they hard-require the parser libs).
           pip install .[calendar]
@@ -34,7 +34,11 @@ jobs:
       - name: Ruff
         run: ruff check .
 
+      # Each test runs in its own forked process: Qt's offscreen platform is
+      # unstable when many tests share one process (a later Qt test can crash or
+      # hang on an earlier test's teardown). --timeout bounds any stuck test to
+      # seconds; --timeout-method=thread is required to bound a hang under --forked.
       - name: Tests
         env:
           QT_QPA_PLATFORM: offscreen
-        run: python -m pytest -q
+        run: python -m pytest -q --forked --timeout=60 --timeout-method=thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **CI runs each test in its own process, so the headless test suite stops crashing/hanging.** Under the offscreen Qt platform, tests that share one process could corrupt each other on teardown — a char-pack animation-decode test segfaulted whenever it ran after any test that had created a `QApplication`, and in CI the run hung to the 6-hour job timeout (each test file passed in isolation; it was a pre-existing cross-test flake, reproducible back to 0.1.29). The CI test step now runs `pytest --forked --timeout=60 --timeout-method=thread`, isolating every test in its own subprocess so one test's Qt teardown can't reach the next, with a per-test timeout so a stuck test fails in seconds instead of hours (branch `fix/ci-flaky-qt-tests`).
+
 ## [0.1.30] - 2026-08-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dependencies = [
 dev = [
     "ruff>=0.14.3",
     "pytest>=8.0",
+    # Run each test in its own process (Qt's offscreen platform is unstable
+    # across tests in one process); pytest-timeout bounds any stuck test.
+    "pytest-forked>=1.6",
+    "pytest-timeout>=2.0",
 ]
 
 # Optional: store API keys in the OS keyring instead of plaintext config.


### PR DESCRIPTION
## Summary

CI's headless (offscreen) Qt test run could crash or hang from cross-test teardown state. `test_char_engine`'s char-pack animation decode **segfaulted** whenever it ran in the same process after any test that had created a `QApplication` (calendar / reminder / activity / speech-bubble tests all trigger it); in CI it instead **hung to the 6-hour job timeout**. Each test *file* passes in isolation — it's a pre-existing cross-test flake, reproducible back to **0.1.29**, not from any recent feature.

Fix: run the CI test step under **pytest-forked** so every test executes in its own subprocess (one test's Qt teardown can't reach the next), with **pytest-timeout** bounding any stuck test to seconds. `--timeout-method=thread` is required to bound a hang under `--forked` (the default `signal` method does not).

Changes:
- `ci.yml`: install `pytest-forked` + `pytest-timeout`; test step runs `pytest -q --forked --timeout=60 --timeout-method=thread`.
- `pyproject.toml`: add both to the `dev` extra.
- `CHANGELOG.md`: note under Unreleased.

## Test plan

- [x] Repro confirmed: `test_reminder.py + test_char_engine.py` in one process = segfault (exit 139); with `--forked` = exit 0.
- [x] Full suite offscreen **with** an X server: `268 passed`, exit 0.
- [x] Full suite offscreen **without** DISPLAY (CI-like): `268 passed`, exit 0.
- [x] Exact CI flags (`--forked --timeout=60 --timeout-method=thread`), no-DISPLAY: `268 passed`, exit 0.
- [ ] CI green on this PR (both Python 3.10 and 3.12).