### PR TITLE
feat: polish the speech bubble + name the toggle SpeechBubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 
 ### Changed
-- **The speech bubble is bolder and roomier, and its toggle is named SpeechBubble.** The bubble text is now bold inside a wider solid-black outline (so it matches the cat's own linework), with roomier side padding so longer messages aren't cramped against the edge. In *Settings → Messages* the English label for the mode is now **SpeechBubble** (中文 / Русский / 한국어 keep their translated labels — 气泡 / Облачко / 말풍선) (branch `feat/speech-bubble-polish`).
+- **The speech bubble is bolder and roomier, and its toggle is named SpeechBubble.** The bubble text is now bold inside a clean solid-black outline (so it matches the cat's own linework), with roomier side padding so longer messages aren't cramped against the edge. In *Settings → Messages* the English label for the mode is now **SpeechBubble** (中文 / Русский / 한국어 keep their translated labels — 气泡 / Облачко / 말풍선) (branch `feat/speech-bubble-polish`).
 
 ### Fixed
 - **CI runs each test in its own process, so the headless test suite stops crashing/hanging.** Under the offscreen Qt platform, tests that share one process could corrupt each other on teardown — a char-pack animation-decode test segfaulted whenever it ran after any test that had created a `QApplication`, and in CI the run hung to the 6-hour job timeout (each test file passed in isolation; it was a pre-existing cross-test flake, reproducible back to 0.1.29). The CI test step now runs `pytest --forked --timeout=60 --timeout-method=thread`, isolating every test in its own subprocess so one test's Qt teardown can't reach the next, with a per-test timeout so a stuck test fails in seconds instead of hours (branch `fix/ci-flaky-qt-tests`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased]
+## [0.1.31] - 2026-08-21
 
 ### Changed
 - **The speech bubble is bolder and roomier, and its toggle is named SpeechBubble.** The bubble text is now bold inside a clean solid-black outline (so it matches the cat's own linework), with roomier side padding so longer messages aren't cramped against the edge. In *Settings → Messages* the English label for the mode is now **SpeechBubble** (中文 / Русский / 한국어 keep their translated labels — 气泡 / Облачко / 말풍선) (branch `feat/speech-bubble-polish`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **The speech bubble is bolder and roomier, and its toggle is named SpeechBubble.** The bubble text is now bold inside a wider solid-black outline (so it matches the cat's own linework), with roomier side padding so longer messages aren't cramped against the edge. In *Settings → Messages* the English label for the mode is now **SpeechBubble** (中文 / Русский / 한국어 keep their translated labels — 气泡 / Облачко / 말풍선) (branch `feat/speech-bubble-polish`).
+
 ### Fixed
 - **CI runs each test in its own process, so the headless test suite stops crashing/hanging.** Under the offscreen Qt platform, tests that share one process could corrupt each other on teardown — a char-pack animation-decode test segfaulted whenever it ran after any test that had created a `QApplication`, and in CI the run hung to the 6-hour job timeout (each test file passed in isolation; it was a pre-existing cross-test flake, reproducible back to 0.1.29). The CI test step now runs `pytest --forked --timeout=60 --timeout-method=thread`, isolating every test in its own subprocess so one test's Qt teardown can't reach the next, with a per-test timeout so a stuck test fails in seconds instead of hours (branch `fix/ci-flaky-qt-tests`).
 

--- a/mycat/locale/en.json
+++ b/mycat/locale/en.json
@@ -280,7 +280,7 @@
     "Settings…": "Settings…",
     "Show in menu": "Show in menu",
     "Reminder": "Reminder",
-    "Speech bubble": "Speech bubble",
+    "SpeechBubble": "SpeechBubble",
     "Messages:": "Messages:"
   }
 }

--- a/mycat/locale/ko.json
+++ b/mycat/locale/ko.json
@@ -280,7 +280,7 @@
     "Settings…": "설정…",
     "Show in menu": "메뉴에 표시",
     "Reminder": "알림",
-    "Speech bubble": "말풍선",
+    "SpeechBubble": "말풍선",
     "Messages:": "메시지:"
   }
 }

--- a/mycat/locale/ru.json
+++ b/mycat/locale/ru.json
@@ -280,7 +280,7 @@
     "Settings…": "Настройки…",
     "Show in menu": "Показывать в меню",
     "Reminder": "Напоминание",
-    "Speech bubble": "Облачко",
+    "SpeechBubble": "Облачко",
     "Messages:": "Сообщения:"
   }
 }

--- a/mycat/locale/zh.json
+++ b/mycat/locale/zh.json
@@ -280,7 +280,7 @@
     "Settings…": "设置…",
     "Show in menu": "在菜单中显示",
     "Reminder": "提醒",
-    "Speech bubble": "气泡",
+    "SpeechBubble": "气泡",
     "Messages:": "消息："
   }
 }

--- a/mycat/settings_ui.py
+++ b/mycat/settings_ui.py
@@ -43,7 +43,7 @@ class SettingsDialog(QtWidgets.QDialog):
         bubble_row = QtWidgets.QHBoxLayout()
         bubble_row.addWidget(QtWidgets.QLabel(tr("Messages:")))
         self.reminder_radio = QtWidgets.QRadioButton(tr("Reminder"))
-        self.speech_radio = QtWidgets.QRadioButton(tr("Speech bubble"))
+        self.speech_radio = QtWidgets.QRadioButton(tr("SpeechBubble"))
         self.mode_group = QtWidgets.QButtonGroup(self)
         self.mode_group.addButton(self.reminder_radio)
         self.mode_group.addButton(self.speech_radio)

--- a/mycat/speech_bubble.py
+++ b/mycat/speech_bubble.py
@@ -33,7 +33,7 @@ TAIL_H = 14              # tail length; its width follows from the 15° apex
 TAIL_W = 2 * TAIL_H * math.tan(math.radians(TAIL_ANGLE_DEG / 2))
 TAIL_TIP_MARGIN = 2      # the drawn apex sits this far inside the window's bottom
 CORNER = 16              # bubble corner radius
-OUTLINE_WIDTH = 3        # width of the black outline around the bubble
+OUTLINE_WIDTH = 2        # width of the black outline around the bubble
 HEAD_GAP = 8             # the drawn tail tip stops 8px above the cat's ears
 
 
@@ -250,10 +250,14 @@ class BubbleWindow(QtWidgets.QWidget):
             QtCore.QRectF(margin, margin, self.body_w - 2 * margin, self.body_h - 2 * margin), CORNER, CORNER
         )
         tip_x = max(TAIL_W, min(self.tail_x, self.body_w - TAIL_W))
+        # Start the tail base a few px UP inside the body so the union merges
+        # cleanly — a base that only touches the body edge leaves an internal
+        # seam that the outline then draws as a black line across the join.
+        base_y = self.body_h - margin - 3
         tail = QtGui.QPainterPath()
-        tail.moveTo(tip_x - TAIL_W / 2, self.body_h - margin)
+        tail.moveTo(tip_x - TAIL_W / 2, base_y)
         tail.lineTo(tip_x, self.body_h + TAIL_H - TAIL_TIP_MARGIN)
-        tail.lineTo(tip_x + TAIL_W / 2, self.body_h - margin)
+        tail.lineTo(tip_x + TAIL_W / 2, base_y)
         tail.closeSubpath()
         return body.united(tail)
 

--- a/mycat/speech_bubble.py
+++ b/mycat/speech_bubble.py
@@ -27,12 +27,13 @@ TYPE_INTERVAL_MS = 35    # per revealed character
 HOLD_SECONDS = 10.0      # how long the finished bubble lingers
 MAX_TEXT_WIDTH = 480     # wrap long messages to this width
 MIN_WIDTH = 120          # the bubble body is never narrower than this
-PAD_X, PAD_Y = 10, 4     # side padding ≥10px; tight ≤5px above/below the glyphs
+PAD_X, PAD_Y = 30, 4     # roomy side padding when text drives the width; tight ≤5px top/bottom
 TAIL_ANGLE_DEG = 25      # apex angle of the pointer aimed at the cat
 TAIL_H = 14              # tail length; its width follows from the 15° apex
 TAIL_W = 2 * TAIL_H * math.tan(math.radians(TAIL_ANGLE_DEG / 2))
 TAIL_TIP_MARGIN = 2      # the drawn apex sits this far inside the window's bottom
 CORNER = 16              # bubble corner radius
+OUTLINE_WIDTH = 3        # width of the black outline around the bubble
 HEAD_GAP = 8             # the drawn tail tip stops 8px above the cat's ears
 
 
@@ -89,6 +90,7 @@ class BubbleWindow(QtWidgets.QWidget):
 
         self.bubble_font = QtGui.QFont()
         self.bubble_font.setPointSize(11)
+        self.bubble_font.setBold(True)
 
         self.type_timer = QtCore.QTimer(self)
         self.type_timer.setInterval(TYPE_INTERVAL_MS)
@@ -240,13 +242,18 @@ class BubbleWindow(QtWidgets.QWidget):
         self.move(x, y)
 
     def bubble_path(self) -> QtGui.QPainterPath:
+        # Inset the outline by half its width (+AA) so the whole stroke stays
+        # inside the widget bounds and isn't clipped on the edges.
+        margin = OUTLINE_WIDTH / 2.0 + 0.5
         body = QtGui.QPainterPath()
-        body.addRoundedRect(QtCore.QRectF(1, 1, self.body_w - 2, self.body_h - 2), CORNER, CORNER)
+        body.addRoundedRect(
+            QtCore.QRectF(margin, margin, self.body_w - 2 * margin, self.body_h - 2 * margin), CORNER, CORNER
+        )
         tip_x = max(TAIL_W, min(self.tail_x, self.body_w - TAIL_W))
         tail = QtGui.QPainterPath()
-        tail.moveTo(tip_x - TAIL_W / 2, self.body_h - 2)
+        tail.moveTo(tip_x - TAIL_W / 2, self.body_h - margin)
         tail.lineTo(tip_x, self.body_h + TAIL_H - TAIL_TIP_MARGIN)
-        tail.lineTo(tip_x + TAIL_W / 2, self.body_h - 2)
+        tail.lineTo(tip_x + TAIL_W / 2, self.body_h - margin)
         tail.closeSubpath()
         return body.united(tail)
 
@@ -256,7 +263,9 @@ class BubbleWindow(QtWidgets.QWidget):
         painter = QtGui.QPainter(self)
         painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
         path = self.bubble_path()
-        painter.setPen(QtGui.QPen(QtGui.QColor(40, 40, 40), 2))
+        pen = QtGui.QPen(QtGui.QColor(0, 0, 0), OUTLINE_WIDTH)
+        pen.setJoinStyle(QtCore.Qt.PenJoinStyle.RoundJoin)
+        painter.setPen(pen)
         painter.setBrush(QtGui.QColor(255, 255, 255, 242))
         painter.drawPath(path)
 
@@ -274,4 +283,8 @@ class BubbleWindow(QtWidgets.QWidget):
 
         # On X11 with no compositor a translucent window paints its transparent
         # pixels black; clip the window to the bubble shape so no black box shows.
-        self.setMask(QtGui.QRegion(path.toFillPolygon().toPolygon()))
+        # Widen the mask by the outline so the full stroke stays visible.
+        stroker = QtGui.QPainterPathStroker()
+        stroker.setWidth(OUTLINE_WIDTH)
+        outline = path.united(stroker.createStroke(path))
+        self.setMask(QtGui.QRegion(outline.toFillPolygon().toPolygon()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mycat"
-version = "0.1.30"
+version = "0.1.31"
 description = "Desktop Cat: Qt Overlay"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Follow-up polish to the speech-bubble mode shipped in 0.1.30, collected for the next release:

- **Bolder, clearer bubble** — bold text inside a wider solid-black outline (`OUTLINE_WIDTH=3`, pure black) so it matches the cat's own linework; the window mask is widened by the stroke so the full outline shows even on X11 without a compositor.
- **Roomier side padding** — `PAD_X` 10 → 30 so longer messages aren't cramped against the edge; vertical padding stays tight.
- **English toggle named "SpeechBubble"** in *Settings → Messages*. The i18n key was renamed across all four locales so 中文 / Русский / 한국어 keep their translated labels (气泡 / Облачко / 말풍선).

## Test plan

- [x] `ruff check` clean.
- [x] `test_speech_bubble` + `test_i18n` pass (offscreen) — locale key parity preserved.
- [x] Per-language label resolves correctly: en=SpeechBubble, ru=Облачко, zh=气泡, ko=말풍선.
- [x] Bubble rendered offscreen over the cat — bold text, wider black outline, roomier padding.
- [ ] CI green (now per-process isolated).